### PR TITLE
doc: add some uses commands

### DIFF
--- a/blueprint/src/coding_theory/defs.tex
+++ b/blueprint/src/coding_theory/defs.tex
@@ -35,9 +35,11 @@ This section contains definitions and theorems about coding theory as they are u
 \begin{definition}[Proximity Measure]
     \label{def:proximity_measure}
     \lean{proximityMeasure}
+    \uses{def:distance_from_code}
 \end{definition}
 
 \begin{definition}[Proximity Gap]
     \label{def:proximity_gap}
     \lean{proximityGap}
+    \uses{def:distance_from_code}
 \end{definition}

--- a/blueprint/src/oracle_reductions/defs.tex
+++ b/blueprint/src/oracle_reductions/defs.tex
@@ -30,7 +30,7 @@ We now go into more details on these objects.
 
 \begin{definition}[Type Signature of an Oracle Reduction]
     \label{def:oracle_reduction_type_signature}
-    A protocol specification $\rho : \mathsf{PSpec}\; n$ of an oracle reduction is parametrized by a fixed number of messages sent in total. For each step of interaction, it specifies a direction for the messsage (prover to verifier, or vice versa), and a type for the message. If a message from the prover to the verifier is further marked as oracle, then we also expect an oracle interface for that message. In Lean, we handle these oracle interfaces via the $\mathsf{OracleInterface}$ type class.
+    A protocol specification $\rho : \mathsf{PSpec}\; n$ of an oracle reduction is parametrized by a fixed number of messages sent in total. For each step of interaction, it specifies a direction for the message (prover to verifier, or vice versa), and a type for the message. If a message from the prover to the verifier is further marked as oracle, then we also expect an oracle interface for that message. In Lean, we handle these oracle interfaces via the $\mathsf{OracleInterface}$ type class.
     \lean{ProtocolSpec, OracleInterface}
 \end{definition}
 
@@ -106,6 +106,7 @@ l
     \label{def:interactive_oracle_reduction}
     \lean{OracleReduction}
     An interactive oracle reduction for a given context $\Gamma$ is a combination a prover and a verifier of the types specified above.
+    \uses{def:oracle_reduction_type_signature}
 \end{definition}
 
 \textbf{PL Formalization.} We write our definitions in PL notation in~\Cref{fig:type-defs}. The set of types $\Type$ is the same as Lean's dependent type theory (omitting universe levels); in particular, we care about basic dependent types (Pi and Sigma), finite natural numbers, finite fields, lists, vectors, and polynomials.
@@ -194,6 +195,7 @@ error).
 \begin{definition}[Completeness]
     \label{def:completeness}
     \lean{Reduction.completeness}
+    \uses{def:interactive_oracle_reduction}
 \end{definition}
 
 Almost all oracle reductions we consider actually satisfy \emph{perfect completeness}, which
@@ -215,6 +217,7 @@ special soundness (via rewinding). At the moment, we only care about non-rewindi
 \begin{definition}[Soundness]
     \label{def:soundness}
     \lean{Reduction.soundness}
+    \uses{def:interactive_oracle_reduction}
 \end{definition}
 
 A (straightline) extractor for knowledge soundness is a deterministic algorithm that takes in the output public context after executing the oracle reduction, the side information (i.e. log of oracle queries from the malicious prover) observed during execution, and outputs the witness for the input context.
@@ -226,6 +229,7 @@ the execution.
 \begin{definition}[Knowledge Soundness]
     \label{def:knowledge_soundness}
     \lean{Reduction.knowledgeSoundness}
+    \uses{def:interactive_oracle_reduction}
 \end{definition}
 
 To define round-by-round (knowledge) soundness, we need to define the notion of a \emph{state function}. This is a (possibly inefficient) function $\mathsf{StateF}$ that, for every challenge sent by the verifier, takes in the transcript of the protocol so far and outputs whether the state is doomed or not. Roughly speaking, the requirement of round-by-round soundness is that, for any (possibly malicious) prover $P$, if the state function outputs that the state is doomed on some partial transcript of the protocol, then the verifier will reject with high probability.
@@ -238,11 +242,13 @@ To define round-by-round (knowledge) soundness, we need to define the notion of 
 \begin{definition}[Round-by-Round Soundness]
     \label{def:round_by_round_soundness}
     \lean{Reduction.rbrSoundness}
+    \uses{def:interactive_oracle_reduction}
 \end{definition}
 
 \begin{definition}[Round-by-Round Knowledge Soundness]
     \label{def:round_by_round_knowledge_soundness}
     \lean{Reduction.rbrKnowledgeSoundness}
+    \uses{def:interactive_oracle_reduction}
 \end{definition}
 
 By default, the properties we consider are perfect completeness and (straightline) round-by-round knowledge soundness. We can encapsulate these properties into the following typing judgement:

--- a/blueprint/src/vcv/defs.tex
+++ b/blueprint/src/vcv/defs.tex
@@ -19,6 +19,7 @@ The main ingredients of the library are as follows:
     The indexing allows for potentially infinite collections of oracles, and the specification itself 
     is agnostic to how the oracles actually behave - it just describes their interfaces.
     \lean{OracleSpec}
+    \leanok
 \end{definition}
 
 Some examples of oracle specifications (and their intended behavior) are as follows:
@@ -43,6 +44,7 @@ or finiteness properties \lean{OracleSpec.FiniteRange}.
     \end{itemize}
     The formal implementation uses a free monad on the inductive type of oracle queries \lean{OracleSpec.OracleQuery} wrapped in an option monad transformer (i.e. \verb|OptionT(FreeMonad(OracleQuery spec))|).
     \lean{OracleComp}
+    \uses{def:oracle_spec}
 \end{definition}
 
 \begin{definition}[Handling Oracle Queries]
@@ -50,6 +52,7 @@ or finiteness properties \lean{OracleSpec.FiniteRange}.
     To actually run oracle computations, we need a way to handle (or implement) the oracle queries.
     An oracle implementation consists a mapping from oracle queries to values in another monad. Depending on the monad, this may allow for various interpretations of the oracle queries.
     \lean{QueryImpl}
+    \uses{def:oracle_spec}
 \end{definition}
 
 \begin{definition}[Probabilistic Semantics of Oracle Computations]
@@ -59,6 +62,7 @@ or finiteness properties \lean{OracleSpec.FiniteRange}.
     outputs (including the possibility of failure). The semantics maps each oracle query to a 
     uniform distribution over its possible responses.
     \lean{OracleComp.evalDist}
+    \uses{def:oracle_computation}
 \end{definition}
 
 Once we have mapped an oracle computation to a probability distribution, we can define various associated probabilities, such as the probability of failure, or the probability of the output satisfying a given predicate (assuming it does not fail).
@@ -80,6 +84,7 @@ Once we have mapped an oracle computation to a probability distribution, we can 
     \end{itemize}
     These are implemented as special cases of simulation oracles.
     \lean{loggingOracle, cachingOracle}
+    \uses{def:oracle_computation, def:handling_oracle_queries}
 \end{definition}
 
 \begin{definition}[Random Oracle]
@@ -90,6 +95,7 @@ Once we have mapped an oracle computation to a probability distribution, we can 
         \item On repeated queries: returns the cached response
     \end{itemize}
     \lean{randomOracle}
+    \uses{def:oracle_computation, def:handling_oracle_queries}
 \end{definition}
 
 % In summary, the VCVio library consists of:


### PR DESCRIPTION
This PR adds some `\uses` commands to the leanblueprint source, to try to avoid the blueprint dependency chart being a flat list of declarations.