### PR TITLE
feat: more component IORs & miscellaneous progress

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -52,8 +52,10 @@ import ArkLib.OracleReduction.Security.Basic
 import ArkLib.OracleReduction.Transform.BCS
 import ArkLib.OracleReduction.Transform.FiatShamir
 import ArkLib.OracleReduction.VectorIOR
-import ArkLib.ProofSystem.Component.CheckPred
+import ArkLib.ProofSystem.Component.CheckClaim
+import ArkLib.ProofSystem.Component.DoNothing
 import ArkLib.ProofSystem.Component.RandomQuery
+import ArkLib.ProofSystem.Component.ReduceClaim
 import ArkLib.ProofSystem.Component.SendClaim
 import ArkLib.ProofSystem.Component.SendWitness
 import ArkLib.ProofSystem.ConstraintSystem.IndexedLookup

--- a/ArkLib/OracleReduction/Basic.lean
+++ b/ArkLib/OracleReduction/Basic.lean
@@ -157,6 +157,10 @@ end OracleInterfaces
 /-- There is only one protocol specification with 0 messages (the empty one) -/
 instance : Unique (ProtocolSpec 0) := inferInstance
 
+instance : ∀ i, VCVCompatible ((default : ProtocolSpec 0).Challenge i) := fun i => by aesop
+instance : ∀ i, OracleInterface ((default : ProtocolSpec 0).Message i) := fun i => by
+  simp [default] at i; exact Fin.elim0 i.1
+
 /-- A (partial) transcript of a protocol specification, indexed by some `k : Fin (n + 1)`, is a
     list of messages from the protocol for all indices `i` less than `k`. -/
 @[reducible, inline, specialize]

--- a/ArkLib/OracleReduction/Basic.lean
+++ b/ArkLib/OracleReduction/Basic.lean
@@ -157,9 +157,13 @@ end OracleInterfaces
 /-- There is only one protocol specification with 0 messages (the empty one) -/
 instance : Unique (ProtocolSpec 0) := inferInstance
 
-instance : ∀ i, VCVCompatible ((default : ProtocolSpec 0).Challenge i) := fun i => by aesop
-instance : ∀ i, OracleInterface ((default : ProtocolSpec 0).Message i) := fun i => by
-  simp [default] at i; exact Fin.elim0 i.1
+-- Two different ways to write the empty protocol specification: `![]` and `default`
+
+instance : ∀ i, VCVCompatible (Challenge ![] i) := fun ⟨i, _⟩ => Fin.elim0 i
+instance : ∀ i, OracleInterface (Message ![] i) := fun ⟨i, _⟩ => Fin.elim0 i
+
+instance : ∀ i, VCVCompatible ((default : ProtocolSpec 0).Challenge i) := fun ⟨i, _⟩ => Fin.elim0 i
+instance : ∀ i, OracleInterface ((default : ProtocolSpec 0).Message i) := fun ⟨i, _⟩ => Fin.elim0 i
 
 /-- A (partial) transcript of a protocol specification, indexed by some `k : Fin (n + 1)`, is a
     list of messages from the protocol for all indices `i` less than `k`. -/
