### PR TITLE
feat: define general inductive trees

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -51,6 +51,8 @@ import ArkLib.Data.Polynomial.EvenAndOdd
 import ArkLib.Data.Polynomial.Interface
 import ArkLib.Data.Probability.Instances
 import ArkLib.Data.Probability.Notation
+import ArkLib.Data.Tree.Binary
+import ArkLib.Data.Tree.General
 import ArkLib.Data.UniPoly.Basic
 import ArkLib.Data.UniPoly.BasicOld
 import ArkLib.Data.UniPoly.PolynomialReflection

--- a/ArkLib/Data/Tree/Binary.lean
+++ b/ArkLib/Data/Tree/Binary.lean
@@ -1,0 +1,167 @@
+/-
+Copyright (c) 2024-2025 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import Mathlib.Data.Tree.Basic
+
+/-!
+  # Binary Trees
+
+  This file defines binary tree data structures with different value storage patterns.
+
+  We provide two main variants:
+  - `BinaryTree`: Trees where both leaf and internal nodes can hold values
+  - `BinaryLeafTree`: Trees where only leaf nodes hold values, internal nodes are structural
+
+  These complement Mathlib's `Tree` type (which stores values only in internal nodes)
+  and are particularly useful for Merkle tree implementations and other cryptographic
+  applications where different node types serve different purposes.
+
+  ## Comparison with Mathlib's Tree
+
+  - **Mathlib's `Tree α`**: Values only in internal nodes (traditional binary tree)
+  - **`BinaryTree α`**: Values in both leaf and internal nodes (maximum flexibility)
+  - **`BinaryLeafTree α`**: Values only in leaf nodes (common in Merkle trees)
+-/
+
+/-- A binary tree with (possibly null) values stored at both leaf and internal nodes.
+
+    This provides maximum flexibility where both leaf and internal nodes can carry data.
+    Useful for complex tree structures where different types of nodes serve different purposes. -/
+inductive BinaryTree (α : Type*) where
+  | leaf : α → BinaryTree α
+  | node : α → BinaryTree α → BinaryTree α → BinaryTree α
+  | nil : BinaryTree α
+  deriving Inhabited, Repr
+
+/-- A binary tree where only leaf nodes can have values.
+    Internal nodes are purely structural and do not store values.
+
+    This is commonly used as input to Merkle tree construction where
+    only the leaf data matters for the cryptographic commitments. -/
+inductive BinaryLeafTree (α : Type*) where
+  | leaf : α → BinaryLeafTree α
+  | node : BinaryLeafTree α → BinaryLeafTree α → BinaryLeafTree α
+  | nil : BinaryLeafTree α
+  deriving Inhabited, Repr
+
+namespace BinaryTree
+
+variable {α : Type*}
+
+/-- Get the root value of a binary tree, if it exists. -/
+def getRoot : BinaryTree α → Option α
+  | BinaryTree.nil => none
+  | BinaryTree.leaf a => some a
+  | BinaryTree.node a _ _ => some a
+
+/-- Check if the tree is a leaf. -/
+def isLeaf : BinaryTree α → Bool
+  | BinaryTree.leaf _ => true
+  | _ => false
+
+/-- Check if the tree is empty. -/
+def isEmpty : BinaryTree α → Bool
+  | BinaryTree.nil => true
+  | _ => false
+
+/-- Get the left child of the tree. -/
+def left : BinaryTree α → BinaryTree α
+  | BinaryTree.nil => BinaryTree.nil
+  | BinaryTree.leaf _ => BinaryTree.nil
+  | BinaryTree.node _ l _ => l
+
+/-- Get the right child of the tree. -/
+def right : BinaryTree α → BinaryTree α
+  | BinaryTree.nil => BinaryTree.nil
+  | BinaryTree.leaf _ => BinaryTree.nil
+  | BinaryTree.node _ _ r => r
+
+/-- Find the path from root to a leaf with the given value.
+    Returns a list of boolean directions (false = left, true = right). -/
+def findPath [DecidableEq α] (a : α) : BinaryTree α → Option (List Bool)
+  | BinaryTree.nil => none
+  | BinaryTree.leaf b => if a = b then some [] else none
+  | BinaryTree.node _ left right =>
+    match findPath a left with
+    | some path => some (false :: path)
+    | none =>
+      match findPath a right with
+      | some path => some (true :: path)
+      | none => none
+
+
+
+end BinaryTree
+
+namespace BinaryLeafTree
+
+variable {α : Type*}
+
+/-- Check if the tree is a leaf. -/
+def isLeaf : BinaryLeafTree α → Bool
+  | BinaryLeafTree.leaf _ => true
+  | _ => false
+
+/-- Check if the tree is empty. -/
+def isEmpty : BinaryLeafTree α → Bool
+  | BinaryLeafTree.nil => true
+  | _ => false
+
+/-- Get the left child of the tree. -/
+def left : BinaryLeafTree α → BinaryLeafTree α
+  | BinaryLeafTree.nil => BinaryLeafTree.nil
+  | BinaryLeafTree.leaf _ => BinaryLeafTree.nil
+  | BinaryLeafTree.node l _ => l
+
+/-- Get the right child of the tree. -/
+def right : BinaryLeafTree α → BinaryLeafTree α
+  | BinaryLeafTree.nil => BinaryLeafTree.nil
+  | BinaryLeafTree.leaf _ => BinaryLeafTree.nil
+  | BinaryLeafTree.node _ r => r
+
+/-- Find the path from root to a leaf with the given value.
+    Returns a list of boolean directions (false = left, true = right). -/
+def findPath [DecidableEq α] (a : α) : BinaryLeafTree α → Option (List Bool)
+  | BinaryLeafTree.nil => none
+  | BinaryLeafTree.leaf b => if a = b then some [] else none
+  | BinaryLeafTree.node left right =>
+    match findPath a left with
+    | some path => some (false :: path)
+    | none =>
+      match findPath a right with
+      | some path => some (true :: path)
+      | none => none
+
+end BinaryLeafTree
+
+-- Example usage:
+section Examples
+
+-- Example:
+--        1
+--       / \
+--      2   3
+--     / \   \
+--    4   5   6
+--       /
+--      7
+-- A tree with values at both leaf and internal nodes
+def BinaryTree.example : BinaryTree (Fin 10) :=
+  .node 1
+    (.node 2
+      (.leaf 4)
+      (.node 5 (.leaf 7) .nil))
+    (.node 3
+      .nil
+      (.leaf 6))
+
+-- A leaf tree where only leaves hold values
+def BinaryLeafTree.example : BinaryLeafTree (Fin 10) :=
+  .node
+    (.node (.leaf 1) (.leaf 2))
+    (.node (.leaf 3) .nil)
+
+end Examples