@@ -341,6 +345,8 @@ structure OracleVerifier (pSpec : ProtocolSpec n) {ι : Type} (oSpec : OracleSpe
     [Oₘ : ∀ i, OracleInterface (pSpec.Message i)] (StmtIn StmtOut : Type)
     {ιₛᵢ : Type} (OStmtIn : ιₛᵢ → Type) [Oₛᵢ : ∀ i, OracleInterface (OStmtIn i)]
     {ιₛₒ : Type} (OStmtOut : ιₛₒ → Type) where
+    -- This will be needed after the switch to `simOStmt`
+    -- [Oₛₒ : ∀ i, OracleInterface (OStmtOut i)]
 
   /-- The core verification logic. Takes the input statement `stmtIn` and all verifier challenges
   `challenges` (which are determined outside this function, typically by sampling for
@@ -349,6 +355,12 @@ structure OracleVerifier (pSpec : ProtocolSpec n) {ι : Type} (oSpec : OracleSpe
   oracles `pSpec.Message`. -/
   verify : StmtIn → pSpec.Challenges →
     OracleComp (oSpec ++ₒ ([OStmtIn]ₒ ++ₒ [pSpec.Message]ₒ)) StmtOut
+
+  -- TODO: this seems like the right way for compositionality
+  -- Makes it potentially more difficult for compilation with commitment schemes
+  -- Can recover the old version (with `embed` and `hEq`) via a constructor `QueryImpl.ofEmbed`
+
+  -- simOStmt : QueryImpl [OStmtOut]ₒ (OracleComp ([OStmtIn]ₒ ++ₒ [pSpec.Message]ₒ))
 
   /-- An embedding that specifies how each output oracle statement (indexed by `ιₛₒ`) is derived.
   It maps an index `i : ιₛₒ` to either an index `j : ιₛᵢ` (meaning `OStmtOut i` comes from

--- a/ArkLib/OracleReduction/OracleInterface.lean
+++ b/ArkLib/OracleReduction/OracleInterface.lean
@@ -129,12 +129,20 @@ end SimOracle
 
 /-- `OracleInterface` is a type class that provides an oracle interface for a type `Message`. It
     consists of a query type `Query`, a response type `Response`, and a function `oracle` that
-    transforms a message `m : Message` into a function `Query → Response`. -/
+    transforms a message `m : Message` into a function `Query → Response`.
+
+  TODO: turn `(Query, Response)` into a general `PFunctor` (i.e. `Response : Query → Type`) This
+  allows for better compositionality of `OracleInterface`, including (indexed) sum, instead of
+  requiring indexed family of `OracleInterface`s.
+
+  However, this won't be possible until `OracleSpec` is changed to be an alias for `PFunctor` -/
 @[ext]
 class OracleInterface (Message : Type) where
   Query : Type
   Response : Type
   oracle : Message → Query → Response
+
+#check PFunctor
 
 namespace OracleInterface
 

--- a/ArkLib/ProofSystem/Component/CheckClaim.lean
+++ b/ArkLib/ProofSystem/Component/CheckClaim.lean
@@ -32,7 +32,7 @@ section Reduction
 
 /-- The prover for the `CheckClaim` reduction. -/
 @[inline, specialize]
-def prover : Prover (default : ProtocolSpec 0) oSpec Statement Unit Statement Unit where
+def prover : Prover ![] oSpec Statement Unit Statement Unit where
   PrvState := fun _ => Statement
   input := fun stmt _ => stmt
   sendMessage := fun i => nomatch i
@@ -43,12 +43,12 @@ variable (pred : Statement → Prop) [DecidablePred pred]
 
 /-- The verifier for the `CheckClaim` reduction. -/
 @[inline, specialize]
-def verifier : Verifier (default : ProtocolSpec 0) oSpec Statement Statement where
+def verifier : Verifier ![] oSpec Statement Statement where
   verify := fun stmt _ => do guard (pred stmt); return stmt
 
 /-- The reduction for the `CheckClaim` reduction. -/
 @[inline, specialize]
-def reduction : Reduction (default : ProtocolSpec 0) oSpec Statement Unit Statement Unit where
+def reduction : Reduction ![] oSpec Statement Unit Statement Unit where
   prover := prover oSpec Statement
   verifier := verifier oSpec Statement pred
 
@@ -73,7 +73,7 @@ variable {ιₛ : Type} (OStatement : ιₛ → Type) [∀ i, OracleInterface (O
 
 /-- The oracle prover for the `CheckClaim` oracle reduction. -/
 @[inline, specialize]
-def oracleProver : OracleProver (default : ProtocolSpec 0) oSpec
+def oracleProver : OracleProver ![] oSpec
     Statement Unit Statement Unit OStatement OStatement where
   PrvState := fun _ => Statement × (∀ i, OStatement i)
   input := fun stmt _ => stmt
@@ -86,7 +86,7 @@ variable (pred : ReaderT Statement (OracleComp [OStatement]ₒ) Prop)
 
 /-- The oracle verifier for the `CheckClaim` oracle reduction. -/
 @[inline, specialize]
-def oracleVerifier : OracleVerifier (default : ProtocolSpec 0) oSpec
+def oracleVerifier : OracleVerifier ![] oSpec
     Statement Statement OStatement OStatement where
   verify := fun stmt _ => do let _ ← pred stmt; return stmt
   embed := Embedding.inl
@@ -94,7 +94,7 @@ def oracleVerifier : OracleVerifier (default : ProtocolSpec 0) oSpec
 
 /-- The oracle reduction for the `CheckClaim` oracle reduction. -/
 @[inline, specialize]
-def oracleReduction : OracleReduction (default : ProtocolSpec 0) oSpec
+def oracleReduction : OracleReduction ![] oSpec
     Statement Unit Statement Unit OStatement OStatement where
   prover := oracleProver oSpec Statement OStatement
   verifier := oracleVerifier oSpec Statement OStatement pred

--- a/ArkLib/ProofSystem/Component/CheckClaim.lean
+++ b/ArkLib/ProofSystem/Component/CheckClaim.lean
@@ -19,7 +19,8 @@ import ArkLib.OracleReduction.Security.Basic
      `ReaderT`), and returning a `Prop`. Verifier performs this oracle computation, and returns the
      same statement & oracle statement if successful.
 
-  In both cases, the output relation is trivial.
+  In both cases, the output relation is trivial (since the input relation has been checked by the
+  verifier).
 -/
 
 open OracleComp OracleInterface ProtocolSpec Function
@@ -114,9 +115,9 @@ variable [oSpec.FiniteRange]
 theorem oracleReduction_completeness :
     (oracleReduction oSpec Statement OStatement pred).perfectCompleteness (toRelInput pred hPred)
     (fun _ _ => True) := by
-  simp [Reduction.run, Prover.run, Prover.runToRound, Prover.processRound, Verifier.run,
-    OracleReduction.perfectCompleteness, oracleReduction, oracleProver,
-    oracleVerifier]
+  simp [OracleReduction.perfectCompleteness, OracleReduction.toReduction, OracleVerifier.toVerifier,
+    oracleReduction, oracleProver, oracleVerifier, toRelInput]
+  simp [Reduction.run, Prover.run, Verifier.run, simOracle2]
   sorry
 
 theorem oracleReduction_rbr_knowledge_soundness : True := sorry

--- a/ArkLib/ProofSystem/Component/CheckClaim.lean
+++ b/ArkLib/ProofSystem/Component/CheckClaim.lean
@@ -7,7 +7,7 @@ Authors: Quang Dao
 import ArkLib.OracleReduction.Security.Basic
 
 /-!
-  # Simple (Oracle) Reduction: Check if a predicate on a statement is satisfied
+  # Simple (Oracle) Reduction: Check if a predicate / claim on a statement is satisfied
 
   This is a zero-round (oracle) reduction. There is no witness.
 
@@ -24,13 +24,13 @@ import ArkLib.OracleReduction.Security.Basic
 
 open OracleComp OracleInterface ProtocolSpec Function
 
-namespace CheckPred
+namespace CheckClaim
 
 variable {ι : Type} (oSpec : OracleSpec ι) (Statement : Type)
 
 section Reduction
 
-/-- The prover for the `CheckPred` reduction. -/
+/-- The prover for the `CheckClaim` reduction. -/
 @[inline, specialize]
 def prover : Prover (default : ProtocolSpec 0) oSpec Statement Unit Statement Unit where
   PrvState := fun _ => Statement
@@ -41,12 +41,12 @@ def prover : Prover (default : ProtocolSpec 0) oSpec Statement Unit Statement Un
 
 variable (pred : Statement → Prop) [DecidablePred pred]
 
-/-- The verifier for the `CheckPred` reduction. -/
+/-- The verifier for the `CheckClaim` reduction. -/
 @[inline, specialize]
 def verifier : Verifier (default : ProtocolSpec 0) oSpec Statement Statement where
   verify := fun stmt _ => do guard (pred stmt); return stmt
 
-/-- The reduction for the `CheckPred` reduction. -/
+/-- The reduction for the `CheckClaim` reduction. -/
 @[inline, specialize]
 def reduction : Reduction (default : ProtocolSpec 0) oSpec Statement Unit Statement Unit where
   prover := prover oSpec Statement
@@ -54,7 +54,7 @@ def reduction : Reduction (default : ProtocolSpec 0) oSpec Statement Unit Statem
 
 variable [oSpec.FiniteRange]
 
-/-- The `CheckPred` reduction satisfies perfect completeness. -/
+/-- The `CheckClaim` reduction satisfies perfect completeness. -/
 @[simp]
 theorem reduction_completeness :
     (reduction oSpec Statement pred).perfectCompleteness (fun stmt _ => pred stmt)
@@ -62,7 +62,7 @@ theorem reduction_completeness :
   simp [reduction, Reduction.run, Prover.run, Prover.runToRound, Prover.processRound, Verifier.run,
     prover, verifier]
 
-/-- The `CheckPred` reduction satisfies perfect round-by-round knowledge soundness. -/
+/-- The `CheckClaim` reduction satisfies perfect round-by-round knowledge soundness. -/
 theorem reduction_rbr_knowledge_soundness : True := sorry
 
 end Reduction
@@ -71,7 +71,7 @@ section OracleReduction
 
 variable {ιₛ : Type} (OStatement : ιₛ → Type) [∀ i, OracleInterface (OStatement i)]
 
-/-- The oracle prover for the `CheckPred` oracle reduction. -/
+/-- The oracle prover for the `CheckClaim` oracle reduction. -/
 @[inline, specialize]
 def oracleProver : OracleProver (default : ProtocolSpec 0) oSpec
     Statement Unit Statement Unit OStatement OStatement where
@@ -84,7 +84,7 @@ def oracleProver : OracleProver (default : ProtocolSpec 0) oSpec
 variable (pred : ReaderT Statement (OracleComp [OStatement]ₒ) Prop)
   (hPred : ∀ stmt, (pred stmt).neverFails)
 
-/-- The oracle verifier for the `CheckPred` oracle reduction. -/
+/-- The oracle verifier for the `CheckClaim` oracle reduction. -/
 @[inline, specialize]
 def oracleVerifier : OracleVerifier (default : ProtocolSpec 0) oSpec
     Statement Statement OStatement OStatement where
@@ -92,7 +92,7 @@ def oracleVerifier : OracleVerifier (default : ProtocolSpec 0) oSpec
   embed := Embedding.inl
   hEq := by intro i; simp
 
-/-- The oracle reduction for the `CheckPred` oracle reduction. -/
+/-- The oracle reduction for the `CheckClaim` oracle reduction. -/
 @[inline, specialize]
 def oracleReduction : OracleReduction (default : ProtocolSpec 0) oSpec
     Statement Unit Statement Unit OStatement OStatement where
@@ -109,7 +109,7 @@ def toRelInput : Statement × (∀ i, OStatement i) → Unit → Prop :=
 
 variable [oSpec.FiniteRange]
 
-/-- The `CheckPred` reduction satisfies perfect completeness. -/
+/-- The `CheckClaim` reduction satisfies perfect completeness. -/
 @[simp]
 theorem oracleReduction_completeness :
     (oracleReduction oSpec Statement OStatement pred).perfectCompleteness (toRelInput pred hPred)
@@ -123,4 +123,4 @@ theorem oracleReduction_rbr_knowledge_soundness : True := sorry
 
 end OracleReduction
 
-end CheckPred
+end CheckClaim

--- a/ArkLib/ProofSystem/Component/CheckPred.lean
+++ b/ArkLib/ProofSystem/Component/CheckPred.lean
@@ -105,9 +105,9 @@ def toRelInput : Statement × (∀ i, OStatement i) → Unit → Prop :=
   fun ⟨stmt, oStmt⟩ _ =>
     simulateQNeverFails (toOracleImpl OStatement oStmt) (pred stmt) (hPred stmt)
 
-variable [oSpec.FiniteRange]
-
 -- theorem oracleProver_run
+
+variable [oSpec.FiniteRange]
 
 /-- The `CheckPred` reduction satisfies perfect completeness. -/
 @[simp]

--- a/ArkLib/ProofSystem/Component/CheckPred.lean
+++ b/ArkLib/ProofSystem/Component/CheckPred.lean
@@ -9,21 +9,20 @@ import ArkLib.OracleReduction.Security.Basic
 /-!
   # Simple (Oracle) Reduction: Check if a predicate on a statement is satisfied
 
-  This is a zero-round (oracle) reduction.
+  This is a zero-round (oracle) reduction. There is no witness.
 
-  1. Reduction version: the input relation is constant on witness, and becomes a predicate on the
-  statement. Verifier checks this statement, and returns yes / no.
+  1. Reduction version: the input relation becomes a predicate on the statement. Verifier checks
+     this predicate, and returns the same statement if successful.
 
-  Verifier may decide to keep the statement or not (send it to Unit)?
+  2. Oracle reduction version: the input relation becomes an oracle computation having as oracles
+     the oracle statements, and taking in the (non-oracle) statement as an input (i.e. via
+     `ReaderT`), and returning a `Prop`. Verifier performs this oracle computation, and returns the
+     same statement & oracle statement if successful.
 
-  2. Oracle reduction version: the input relation is constant on witness, and there is an oracle
-  computation having as oracles the oracle statements, and taking in the (non-oracle) statement as
-  an input (i.e. via `ReaderT`), and returning a `Prop`.
-
-  Verifier performs this oracle computation, and may decide to keep the (oracle) statement or not
+  In both cases, the output relation is trivial.
 -/
 
-open OracleComp ProtocolSpec
+open OracleComp OracleInterface ProtocolSpec Function
 
 namespace CheckPred
 
@@ -31,6 +30,8 @@ variable {ι : Type} (oSpec : OracleSpec ι) (Statement : Type)
 
 section Reduction
 
+/-- The prover for the `CheckPred` reduction. -/
+@[inline, specialize]
 def prover : Prover (default : ProtocolSpec 0) oSpec Statement Unit Statement Unit where
   PrvState := fun _ => Statement
   input := fun stmt _ => stmt
@@ -40,14 +41,16 @@ def prover : Prover (default : ProtocolSpec 0) oSpec Statement Unit Statement Un
 
 variable (pred : Statement → Prop) [DecidablePred pred]
 
+/-- The verifier for the `CheckPred` reduction. -/
+@[inline, specialize]
 def verifier : Verifier (default : ProtocolSpec 0) oSpec Statement Statement where
   verify := fun stmt _ => do guard (pred stmt); return stmt
 
+/-- The reduction for the `CheckPred` reduction. -/
+@[inline, specialize]
 def reduction : Reduction (default : ProtocolSpec 0) oSpec Statement Unit Statement Unit where
   prover := prover oSpec Statement
   verifier := verifier oSpec Statement pred
-
-instance : ∀ i, VCVCompatible ((default : ProtocolSpec 0).Challenge i) := fun i => by aesop
 
 variable [oSpec.FiniteRange]
 
@@ -55,17 +58,68 @@ variable [oSpec.FiniteRange]
 @[simp]
 theorem reduction_completeness :
     (reduction oSpec Statement pred).perfectCompleteness (fun stmt _ => pred stmt)
-    (fun stmt _ => pred stmt) := by
+    (fun _ _ => True) := by
   simp [reduction, Reduction.run, Prover.run, Prover.runToRound, Prover.processRound, Verifier.run,
     prover, verifier]
-  aesop
 
+/-- The `CheckPred` reduction satisfies perfect round-by-round knowledge soundness. -/
 theorem reduction_rbr_knowledge_soundness : True := sorry
 
 end Reduction
 
 section OracleReduction
 
+variable {ιₛ : Type} (OStatement : ιₛ → Type) [∀ i, OracleInterface (OStatement i)]
+
+/-- The oracle prover for the `CheckPred` oracle reduction. -/
+@[inline, specialize]
+def oracleProver : OracleProver (default : ProtocolSpec 0) oSpec
+    Statement Unit Statement Unit OStatement OStatement where
+  PrvState := fun _ => Statement × (∀ i, OStatement i)
+  input := fun stmt _ => stmt
+  sendMessage := fun i => nomatch i
+  receiveChallenge := fun i => nomatch i
+  output := fun stmt => (stmt, ())
+
+variable (pred : ReaderT Statement (OracleComp [OStatement]ₒ) Prop)
+  (hPred : ∀ stmt, (pred stmt).neverFails)
+
+/-- The oracle verifier for the `CheckPred` oracle reduction. -/
+@[inline, specialize]
+def oracleVerifier : OracleVerifier (default : ProtocolSpec 0) oSpec
+    Statement Statement OStatement OStatement where
+  verify := fun stmt _ => do let _ ← pred stmt; return stmt
+  embed := Embedding.inl
+  hEq := by intro i; simp
+
+/-- The oracle reduction for the `CheckPred` oracle reduction. -/
+@[inline, specialize]
+def oracleReduction : OracleReduction (default : ProtocolSpec 0) oSpec
+    Statement Unit Statement Unit OStatement OStatement where
+  prover := oracleProver oSpec Statement OStatement
+  verifier := oracleVerifier oSpec Statement OStatement pred
+
+variable {Statement} {OStatement}
+
+def toRelInput : Statement × (∀ i, OStatement i) → Unit → Prop :=
+  fun ⟨stmt, oStmt⟩ _ =>
+    simulateQNeverFails (toOracleImpl OStatement oStmt) (pred stmt) (hPred stmt)
+
+variable [oSpec.FiniteRange]
+
+-- theorem oracleProver_run
+
+/-- The `CheckPred` reduction satisfies perfect completeness. -/
+@[simp]
+theorem oracleReduction_completeness :
+    (oracleReduction oSpec Statement OStatement pred).perfectCompleteness (toRelInput pred hPred)
+    (fun _ _ => True) := by
+  simp [Reduction.run, Prover.run, Prover.runToRound, Prover.processRound, Verifier.run,
+    OracleReduction.perfectCompleteness, oracleReduction, oracleProver,
+    oracleVerifier]
+  sorry
+
+theorem oracleReduction_rbr_knowledge_soundness : True := sorry
 
 end OracleReduction
 

--- a/ArkLib/ProofSystem/Component/DoNothing.lean
+++ b/ArkLib/ProofSystem/Component/DoNothing.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2024-2025 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.OracleReduction.Security.Basic
+
+/-!
+  # The Trivial (Oracle) Reduction: Do Nothing!
+
+  This is a zero-round (oracle) reduction. Both the (oracle) prover and the (oracle) verifier simply
+  pass on their inputs unchanged.
+
+  We still define this as the base for realizing other zero-round reductions, via lens / lifting.
+-/
+
+namespace DoNothing
+
+variable {ι : Type} (oSpec : OracleSpec ι) (Statement Witness : Type)
+
+section Reduction
+
+/-- The prover for the `DoNothing` reduction. -/
+def prover : Prover ![] oSpec Statement Witness Statement Witness where
+  PrvState | 0 => Statement × Witness
+  input := id.curry
+  sendMessage := fun i => nomatch i
+  receiveChallenge := fun i => nomatch i
+  output := id
+
+/-- The verifier for the `DoNothing` reduction. -/
+def verifier : Verifier ![] oSpec Statement Statement where
+  verify := fun stmt _ => pure stmt
+
+/-- The reduction for the `DoNothing` reduction.
+  - Prover simply returns the statement and witness.
+  - Verifier simply returns the statement.
+-/
+def reduction : Reduction ![] oSpec Statement Witness Statement Witness where
+  prover := prover oSpec Statement Witness
+  verifier := verifier oSpec Statement
+
+variable [oSpec.FiniteRange] (rel : Statement → Witness → Prop)
+
+/-- The `DoNothing` reduction satisfies perfect completeness for any relation. -/
+@[simp]
+theorem reduction_completeness :
+    (reduction oSpec Statement Witness).perfectCompleteness rel rel := by
+  simp [Reduction.run, Prover.run, Prover.runToRound, Prover.processRound, Verifier.run,
+    reduction, prover, verifier]
+
+-- theorem reduction_rbr_knowledge_soundness :
+--     (reduction oSpec Statement Witness).rbrKnowledgeSoundness rel rel := by
+  -- simp [Reduction.run, Prover.run, Prover.runToRound, Prover.processRound, Verifier.run,
+  --   reduction, prover, verifier]
+
+end Reduction
+
+section OracleReduction
+
+variable {ιₛ : Type} (OStatement : ιₛ → Type) [∀ i, OracleInterface (OStatement i)]
+
+/-- The oracle prover for the `DoNothing` oracle reduction. -/
+def oracleProver : OracleProver ![] oSpec Statement Witness Statement Witness
+    OStatement OStatement where
+  PrvState | 0 => (Statement × (∀ i, OStatement i)) × Witness
+  input := id.curry
+  sendMessage := fun i => nomatch i
+  receiveChallenge := fun i => nomatch i
+  output := id
+
+/-- The oracle verifier for the `DoNothing` oracle reduction. -/
+def oracleVerifier : OracleVerifier ![] oSpec Statement Statement OStatement OStatement where
+  verify := fun stmt _ => pure stmt
+  embed := Function.Embedding.inl
+  hEq := by intro i; simp
+
+/-- The oracle reduction for the `DoNothing` oracle reduction.
+  - Prover simply returns the (non-oracle and oracle) statement and witness.
+  - Verifier simply returns the (non-oracle and oracle) statement.
+-/
+def oracleReduction : OracleReduction ![] oSpec Statement Witness Statement Witness
+    OStatement OStatement where
+  prover := oracleProver oSpec Statement Witness OStatement
+  verifier := oracleVerifier oSpec Statement OStatement
+
+variable [oSpec.FiniteRange] (rel : Statement × (∀ i, OStatement i) → Witness → Prop)
+
+/-- The `DoNothing` oracle reduction satisfies perfect completeness for any relation. -/
+@[simp]
+theorem oracleReduction_completeness :
+    (oracleReduction oSpec Statement Witness OStatement).perfectCompleteness rel rel := by
+  simp [OracleReduction.perfectCompleteness, OracleReduction.toReduction, OracleVerifier.toVerifier,
+    oracleReduction, oracleProver, oracleVerifier]
+  -- Need to simp the below separately, otherwise we get timeout
+  simp [Reduction.run, Prover.run, Verifier.run]
+  aesop
+
+-- theorem oracleReduction_rbr_knowledge_soundness :
+--     (oracleReduction oSpec Statement Witness OStatement).rbrKnowledgeSoundness rel rel := by
+--   simp [OracleReduction.rbrKnowledgeSoundness, OracleReduction.toReduction,
+--     OracleVerifier.toVerifier, oracleReduction, oracleProver, oracleVerifier]
+--   -- Need to simp the below separately, otherwise we get timeout
+--   simp [Reduction.run, Prover.run, Verifier.run]
+--   aesop
+
+end OracleReduction
+
+end DoNothing

--- a/ArkLib/ProofSystem/Component/DoNothing.lean
+++ b/ArkLib/ProofSystem/Component/DoNothing.lean
@@ -22,6 +22,7 @@ variable {ι : Type} (oSpec : OracleSpec ι) (Statement Witness : Type)
 section Reduction
 
 /-- The prover for the `DoNothing` reduction. -/
+@[inline, specialize]
 def prover : Prover ![] oSpec Statement Witness Statement Witness where
   PrvState | 0 => Statement × Witness
   input := id.curry
@@ -30,6 +31,7 @@ def prover : Prover ![] oSpec Statement Witness Statement Witness where
   output := id
 
 /-- The verifier for the `DoNothing` reduction. -/
+@[inline, specialize]
 def verifier : Verifier ![] oSpec Statement Statement where
   verify := fun stmt _ => pure stmt
 
@@ -37,6 +39,7 @@ def verifier : Verifier ![] oSpec Statement Statement where
   - Prover simply returns the statement and witness.
   - Verifier simply returns the statement.
 -/
+@[inline, specialize]
 def reduction : Reduction ![] oSpec Statement Witness Statement Witness where
   prover := prover oSpec Statement Witness
   verifier := verifier oSpec Statement
@@ -62,6 +65,7 @@ section OracleReduction
 variable {ιₛ : Type} (OStatement : ιₛ → Type) [∀ i, OracleInterface (OStatement i)]
 
 /-- The oracle prover for the `DoNothing` oracle reduction. -/
+@[inline, specialize]
 def oracleProver : OracleProver ![] oSpec Statement Witness Statement Witness
     OStatement OStatement where
   PrvState | 0 => (Statement × (∀ i, OStatement i)) × Witness
@@ -71,6 +75,7 @@ def oracleProver : OracleProver ![] oSpec Statement Witness Statement Witness
   output := id
 
 /-- The oracle verifier for the `DoNothing` oracle reduction. -/
+@[inline, specialize]
 def oracleVerifier : OracleVerifier ![] oSpec Statement Statement OStatement OStatement where
   verify := fun stmt _ => pure stmt
   embed := Function.Embedding.inl
@@ -80,6 +85,7 @@ def oracleVerifier : OracleVerifier ![] oSpec Statement Statement OStatement OSt
   - Prover simply returns the (non-oracle and oracle) statement and witness.
   - Verifier simply returns the (non-oracle and oracle) statement.
 -/
+@[inline, specialize]
 def oracleReduction : OracleReduction ![] oSpec Statement Witness Statement Witness
     OStatement OStatement where
   prover := oracleProver oSpec Statement Witness OStatement

--- a/ArkLib/ProofSystem/Component/ReduceClaim.lean
+++ b/ArkLib/ProofSystem/Component/ReduceClaim.lean
@@ -7,17 +7,102 @@ Authors: Quang Dao
 import ArkLib.OracleReduction.Security.Basic
 
 /-!
-  # Simple (Oracle) Reduction: Locally reduce a claim
+  # Simple (Oracle) Reduction: Locally / non-interactively reduce a claim
 
-  This is a zero-round (oracle) reduction. There is no witness.
+  This is a zero-round (oracle) reduction.
 
-  1. Reduction version: the input relation becomes a predicate on the statement. Verifier checks
-     this predicate, and returns the same statement if successful.
+  1. Reduction version: there are mappings between `StmtIn → StmtOut` and `WitIn → WitOut`. The
+     prover and verifier applies these mappings to the input statement and witness, and returns the
+     output statement and witness.
 
-  2. Oracle reduction version: the input relation becomes an oracle computation having as oracles
-     the oracle statements, and taking in the (non-oracle) statement as an input (i.e. via
-     `ReaderT`), and returning a `Prop`. Verifier performs this oracle computation, and returns the
-     same statement & oracle statement if successful.
+  This reduction is secure via pull-backs on relations. In other words, the outputs of the reduction
+  satisfies some relation `relOut` if and only if the inputs satisfy the relation
+  `relIn := relOut (mapStmt ·) (mapWit ·)`.
 
-  In both cases, the output relation is trivial.
+  2. Oracle reduction version: same as above, but with the extra mapping `OStmtIn → OStmtOut`,
+     defined as an oracle simulation / embedding.
+
+  This oracle reduction is secure via pull-backs on relations. In other words, the outputs of the
+  reduction satisfies some relation `relOut` if and only if the inputs satisfy the relation
+  `relIn := relOut ((mapStmt ·) ⊗ (mapOStmt ·)) (mapWit ·)`.
 -/
+
+namespace ReduceClaim
+
+variable {ι : Type} (oSpec : OracleSpec ι) (StmtIn WitIn StmtOut WitOut : Type)
+  (mapStmt : StmtIn → StmtOut) (mapWit : WitIn → WitOut)
+
+section Reduction
+
+/-- The prover for the `ReduceClaim` reduction. -/
+def prover : Prover ![] oSpec StmtIn WitIn StmtOut WitOut where
+  PrvState | 0 => StmtIn × WitIn
+  input := fun stmt wit => ⟨stmt, wit⟩
+  sendMessage := fun i => nomatch i
+  receiveChallenge := fun i => nomatch i
+  output := fun ⟨stmt, wit⟩ => (mapStmt stmt, mapWit wit)
+
+/-- The verifier for the `ReduceClaim` reduction. -/
+def verifier : Verifier ![] oSpec StmtIn StmtOut where
+  verify := fun stmt _ => pure (mapStmt stmt)
+
+/-- The reduction for the `ReduceClaim` reduction. -/
+def reduction : Reduction ![] oSpec StmtIn WitIn StmtOut WitOut where
+  prover := prover oSpec StmtIn WitIn StmtOut WitOut mapStmt mapWit
+  verifier := verifier oSpec StmtIn StmtOut mapStmt
+
+variable [oSpec.FiniteRange] (relIn : StmtIn → WitIn → Prop) (relOut : StmtOut → WitOut → Prop)
+
+/-- The `ReduceClaim` reduction satisfies perfect completeness for any relation. -/
+@[simp]
+theorem reduction_completeness (hRel : ∀ stmtIn witIn, relIn stmtIn witIn ↔
+    relOut (mapStmt stmtIn) (mapWit witIn)) :
+    (reduction oSpec StmtIn WitIn StmtOut WitOut mapStmt mapWit).perfectCompleteness
+      relIn relOut := by
+  simp [reduction, Reduction.run, Prover.run, Prover.runToRound, Prover.processRound, Verifier.run,
+    prover, verifier, hRel]
+
+end Reduction
+
+section OracleReduction
+
+variable {ιₛᵢ : Type} (OStmtIn : ιₛᵢ → Type) [∀ i, OracleInterface (OStmtIn i)]
+  {ιₛₒ : Type} (OStmtOut : ιₛₒ → Type)
+  -- Require map on indices to go the other way
+  (embedIdx : ιₛₒ ↪ ιₛᵢ) (hEq : ∀ i, OStmtIn (embedIdx i) = OStmtOut i)
+
+/-- The oracle prover for the `ReduceClaim` oracle reduction. -/
+def oracleProver : OracleProver ![] oSpec StmtIn WitIn StmtOut WitOut OStmtIn OStmtOut where
+  PrvState | 0 => (StmtIn × (∀ i, OStmtIn i)) × WitIn
+  input := fun stmt wit => ⟨stmt, wit⟩
+  sendMessage := fun i => nomatch i
+  receiveChallenge := fun i => nomatch i
+  output := fun ⟨⟨stmt, oStmt⟩, wit⟩ =>
+    ((mapStmt stmt, fun i => (hEq i) ▸ oStmt (embedIdx i)), mapWit wit)
+
+/-- The oracle verifier for the `ReduceClaim` oracle reduction. -/
+def oracleVerifier : OracleVerifier ![] oSpec StmtIn StmtOut OStmtIn OStmtOut where
+  verify := fun stmt _ => pure (mapStmt stmt)
+  embed := .trans embedIdx .inl
+  hEq := by intro i; simp [hEq]
+
+/-- The oracle reduction for the `ReduceClaim` oracle reduction. -/
+def oracleReduction : OracleReduction ![] oSpec StmtIn WitIn StmtOut WitOut OStmtIn OStmtOut where
+  prover := oracleProver oSpec StmtIn WitIn StmtOut WitOut mapStmt mapWit
+    OStmtIn OStmtOut embedIdx hEq
+  verifier := oracleVerifier oSpec StmtIn StmtOut mapStmt OStmtIn OStmtOut embedIdx hEq
+
+variable [oSpec.FiniteRange] (relIn : StmtIn → WitIn → Prop) (relOut : StmtOut → WitOut → Prop)
+
+-- /-- The `ReduceClaim` oracle reduction satisfies perfect completeness for any relation. -/
+-- @[simp]
+-- theorem oracleReduction_completeness (hRel : ∀ stmtIn witIn, relIn stmtIn witIn ↔
+--     relOut (mapStmt stmtIn) (mapWit witIn)) :
+--     (oracleReduction oSpec StmtIn WitIn StmtOut WitOut OStmtIn OStmtOut embedIdx hEq).perfectCompleteness
+--       relIn relOut := by
+--   sorry
+
+
+end OracleReduction
+
+end ReduceClaim

--- a/ArkLib/ProofSystem/Component/ReduceClaim.lean
+++ b/ArkLib/ProofSystem/Component/ReduceClaim.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2024-2025 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.OracleReduction.Security.Basic
+
+/-!
+  # Simple (Oracle) Reduction: Locally reduce a claim
+
+  This is a zero-round (oracle) reduction. There is no witness.
+
+  1. Reduction version: the input relation becomes a predicate on the statement. Verifier checks
+     this predicate, and returns the same statement if successful.
+
+  2. Oracle reduction version: the input relation becomes an oracle computation having as oracles
+     the oracle statements, and taking in the (non-oracle) statement as an input (i.e. via
+     `ReaderT`), and returning a `Prop`. Verifier performs this oracle computation, and returns the
+     same statement & oracle statement if successful.
+
+  In both cases, the output relation is trivial.
+-/

--- a/ArkLib/ProofSystem/Component/SendWitness.lean
+++ b/ArkLib/ProofSystem/Component/SendWitness.lean
@@ -110,17 +110,6 @@ def oracleProver : OracleProver (oraclePSpec Witness) oSpec
   receiveChallenge := fun i => nomatch i
   output := fun ⟨stmt, oStmt, wit⟩ => (⟨stmt, Sum.rec oStmt wit⟩, ())
 
-  -- -- Need to provide an embedding `ιₛ₃ ↪ ιₛ₁ ⊕ (pSpec₁ ++ₚ pSpec₂).MessageIdx`
-  -- embed :=
-  --   -- `ιₛ₃ ↪ ιₛ₂ ⊕ pSpec₂.MessageIdx`
-  --   .trans V₂.embed <|
-  --   -- `ιₛ₂ ⊕ pSpec₂.MessageIdx ↪ (ιₛ₁ ⊕ pSpec₁.MessageIdx) ⊕ pSpec₂.MessageIdx`
-  --   .trans (.sumMap V₁.embed (.refl _)) <|
-  --   -- re-associate the sum `_ ↪ ιₛ₁ ⊕ (pSpec₁.MessageIdx ⊕ pSpec₂.MessageIdx)`
-  --   .trans (Equiv.sumAssoc _ _ _).toEmbedding <|
-  --   -- use the equivalence `pSpec₁.MessageIdx ⊕ pSpec₂.MessageIdx ≃ (pSpec₁ ++ₚ pSpec₂).MessageIdx`
-  --   .sumMap (.refl _) MessageIdx.sumEquiv.toEmbedding
-
 /-- The oracle verifier for the `SendWitness` oracle reduction.
 
 It receives the input statement `stmt` and returns it, and also specifying the combination of

--- a/ArkLib/ProofSystem/Component/SendWitness.lean
+++ b/ArkLib/ProofSystem/Component/SendWitness.lean
@@ -218,6 +218,7 @@ def oracleVerifier : OracleVerifier (oraclePSpec Witness) oSpec
     <|.symm (subtypeUnivEquiv (by simp))
   hEq := by intro i; rcases i <;> simp
 
+@[inline, specialize]
 def oracleReduction : OracleReduction (oraclePSpec Witness) oSpec
     Statement Witness Statement Unit
     OStatement (OStatement ⊕ᵥ (fun _ : Fin 1 => Witness)) where

--- a/ArkLib/ProofSystem/Component/SendWitness.lean
+++ b/ArkLib/ProofSystem/Component/SendWitness.lean
@@ -4,71 +4,98 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 import ArkLib.OracleReduction.Security.Basic
+import Mathlib.Data.FinEnum
 
 /-!
 # Simple Oracle Reduction - SendWitness
 
-- The prover sends an oracle of type `WitEquiv` (supposed to be the witness up to equivalence) to
-     the verifier.
-   - The verifier does nothing.
-   - The output data has the same `Statement`, have output `OStatement` be the previous `OStatement`
-     plus an oracle for `EncWit`, and have no witness.
-   - The new relation is `rel` but replacing `Witness` with `EncWit`.
+This file contains the (oracle) reduction for the trivial one-message protocol where the prover
+sends the (entire) witness to the verifier. There are two variants:
 
-This is usually used as the first step of an oracle reduction, to replace the witness with an
-oracle statement.
+1. For oracle reduction: the witness is a finitely indexed type, and sent as a series of oracle
+   statements to the verifier.
+
+2. For reduction: the witness is a type, and sent as a statement to the verifier.
 -/
 
-open OracleSpec OracleComp OracleQuery
+open OracleSpec OracleComp OracleQuery ProtocolSpec
 
 namespace SendWitness
 
-variable {ι : Type} (oSpec : OracleSpec ι) (Statement Witness : Type)
-  {ιₛᵢ : Type} (OStatement : ιₛᵢ → Type) [∀ i, OracleInterface (OStatement i)]
-  (WitEquiv : Type) [OracleInterface WitEquiv] (equiv : Witness ≃ WitEquiv)
+variable {ι : Type} (oSpec : OracleSpec ι) (Statement : Type)
 
-@[reducible]
-def pSpec : ProtocolSpec 1 := ![(.P_to_V, WitEquiv)]
+/-!
+  First, the reduction version (no oracle statements)
+-/
 
--- TODO: figure out why `OracleInterface` & `VCVCompatible` instances cannot be automatically
--- synthesized
-instance : ∀ i, OracleInterface ((pSpec WitEquiv).Message i)
-  | ⟨0, _⟩ => by dsimp; infer_instance
-instance : ∀ i, VCVCompatible ((pSpec WitEquiv).Challenge i) | ⟨0, h⟩ => nomatch h
+section Reduction
 
-def prover : OracleProver (pSpec WitEquiv) oSpec Statement Witness Statement Unit
-    OStatement (OStatement ⊕ᵥ (fun _ : Unit => WitEquiv)) where
+variable (Witness : Type)
+
+@[reducible, simp]
+def pSpec : ProtocolSpec 1 := ![(.P_to_V, Witness)]
+
+instance : ∀ i, VCVCompatible ((pSpec Witness).Challenge i) | ⟨0, h⟩ => nomatch h
+
+@[inline, specialize]
+def prover : Prover (pSpec Witness) oSpec Statement Witness (Statement × Witness) Unit where
   PrvState
-  | 0 => Statement × (∀ i, OStatement i) × Witness
-  | 1 => Statement × (∀ i, OStatement i) × WitEquiv
-  input := fun ⟨stmt, oStmt⟩ wit => ⟨stmt, oStmt, wit⟩
-  sendMessage | ⟨0, _⟩ => fun ⟨stmt, oStmt, wit⟩ => pure (equiv wit, ⟨stmt, oStmt, equiv wit⟩)
+  | 0 => Statement × Witness
+  | 1 => Statement × Witness
+  input := fun stmt wit => ⟨stmt, wit⟩
+  sendMessage | ⟨0, _⟩ => fun ⟨stmt, wit⟩ => pure (wit, ⟨stmt, wit⟩)
   receiveChallenge | ⟨0, h⟩ => nomatch h
-  output := fun ⟨stmt, oStmt, encWit⟩ => (⟨stmt, (Sum.rec oStmt (fun _ => encWit))⟩, ())
+  output := fun ⟨stmt, wit⟩ => (⟨stmt, wit⟩, ())
 
-def verifier : OracleVerifier (pSpec WitEquiv) oSpec Statement Statement
-    OStatement (OStatement ⊕ᵥ (fun _ : Unit => WitEquiv)) where
-  verify := fun stmt _ => pure stmt
-  embed := by simp [pSpec, ProtocolSpec.MessageIdx]; sorry
-  hEq := sorry
+@[inline, specialize]
+def verifier : Verifier (pSpec Witness) oSpec Statement (Statement × Witness) where
+  verify := fun stmt transcript => pure ⟨stmt, transcript 0⟩
 
-def oracleReduction : OracleReduction (pSpec WitEquiv) oSpec Statement Witness Statement Unit
-    OStatement (OStatement ⊕ᵥ (fun _ : Unit => WitEquiv)) where
-  prover := prover oSpec Statement Witness OStatement WitEquiv equiv
-  verifier := verifier oSpec Statement OStatement WitEquiv
+@[inline, specialize]
+def reduction : Reduction (pSpec Witness) oSpec Statement Witness (Statement × Witness) Unit where
+  prover := prover oSpec Statement Witness
+  verifier := verifier oSpec Statement Witness
 
-variable (relIn : Statement × (∀ i, OStatement i) → Witness → Prop)
+variable {Statement} {Witness} [oSpec.FiniteRange] (relIn : Statement → Witness → Prop)
 
-def toRelOut : Statement × (∀ i, (OStatement ⊕ᵥ (fun _ : Unit => WitEquiv)) i) → Unit → Prop :=
-  fun ⟨stmt, oStmt⟩ _ => relIn ⟨stmt, fun i => oStmt (Sum.inl i)⟩ (equiv.invFun <| oStmt (.inr ()))
+@[reducible, simp]
+def toRelOut : Statement × Witness → Unit → Prop :=
+  fun ⟨stmt, wit⟩ _ => relIn stmt wit
 
-variable [oSpec.FiniteRange]
+/-- The `SendWitness` reduction satisfies perfect completeness. -/
+@[simp]
+theorem reduction_completeness :
+    (reduction oSpec Statement Witness).perfectCompleteness relIn (toRelOut relIn) := by
+  simp [Reduction.run, Prover.run, Prover.runToRound, Prover.processRound, Verifier.run,
+    reduction, prover, verifier]
+  aesop
 
-theorem completeness : OracleReduction.perfectCompleteness
-    relIn
-    (toRelOut Statement Witness OStatement WitEquiv equiv relIn)
-    (oracleReduction oSpec Statement Witness OStatement WitEquiv equiv) := by
-  sorry
-  -- simp [OracleReduction.perfectCompleteness]
+#check MonadLiftT
+
+theorem reduction_rbr_knowledge_soundness : True := sorry
+
+end Reduction
+
+/-!
+  Now, the oracle reduction version
+-/
+
+section OracleReduction
+
+variable {ιₛ : Type} (OStatement : ιₛ → Type) [∀ i, OracleInterface (OStatement i)]
+  {ιw : Type} [FinEnum ιw] (Witness : ιw → Type) [∀ i, OracleInterface (Witness i)]
+
+@[reducible, simp]
+def oraclePSpec : ProtocolSpec (FinEnum.card ιw) :=
+  fun i => (.P_to_V, Witness (FinEnum.equiv.symm i))
+
+instance : IsEmpty (oraclePSpec Witness).ChallengeIdx where
+  false := by aesop
+instance : ∀ i, OracleInterface ((oraclePSpec Witness).Message i) :=
+  fun _ => inferInstance
+instance : ∀ i, VCVCompatible ((oraclePSpec Witness).Challenge i) :=
+  fun _ => by aesop
+
+end OracleReduction
 
 end SendWitness


### PR DESCRIPTION
This PR fleshes out the simple oracle reductions defined for the purpose of composition.

We tentatively define 6 of them currently. Three of them are zero-message:
1. `DoNothing`: everything is trivial, just passes on input
2. `CheckClaim`: reduce an arbitrary input relation (with no witness) to an all-true relation, via letting the verifier check the claim
3. `ReduceClaim`: given some mapping between input and output statement & witness, we can pull back an arbitrary output relation to a corresponding input relation.
The other three are one-message:
4. `SendWitness`: send the entire witness to the verifier, changing the relation to depend on this sent witness
5. `SendClaim`: assuming the statement is a pair, sends the first of the pair to the verifier, changing the relation to stating that: (1) `fst pair = sent msg`, and (2) `rel (sent msg, snd pair) wit = True` (replacing `fst pair` with `sent msg`).
6. `RandomQuery`: assuming we have two oracle statements and the relation is that they are equal, the verifier issues a random query, and if their "oracle distance" is sufficiently large, this means that the reduction is secure with high probability for the output relation of their responses being equal.

We will define more based on needs.

This PR also fleshes out various other stuff, and add TODOs / tentative definitions.