--- a/ArkLib/Data/Tree/General.lean
+++ b/ArkLib/Data/Tree/General.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2024-2025 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import Mathlib.Data.Tree.Basic
+
+/-!
+  # General Trees with Arbitrary Arities
+
+  This file defines general tree data structures where nodes can have an arbitrary number
+  of children (represented as lists).
+
+  We provide two main variants:
+  - `GeneralTree`: Trees where every node (including internal nodes) holds a value
+  - `GeneralLeafTree`: Trees where only leaf nodes hold values, internal nodes are structural
+
+  Both support arbitrary arities and include helper functions for common operations like
+  finding paths, checking properties, and accessing structure information.
+-/
+
+/-- A general tree with arbitrary arity where every node (including internal nodes) holds a value.
+    The children are represented as a list, allowing for any number of child nodes. -/
+inductive GeneralTree (α : Type*) where
+  | leaf : α → GeneralTree α
+  | node : α → List (GeneralTree α) → GeneralTree α
+  | nil : GeneralTree α
+  deriving Inhabited, Repr
+
+/-- A general tree with arbitrary arity where only leaf nodes hold values.
+    Internal nodes are purely structural and do not store values.
+    Used as input to general Merkle tree construction. -/
+inductive GeneralLeafTree (α : Type*) where
+  | leaf : α → GeneralLeafTree α
+  | node : List (GeneralLeafTree α) → GeneralLeafTree α
+  | nil : GeneralLeafTree α
+  deriving Inhabited, Repr
+
+namespace GeneralTree
+
+variable {α : Type*}
+
+/-- Get the root value of a general tree, if it exists. -/
+def getRoot : GeneralTree α → Option α
+  | GeneralTree.nil => none
+  | GeneralTree.leaf a => some a
+  | GeneralTree.node a _ => some a
+
+/-- Get the number of children of a node. -/
+def arity : GeneralTree α → Nat
+  | GeneralTree.nil => 0
+  | GeneralTree.leaf _ => 0
+  | GeneralTree.node _ children => children.length
+
+/-- Get the children of a node. -/
+def children : GeneralTree α → List (GeneralTree α)
+  | GeneralTree.nil => []
+  | GeneralTree.leaf _ => []
+  | GeneralTree.node _ children => children
+
+/-- Check if the tree is a leaf. -/
+def isLeaf : GeneralTree α → Bool
+  | GeneralTree.leaf _ => true
+  | _ => false
+
+/-- Check if the tree is empty. -/
+def isEmpty : GeneralTree α → Bool
+  | GeneralTree.nil => true
+  | _ => false
+
+/-- Find the path from root to a leaf with the given value.
+    The path is represented as a list of child indices. -/
+def findPath [DecidableEq α] (a : α) : GeneralTree α → Option (List Nat)
+  | GeneralTree.nil => none
+  | GeneralTree.leaf b => if a = b then some [] else none
+  | GeneralTree.node _ children => findPathInChildren a children 0
+where
+  findPathInChildren (a : α) (children : List (GeneralTree α)) (idx : Nat) : Option (List Nat) :=
+    match children with
+    | [] => none
+    | child :: rest =>
+      match findPath a child with
+      | some path => some (idx :: path)
+      | none => findPathInChildren a rest (idx + 1)
+
+end GeneralTree
+
+namespace GeneralLeafTree
+
+variable {α : Type*}
+
+/-- Get the number of children of a node. -/
+def arity : GeneralLeafTree α → Nat
+  | GeneralLeafTree.nil => 0
+  | GeneralLeafTree.leaf _ => 0
+  | GeneralLeafTree.node children => children.length
+
+/-- Get the children of a node. -/
+def children : GeneralLeafTree α → List (GeneralLeafTree α)
+  | GeneralLeafTree.nil => []
+  | GeneralLeafTree.leaf _ => []
+  | GeneralLeafTree.node children => children
+
+/-- Check if the tree is a leaf. -/
+def isLeaf : GeneralLeafTree α → Bool
+  | GeneralLeafTree.leaf _ => true
+  | _ => false
+
+/-- Check if the tree is empty. -/
+def isEmpty : GeneralLeafTree α → Bool
+  | GeneralLeafTree.nil => true
+  | _ => false
+
+/-- Find the path from root to a leaf with the given value.
+    The path is represented as a list of child indices. -/
+def findPath [DecidableEq α] (a : α) : GeneralLeafTree α → Option (List Nat)
+  | GeneralLeafTree.nil => none
+  | GeneralLeafTree.leaf b => if a = b then some [] else none
+  | GeneralLeafTree.node children => findPathInChildren a children 0
+where
+  findPathInChildren (a : α) (children : List (GeneralLeafTree α)) (idx : Nat) :
+      Option (List Nat) :=
+    match children with
+    | [] => none
+    | child :: rest =>
+      match findPath a child with
+      | some path => some (idx :: path)
+      | none => findPathInChildren a rest (idx + 1)
+
+end GeneralLeafTree
+
+-- Example usage:
+section Examples
+
+-- A general tree where every node holds a value
+def GeneralTree.example : GeneralTree (Fin 10) :=
+  .node 1 [
+    .leaf 2,
+    .node 3 [.leaf 4, .leaf 5, .leaf 6],
+    .leaf 7,
+    .node 8 [.leaf 9, .nil]
+  ]
+
+-- A general leaf tree where only leaves hold values
+def GeneralLeafTree.example : GeneralLeafTree (Fin 10) :=
+  .node [
+    .leaf 1,
+    .node [.leaf 2, .leaf 3, .leaf 4],
+    .leaf 5,
+    .node [.leaf 6, .nil]
+  ]
+
+end Examples


### PR DESCRIPTION
This PR refactors the MerkleTree file to add dedicated new files for inductively defined trees.

We define two variants: binary trees and general trees (arbitrary arities, represented by `List`). For each we also define a variant where the data are just at the leaves, and another variant where the data is present in each node.

The plan is to define Merkle trees on both kinds of trees, implementing an embedding for binary trees into general trees, and prove properties with regards to general trees.

@BoltonBailey this might mess with your current progress, but I hope not too much. I do think the general version is needed (i.e. to accommodate some Rust libraries with arity more than 2)