### PR TITLE
feat: minor notation & naming change for Additive NTT

### DIFF
--- a/ArkLib/Data/FieldTheory/AdditiveNTT/AdditiveNTT.lean
+++ b/ArkLib/Data/FieldTheory/AdditiveNTT/AdditiveNTT.lean
@@ -16,14 +16,14 @@ original algorithm in [LCH14] through a different interpretation.
 
 ## Main Definitions
 
-- `S_domain`: The intermediate evaluation domain `S⁽ⁱ⁾` for
+- `sDomain`: The intermediate evaluation domain `S⁽ⁱ⁾` for
 the round `i` in the Additive NTT algorithm
-- `q_map`: The quotient map `q⁽ⁱ⁾(X)` that relates successive domains
-- `intermediate_norm_vpoly`: The `i`-th order subspace vanishing
+- `qMap`: The quotient map `q⁽ⁱ⁾(X)` that relates successive domains
+- `intermediateNormVpoly`: The `i`-th order subspace vanishing
 polynomials `Ŵₖ⁽ⁱ⁾` over domain `S⁽ⁱ⁾`
-- `intermediate_novel_basis_X`: The intermediate novel basis `Xⱼ⁽ⁱ⁾` for
+- `intermediateNovelBasisX`: The intermediate novel basis `Xⱼ⁽ⁱ⁾` for
 the round `i` in the Additive NTT algorithm
-- `intermediate_evaluation_poly`: The intermediate evaluation polynomial `P⁽ⁱ⁾(X)`
+- `intermediateEvaluationPoly`: The intermediate evaluation polynomial `P⁽ⁱ⁾(X)`
   for the round `i` in the Additive NTT algorithm
 
 - `additiveNTT`: The main implementation of the Additive NTT encoding algorithm.
@@ -50,6 +50,8 @@ this proves that if the previous round satisfies the invariant, then the current
   over F2 (extended abstract)", in Proceedings of the 1996 International Symposium on
   Symbolic and Algebraic Computation, Zurich, Switzerland, 1996, pp. 1–9.
 -/
+
+set_option linter.style.longFile 2400
 
 open Polynomial AdditiveNTT
 namespace AdditiveNTT
@@ -82,7 +84,7 @@ under the normalized subspace vanishing polynomial `Ŵᵢ(X)`.
 `∀ i ∈ {0, ..., r-1}`, we define `Uᵢ:= <β₀, ..., βᵢ₋₁>_{𝔽q}`, note that `Uᵣ` is not used.
 `∀ i ∈ {0, ..., r-1}, S⁽ⁱ⁾` is the image of the subspace `U_{ℓ+R}`
   under the `𝔽q`-linear map `x ↦ Ŵᵢ(x)`. -/
-noncomputable def S_domain (i : Fin r) : Subspace 𝔽q L :=
+noncomputable def sDomain (i : Fin r) : Subspace 𝔽q L :=
   let W_i_norm := normalizedW 𝔽q β i
   let h_W_i_norm_is_additive : IsLinearMap 𝔽q (fun x : L => W_i_norm.eval x) :=
     AdditiveNTT.normalizedW_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i
@@ -91,16 +93,16 @@ noncomputable def S_domain (i : Fin r) : Subspace 𝔽q L :=
 
 /-- The quotient map `q⁽ⁱ⁾(X)` that relates successive domains.
 `q⁽ⁱ⁾(X) := (Wᵢ(βᵢ)^q / Wᵢ₊₁(βᵢ₊₁)) * ∏_{c ∈ 𝔽q} (X - c)`. Usable range is `∀ i ∈ {0, ..., r-2}` -/
-noncomputable def q_map (i : Fin r) : L[X] :=
+noncomputable def qMap (i : Fin r) : L[X] :=
   let constMultiplier := ((W 𝔽q β i).eval (β i))^(Fintype.card 𝔽q)
     / ((W 𝔽q β (i + 1)).eval (β (i + 1)))
   C constMultiplier * ∏ c: 𝔽q, (X - C (algebraMap 𝔽q L c))
 
 omit [DecidableEq L] in
-theorem q_map_eval_𝔽q_eq_0 (i : Fin r):
-  ∀ c: 𝔽q, (q_map 𝔽q β i).eval (algebraMap 𝔽q L c) = 0 := by
+theorem qMap_eval_𝔽q_eq_0 (i : Fin r):
+  ∀ c: 𝔽q, (qMap 𝔽q β i).eval (algebraMap 𝔽q L c) = 0 := by
   intro u
-  rw [q_map]
+  rw [qMap]
   set vpoly𝔽q := ∏ c: 𝔽q, (X - C ((algebraMap 𝔽q L) c)) with h_vpoly𝔽q
 
   have h_right_term_vanish: eval ((algebraMap 𝔽q L) u) (vpoly𝔽q) = 0 := by
@@ -116,11 +118,11 @@ theorem q_map_eval_𝔽q_eq_0 (i : Fin r):
 
 /-- **Lemma 4.2.** The quotient maps compose with the `Ŵ` polynomials.
 `q⁽ⁱ⁾ ∘ Ŵᵢ = Ŵᵢ₊₁, ∀ i ∈ {0, ..., r-2}`. -/
-lemma q_map_comp_normalizedW
+lemma qMap_comp_normalizedW
   (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
   (h_Fq_char_prime: Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent (R:=𝔽q) (M:=L) (v:=β)) (i : Fin r) (h_i_add_1 : i + 1 < r):
-  (q_map 𝔽q β i).comp (normalizedW 𝔽q β i) = normalizedW 𝔽q β (i + 1) := by
+  (qMap 𝔽q β i).comp (normalizedW 𝔽q β i) = normalizedW 𝔽q β (i + 1) := by
   let q := Fintype.card 𝔽q
   -- `q⁽ⁱ⁾ ∘ Ŵᵢ = ((Wᵢ(βᵢ)^q / Wᵢ₊₁(βᵢ₊₁)) * ∏_{c ∈ 𝔽q} (X - c)) ∘ Ŵᵢ`
   -- `= ((Wᵢ(βᵢ)^q / Wᵢ₊₁(βᵢ₊₁)) * (X^q - X)) ∘ Ŵᵢ` -- X^q - X = ∏_{c ∈ 𝔽q} (X - c)
@@ -147,10 +149,10 @@ lemma q_map_comp_normalizedW
 
   -- The proof proceeds by a chain of equalities
   calc
-    (q_map 𝔽q β i).comp (normalizedW 𝔽q β i)
+    (qMap 𝔽q β i).comp (normalizedW 𝔽q β i)
     _ = C (val_i ^ q / val_i_plus_1)
     * (∏ c:𝔽q, (X - C (algebraMap 𝔽q L c))).comp (normalizedW 𝔽q β i) := by
-      rw [q_map, mul_comp, C_comp]
+      rw [qMap, mul_comp, C_comp]
     _ = C (val_i ^ q / val_i_plus_1) * ((normalizedW 𝔽q β i) ^ q - normalizedW 𝔽q β i) := by
       simp_rw [prod_comp, sub_comp, X_comp, C_comp]
       rw [prod_poly_sub_C_eq_poly_pow_card_sub_poly_in_L h_Fq_card_gt_1]
@@ -192,15 +194,15 @@ lemma q_map_comp_normalizedW
 omit [DecidableEq L] in
 /-- The evaluation of the quotient map `q⁽ⁱ⁾(X)` is an `𝔽q`-linear map.
   Usable range is `∀ i ∈ {0, ..., r-2}`. -/
-theorem q_map_is_linear_map
+theorem qMap_is_linear_map
   (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
   (i : Fin r):
-  IsLinearMap 𝔽q (f:=fun inner_p ↦ (q_map 𝔽q β i).comp inner_p) := by
+  IsLinearMap 𝔽q (f:=fun inner_p ↦ (qMap 𝔽q β i).comp inner_p) := by
   set q := Fintype.card 𝔽q
   set constMultiplier := ((W 𝔽q β i).eval (β i))^q / ((W 𝔽q β (i + 1)).eval (β (i + 1)))
-  have h_q_poly_form : q_map 𝔽q β i = C constMultiplier * (X ^ q - X) := by
-    rw [q_map, prod_poly_sub_C_eq_poly_pow_card_sub_poly_in_L h_Fq_card_gt_1 (p:=X)]
+  have h_q_poly_form : qMap 𝔽q β i = C constMultiplier * (X ^ q - X) := by
+    rw [qMap, prod_poly_sub_C_eq_poly_pow_card_sub_poly_in_L h_Fq_card_gt_1 (p:=X)]
   -- Linearity of `x ↦ c * (x^q - x)` over `𝔽q`
 
   constructor
@@ -228,7 +230,7 @@ theorem q_map_is_linear_map
         ring
       _ = (C constMultiplier) * (((X: L[X]) ^ q - X).comp (f) + ((X: L[X]) ^ q - X).comp (g)) := by
         rw [←sub_comp, ←sub_comp]
-      _ = (q_map 𝔽q β i).comp f + (q_map 𝔽q β i).comp g := by
+      _ = (qMap 𝔽q β i).comp f + (qMap 𝔽q β i).comp g := by
         rw [h_q_poly_form]
         rw [mul_add]
         rw [mul_comp, mul_comp, C_comp, C_comp]
@@ -260,32 +262,32 @@ theorem q_map_is_linear_map
           rw [←X_comp (p:=f)]
         rw [←pow_comp, ←sub_comp]
         rw [C_mul_comp]
-      _ = c • (q_map 𝔽q β i).comp f := by
+      _ = c • (qMap 𝔽q β i).comp f := by
         rw [h_q_poly_form]
 
 /-- **Theorem 4.3.** The quotient map `q⁽ⁱ⁾` maps the domain `S⁽ⁱ⁾` to `S⁽ⁱ⁺¹⁾`.
   Usable range is `∀ i ∈ {0, ..., r-2}`. -/
-theorem q_map_maps_S_domain
+theorem qMap_maps_sDomain
 (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
 (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
 (hβ_lin_indep : LinearIndependent 𝔽q β)
 (ℓ R_rate : ℕ) (h_ℓ_add_R_rate : ℓ + R_rate < r)
 (i : Fin r) (h_i_add_1 : i + 1 < r) :
-  have q_comp_linear_map := q_map_is_linear_map 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime i
+  have q_comp_linear_map := qMap_is_linear_map 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime i
   have q_eval_linear_map := AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval
-    (f:=q_map 𝔽q β i) q_comp_linear_map
-  let q_i_map := poly_eval_linear_map (q_map 𝔽q β i) q_eval_linear_map
-  let S_i: Subspace 𝔽q L := S_domain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep
+    (f:=qMap 𝔽q β i) q_comp_linear_map
+  let q_i_map := poly_eval_linear_map (qMap 𝔽q β i) q_eval_linear_map
+  let S_i: Subspace 𝔽q L := sDomain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep
     ℓ R_rate h_ℓ_add_R_rate i
-  let S_i_plus_1: Subspace 𝔽q L := S_domain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep
+  let S_i_plus_1: Subspace 𝔽q L := sDomain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep
     ℓ R_rate h_ℓ_add_R_rate (i + 1)
   Submodule.map q_i_map S_i = S_i_plus_1 :=
 by
-  set q_comp_linear_map := q_map_is_linear_map 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime i
+  set q_comp_linear_map := qMap_is_linear_map 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime i
   set q_eval_linear_map := AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval
-    (f:=q_map 𝔽q β i) q_comp_linear_map
+    (f:=qMap 𝔽q β i) q_comp_linear_map
   -- Unfold definitions and apply submodule and polynomial composition properties
-  simp_rw [S_domain]
+  simp_rw [sDomain]
   -- `q⁽ⁱ⁾(S⁽ⁱ⁾) = q⁽ⁱ⁾(Ŵᵢ(⟨β₀, ..., β_{ℓ+R-1}⟩))`
   -- `= Ŵᵢ₊₁(⟨β₀, ..., β_{ℓ+R-1}⟩)`
   -- `= S⁽ⁱ⁺¹⁾`
@@ -293,12 +295,12 @@ by
   rw [←Submodule.map_comp] -- for two nested maps (composition) over the same subspace
   -- The goal becomes `q_i_map ∘ₗ Ŵᵢ_map = Ŵᵢ₊₁`
   congr
-  -- ⊢ poly_eval_linear_map (q_map 𝔽q β i) ⋯ ∘ₗ poly_eval_linear_map (normalizedW 𝔽q β i) ⋯ =
+  -- ⊢ poly_eval_linear_map (qMap 𝔽q β i) ⋯ ∘ₗ poly_eval_linear_map (normalizedW 𝔽q β i) ⋯ =
   -- poly_eval_linear_map (normalizedW 𝔽q β (i + 1)) ⋯
 
-  -- We now have `(q_map ...).eval ((normalizedW ... i).eval x) = (normalizedW ... (i + 1)).eval x`.
+  -- We now have `(qMap ...).eval ((normalizedW ... i).eval x) = (normalizedW ... (i + 1)).eval x`.
   -- The `Polynomial.eval_comp` lemma states `p.eval (q.eval x) = (p.comp q).eval x`.
-  set f := poly_eval_linear_map (q_map 𝔽q β i) q_eval_linear_map
+  set f := poly_eval_linear_map (qMap 𝔽q β i) q_eval_linear_map
   set g := poly_eval_linear_map (normalizedW 𝔽q β i)
     (normalizedW_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)
   set t := poly_eval_linear_map (normalizedW 𝔽q β (i + 1))
@@ -313,32 +315,32 @@ by
   -- unfold the linearmaps into their definitions (toFun, map_add, map_smul)
   simp only [LinearMap.coe_mk, AddHom.coe_mk]
   -- NOTE: `LinearMap.coe_mk` and `AddHom.coe_mk` convert linear maps into their functions
-  -- ⊢ eval (eval x (normalizedW 𝔽q β i)) (q_map 𝔽q β i) = eval x (normalizedW 𝔽q β (i + 1))
+  -- ⊢ eval (eval x (normalizedW 𝔽q β i)) (qMap 𝔽q β i) = eval x (normalizedW 𝔽q β (i + 1))
   rw [←Polynomial.eval_comp]
-  rw [q_map_comp_normalizedW 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i h_i_add_1]
+  rw [qMap_comp_normalizedW 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i h_i_add_1]
 
 /-- The composition `q⁽ⁱ⁻¹⁾ ∘ ... ∘ q⁽⁰⁾ ∘ X`. -/
-noncomputable def q_composition_chain (i : Fin r) : L[X] :=
+noncomputable def qCompositionChain (i : Fin r) : L[X] :=
   match i with
   | ⟨0, _⟩ => X
-  | ⟨k + 1, h_k_add_1⟩ => (q_map 𝔽q β ⟨k, by omega⟩).comp (q_composition_chain ⟨k, by omega⟩)
+  | ⟨k + 1, h_k_add_1⟩ => (qMap 𝔽q β ⟨k, by omega⟩).comp (qCompositionChain ⟨k, by omega⟩)
 
 omit [DecidableEq L] in
 /-- Prove the equality between the recursive definition
-of `q_composition_chain` and the Fin.foldl form. -/
-lemma q_composition_chain_eq_foldl
+of `qCompositionChain` and the Fin.foldl form. -/
+lemma qCompositionChain_eq_foldl
   (ℓ R_rate : ℕ)
   (i : Fin r) :
-  q_composition_chain 𝔽q β (ℓ:=ℓ) (R_rate:=R_rate) i =
+  qCompositionChain 𝔽q β (ℓ:=ℓ) (R_rate:=R_rate) i =
   Fin.foldl (n:=i) (fun acc j =>
-    (q_map 𝔽q β ⟨j, by omega⟩).comp acc) (X) := by
+    (qMap 𝔽q β ⟨j, by omega⟩).comp acc) (X) := by
   induction i using Fin.succRecOnSameFinType with
   | zero =>
-    rw [q_composition_chain.eq_def]
+    rw [qCompositionChain.eq_def]
     simp only [Fin.coe_ofNat_eq_mod, Nat.zero_mod, Fin.foldl_zero]
     rfl
   | succ k k_h i_h =>
-    rw [q_composition_chain.eq_def]
+    rw [qCompositionChain.eq_def]
     have h_eq: ⟨k.val.succ, k_h⟩ = k + 1 := by
       rw [Fin.mk_eq_mk]
       rw [Fin.val_add_one]
@@ -351,66 +353,66 @@ lemma q_composition_chain_eq_foldl
 **Corollary 4.4.** For each `i ∈ {0, ..., r-1}`, we have `Ŵᵢ = q⁽ⁱ⁻¹⁾ ∘ ... ∘ q⁽⁰⁾`
 (with the convention that for `i = 0`, this is just `X`).
 -/
-lemma normalizedW_eq_q_map_composition
+lemma normalizedW_eq_qMap_composition
   (h_W₀_eq_X : W 𝔽q β 0 = X)
   (h_β₀_eq_1 : β 0 = 1)
-  -- We also need the hypotheses for q_map_comp_normalizedW
+  -- We also need the hypotheses for qMap_comp_normalizedW
   (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
   (h_Fq_char_prime: Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent 𝔽q β)
   (ℓ R_rate : ℕ)
   (i : Fin r) :
-  normalizedW 𝔽q β i = q_composition_chain 𝔽q β (ℓ:=ℓ) (R_rate:=R_rate) i :=
+  normalizedW 𝔽q β i = qCompositionChain 𝔽q β (ℓ:=ℓ) (R_rate:=R_rate) i :=
 by
   -- We proceed by induction on i.
   induction i using Fin.succRecOnSameFinType with
   | zero =>
     -- Base case: i = 0
-    -- We need to show `normalizedW ... 0 = q_composition_chain 0`.
+    -- We need to show `normalizedW ... 0 = qCompositionChain 0`.
     -- The RHS is `X` by definition of the chain.
-    rw [q_composition_chain.eq_def]
+    rw [qCompositionChain.eq_def]
     -- The LHS is `C (1 / eval (β 0) (W ... 0)) * (W ... 0)`.
     rw [normalizedW, h_W₀_eq_X, eval_X, h_β₀_eq_1, div_one, C_1, one_mul]
     rfl
   | succ k k_h i_h =>
     -- Inductive step: Assume the property holds for k, prove for k+1.
-    -- The goal is `normalizedW ... (k+1) = q_composition_chain (k+1)`.
-    -- The RHS is `(q_map k).comp (q_composition_chain k)` by definition.
-    rw [q_composition_chain.eq_def]
-    -- From Lemma 4.2, we know `normalizedW ... (k+1) = (q_map k).comp (normalizedW ... k)`.
+    -- The goal is `normalizedW ... (k+1) = qCompositionChain (k+1)`.
+    -- The RHS is `(qMap k).comp (qCompositionChain k)` by definition.
+    rw [qCompositionChain.eq_def]
+    -- From Lemma 4.2, we know `normalizedW ... (k+1) = (qMap k).comp (normalizedW ... k)`.
     -- How to choose the rhs?
     have h_eq: ⟨k.val.succ, k_h⟩ = k + 1 := by
       rw [Fin.mk_eq_mk]
       rw [Fin.val_add_one]
       exact k_h
     simp only [h_eq.symm, Nat.succ_eq_add_one, Fin.eta]
-    have h_res := q_map_comp_normalizedW 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep k k_h
-    -- ⊢ normalizedW 𝔽q β ⟨↑k + 1, k_h⟩ = (q_map 𝔽q β k).comp (q_composition_chain 𝔽q β k)
+    have h_res := qMap_comp_normalizedW 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep k k_h
+    -- ⊢ normalizedW 𝔽q β ⟨↑k + 1, k_h⟩ = (qMap 𝔽q β k).comp (qCompositionChain 𝔽q β k)
     rw [←i_h]
     rw [h_res]
     simp only [h_eq]
 
 /-- The vectors `y_j^{(i)} = Ŵᵢ(β_j)` for `j ∈ {i, ..., ℓ+R-1}`. -/
-noncomputable def s_domain_basis_vectors (i : Fin r) : Fin (ℓ + R_rate - i) → L :=
+noncomputable def sDomainBasisVectors (i : Fin r) : Fin (ℓ + R_rate - i) → L :=
   fun k => (normalizedW 𝔽q β i).eval (β ⟨i + k.val, by omega⟩)
 
-/-- The vectors `s_domain_basis_vectors` are indeed elements of the subspace `S_domain`,
+/-- The vectors `sDomainBasisVectors` are indeed elements of the subspace `sDomain`,
   `∀ i ∈ {0, ..., r-1}`. -/
-lemma s_domain_basis_vectors_mem_S_domain
+lemma sDomainBasisVectors_mem_sDomain
     (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
     (h_Fq_char_prime: Fact (Nat.Prime (ringChar 𝔽q)))
     (hβ_lin_indep : LinearIndependent 𝔽q β)
     (ℓ R_rate : ℕ) (h_ℓ_add_R_rate : ℓ + R_rate < r)
     (i : Fin r) (k : Fin (ℓ + R_rate - i)) :
-  s_domain_basis_vectors 𝔽q β ℓ R_rate h_ℓ_add_R_rate i k
-    ∈ S_domain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep ℓ R_rate h_ℓ_add_R_rate i := by
+  sDomainBasisVectors 𝔽q β ℓ R_rate h_ℓ_add_R_rate i k
+    ∈ sDomain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep ℓ R_rate h_ℓ_add_R_rate i := by
   have h_i_add_k_lt_r : i + k.val < r := by
     omega
   have h_i_add_k_lt_ℓ_add_R_rate : i + k.val < ℓ + R_rate := by
     omega
   have h_i_add_k_lt_ℓ_add_R_rate : i + k.val < ℓ + R_rate := by
     omega
-  simp_rw [S_domain, s_domain_basis_vectors]
+  simp_rw [sDomain, sDomainBasisVectors]
   -- The vector is `eval Ŵᵢ (β (i + k.val))`
   -- We must show it's in the image of U_{ℓ+R} under `eval Ŵᵢ`.
   -- This is true if the input `β (i + k.val)` is in `U_{ℓ+R}`.
@@ -467,11 +469,11 @@ lemma S_basis_range_eq (i : Fin r) (h_i : i < ℓ + R_rate):
 
 /-- S⁽ⁱ⁾ is the image over `Wᵢ(X)` of the the subspace spanned by `{βᵢ, ..., β_{ℓ+R-1}}`.
   Usable range is `∀ i ∈ {0, ..., ℓ+R-1}`. -/
-lemma S_domain_eq_image_of_upper_span (i: Fin r) (h_i: i < ℓ + R_rate):
+lemma sDomain_eq_image_of_upper_span (i: Fin r) (h_i: i < ℓ + R_rate):
     let V_i := Submodule.span 𝔽q (Set.range (S_basis 𝔽q β ℓ R_rate h_ℓ_add_R_rate i h_i))
     let W_i_map := poly_eval_linear_map (normalizedW 𝔽q β i)
       (normalizedW_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)
-    S_domain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep ℓ R_rate h_ℓ_add_R_rate i
+    sDomain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep ℓ R_rate h_ℓ_add_R_rate i
     = Submodule.map W_i_map V_i :=
 by
   -- Proof: U_{ℓ+R} is the direct sum of Uᵢ and Vᵢ.
@@ -514,7 +516,7 @@ by
     rw [S_basis_range_eq 𝔽q β ℓ R_rate h_ℓ_add_R_rate i h_i]
 
   -- Now show that the image of U_{ℓ+R} under W_i_map is the same as the image of V_i
-  rw [S_domain, h_span_supremum_decomposition, Submodule.map_sup]
+  rw [sDomain, h_span_supremum_decomposition, Submodule.map_sup]
 
   -- The image of U_i under W_i_map is {0} because W_i vanishes on U_i
   have h_U_i_image : Submodule.map W_i_map (U 𝔽q β i) = ⊥ := by
@@ -533,9 +535,9 @@ by
   rw [bot_sup_eq]
 
 /-- **Corollary 4.5.** The set `{Ŵᵢ(βᵢ), ..., Ŵᵢ(β_{ℓ+R-1})}` is an `𝔽q`-basis for `S⁽ⁱ⁾`. -/
-noncomputable def S_domain_basis (i : Fin r) (h_i : i < ℓ + R_rate) :
+noncomputable def sDomain_basis (i : Fin r) (h_i : i < ℓ + R_rate) :
     Basis (Fin (ℓ + R_rate - i)) 𝔽q (
-      S_domain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep ℓ R_rate h_ℓ_add_R_rate i) := by
+      sDomain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep ℓ R_rate h_ℓ_add_R_rate i) := by
   -- Let V_i be the "upper" subspace spanned by {βᵢ, ..., β_{ℓ+R-1}}.
   let V_i := Submodule.span 𝔽q (Set.range (S_basis 𝔽q β ℓ R_rate h_ℓ_add_R_rate i h_i))
   -- Let W_i_map be the linear map given by evaluating the polynomial Ŵᵢ.
@@ -580,7 +582,7 @@ noncomputable def S_domain_basis (i : Fin r) (h_i : i < ℓ + R_rate) :
 
   -- We construct the isomorphism between Vᵢ and S⁽ⁱ⁾.
   -- S⁽ⁱ⁾ is the image of Vᵢ under W_i_map, and the map is injective on Vᵢ.
-  set S_i := S_domain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep ℓ R_rate h_ℓ_add_R_rate i
+  set S_i := sDomain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep ℓ R_rate h_ℓ_add_R_rate i
   let iso : V_i ≃ₗ[𝔽q] S_i :=
     LinearEquiv.ofBijective
       (LinearMap.codRestrict S_i (W_i_map.comp (Submodule.subtype V_i))
@@ -589,7 +591,7 @@ noncomputable def S_domain_basis (i : Fin r) (h_i : i < ℓ + R_rate) :
           -- ⊢ (W_i_map ∘ₗ V_i.subtype) x ∈ S_i
           have h_x_in_S_i : (W_i_map.comp (Submodule.subtype V_i)) x ∈ S_i := by
             simp only [LinearMap.coe_comp, Submodule.coe_subtype, Function.comp_apply, S_i]
-            rw [S_domain_eq_image_of_upper_span 𝔽q h_Fq_char_prime
+            rw [sDomain_eq_image_of_upper_span 𝔽q h_Fq_char_prime
               h_Fq_card_gt_1 β hβ_lin_indep ℓ R_rate h_ℓ_add_R_rate i h_i]
             exact
               Submodule.apply_coe_mem_map
@@ -642,12 +644,12 @@ noncomputable def S_domain_basis (i : Fin r) (h_i : i < ℓ + R_rate) :
             -- `y` is an element of `S_i` (which is a subtype).
             have h_y_in_image : y.val ∈ Submodule.map W_i_map V_i := by
               have h_y := y.property
-              -- From the lemma `S_domain_eq_image_of_upper_span`,
+              -- From the lemma `sDomain_eq_image_of_upper_span`,
               -- we know that S_i is *exactly* the image of V_i under W_i_map.
               unfold W_i_map V_i
               have h_S_i: S_i = Submodule.map W_i_map V_i := by
                 unfold S_i
-                rw [S_domain_eq_image_of_upper_span 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep
+                rw [sDomain_eq_image_of_upper_span 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep
                   ℓ R_rate h_ℓ_add_R_rate i h_i]
               rw [←h_S_i]
               exact h_y
@@ -669,48 +671,48 @@ noncomputable def S_domain_basis (i : Fin r) (h_i : i < ℓ + R_rate) :
 `Ŵₖ⁽ⁱ⁾ := q⁽ⁱ⁺ᵏ⁻¹⁾ ∘ ⋯ ∘ q⁽ⁱ⁾` for `k ∈ {1, ..., ℓ - i -1}`, and `X` for `k = 0`.
 -- k ∈ {0, ..., ℓ-i-1}
 -/
-noncomputable def intermediate_norm_vpoly
+noncomputable def intermediateNormVpoly
     -- Assuming you have this hypothesis available from the context:
     (i: Fin (ℓ+1)) (k : Fin (ℓ - i)) : L[X] :=
   -- This definition requires strict order
   Fin.foldl (n:=k) (fun acc j =>
-    (q_map 𝔽q β ⟨(i : ℕ) + (j : ℕ), by omega⟩).comp acc) (X)
+    (qMap 𝔽q β ⟨(i : ℕ) + (j : ℕ), by omega⟩).comp acc) (X)
 
 -- /--
 -- **Corollary 4.4.** For each `i ∈ {0, ..., r-1}`, we have `Ŵᵢ = q⁽ⁱ⁻¹⁾ ∘ ... ∘ q⁽⁰⁾`
 -- (with the convention that for `i = 0`, this is just `X`).
 -- -/
--- lemma normalizedW_eq_q_map_composition
+-- lemma normalizedW_eq_qMap_composition
 --   (h_W₀_eq_X : W 𝔽q β 0 = X)
 --   (h_β₀_eq_1 : β 0 = 1)
---   -- We also need the hypotheses for q_map_comp_normalizedW
+--   -- We also need the hypotheses for qMap_comp_normalizedW
 --   (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
 --   (h_Fq_char_prime: Fact (Nat.Prime (ringChar 𝔽q)))
 --   (hβ_lin_indep : LinearIndependent 𝔽q β)
 --   (ℓ R_rate : ℕ)
 --   (i : Fin r) :
---   normalizedW 𝔽q β i = q_composition_chain 𝔽q β (ℓ:=ℓ) (R_rate:=R_rate) i :=
+--   normalizedW 𝔽q β i = qCompositionChain 𝔽q β (ℓ:=ℓ) (R_rate:=R_rate) i :=
 -- by
 
 -- Ŵₖ⁽⁰⁾(X) = Ŵ(X)
-theorem base_intermediate_norm_vpoly
+theorem base_intermediateNormVpoly
   (h_W₀_eq_X : W 𝔽q β 0 = X)
   (h_β₀_eq_1 : β 0 = 1)
   (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent 𝔽q β)
-  (k : Fin (ℓ)):
-  intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨0, by
+  (k : Fin ℓ) :
+  intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨0, by
     by_contra ht
     simp only [not_lt, nonpos_iff_eq_zero] at ht
     contradiction
   ⟩ k =
   normalizedW 𝔽q β ⟨k, by omega⟩ := by
-  unfold intermediate_norm_vpoly
+  unfold intermediateNormVpoly
   simp only [Fin.mk_zero', Fin.coe_ofNat_eq_mod, zero_add]
-  rw [normalizedW_eq_q_map_composition 𝔽q β h_W₀_eq_X
+  rw [normalizedW_eq_qMap_composition 𝔽q β h_W₀_eq_X
     h_β₀_eq_1 h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep ℓ R_rate ⟨k, by omega⟩]
-  rw [q_composition_chain_eq_foldl 𝔽q β ℓ R_rate]
+  rw [qCompositionChain_eq_foldl 𝔽q β ℓ R_rate]
 
 -- i = 0->l: Ŵᵢ = q(i-1) ∘ ⋯ ∘ q(0)
 -- Ŵᵢ is actually Ŵᵢ⁽⁰⁾ => deg(Ŵᵢ) = 2^i = |Uᵢ|, and it vanishes on Uᵢ = Uᵢ⁽⁰⁾ = ⟨β₀, ..., β_{i-1}⟩
@@ -751,63 +753,63 @@ theorem Polynomial.comp_same_inner_eq_if_same_outer (f g : L[X]) (h_f_eq_g : f =
 
 omit [DecidableEq L] in
 -- ∀ i ∈ {0, ..., ℓ-1}, ∀ k ∈ {0, ..., ℓ-i-2}, `Ŵₖ₊₁⁽ⁱ⁾ = Ŵₖ⁽ⁱ⁺¹⁾ ∘ q⁽ⁱ⁾`
-theorem intermediate_norm_vpoly_comp_qmap (i : Fin (ℓ))
+theorem intermediateNormVpoly_comp_qmap (i : Fin (ℓ))
     (k : Fin (ℓ - i - 1)):
-    intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨k+1, by
+    intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨k+1, by
       simp only; omega⟩ =
-    (intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i+1, by omega⟩ ⟨k, by
+    (intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i+1, by omega⟩ ⟨k, by
       simp only; omega;
-  ⟩).comp (q_map 𝔽q β ⟨i, by omega⟩) := by
-  unfold intermediate_norm_vpoly
+  ⟩).comp (qMap 𝔽q β ⟨i, by omega⟩) := by
+  unfold intermediateNormVpoly
   simp only -- Fin.foldl (↑k+1) ... = Fin.foldl (↑k+1) ...
   rw [Fin.foldl_succ] -- convert Fin.foldl (↑k+1) ... into (Fin.foldl (↑k) ...).comp (init value)
   simp only [Fin.val_succ, Fin.coe_ofNat_eq_mod, Nat.zero_mod, add_zero, comp_X]
   conv_lhs =>
-    rw [←X_comp (p:=q_map 𝔽q β ⟨↑i, by omega⟩)]
+    rw [←X_comp (p:=qMap 𝔽q β ⟨↑i, by omega⟩)]
     rw [Polynomial.foldl_comp]
   congr -- convert Fin.foldl equality into equality of accumulator functions
-  -- ⊢ (fun acc j ↦ (q_map 𝔽q β ⟨↑i + (↑j + 1), ⋯⟩).comp acc)
-  -- = fun acc j ↦ (q_map 𝔽q β ⟨↑(i + 1) + ↑j, ⋯⟩).comp acc
+  -- ⊢ (fun acc j ↦ (qMap 𝔽q β ⟨↑i + (↑j + 1), ⋯⟩).comp acc)
+  -- = fun acc j ↦ (qMap 𝔽q β ⟨↑(i + 1) + ↑j, ⋯⟩).comp acc
   funext acc j
   have h_id_eq: i.val + (j.val + 1) = i.val + 1 + j.val := by omega
   simp_rw [h_id_eq]
 
 omit [DecidableEq L] in
--- A helper derivation for intermediate_norm_vpoly_comp_qmap
+-- A helper derivation for intermediateNormVpoly_comp_qmap
 -- i is now in Fin (ℓ-1) instead of Fin ℓ, and k is in Fin (ℓ - (↑i + 1))
-theorem intermediate_norm_vpoly_comp_qmap_helper (i : Fin (ℓ))
+theorem intermediateNormVpoly_comp_qmap_helper (i : Fin (ℓ))
     (k : Fin (ℓ - (↑i + 1))):
-    (intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate
-      ⟨↑i + 1, by omega⟩ k).comp (q_map 𝔽q β ⟨↑i, by omega⟩) =
-    intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+    (intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+      ⟨↑i + 1, by omega⟩ k).comp (qMap 𝔽q β ⟨↑i, by omega⟩) =
+    intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate
       ⟨↑i, by omega⟩ ⟨k + 1, by simp only; omega⟩:= by
-    simp only [intermediate_norm_vpoly_comp_qmap 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩
+    simp only [intermediateNormVpoly_comp_qmap 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩
         k]
 
 /-- ∀ `i` ∈ {0, ..., ℓ}, The `i`-th order novel polynomial basis `Xⱼ⁽ⁱ⁾`.
 `Xⱼ⁽ⁱ⁾ := Π_{k=0}^{ℓ-i-1} (Ŵₖ⁽ⁱ⁾)^{jₖ}`, ∀ j ∈ {0, ..., 2^(ℓ-i)-1} -/
-noncomputable def intermediate_novel_basis_X (i : Fin (ℓ + 1)) (j : Fin (2 ^ (ℓ - i))): L[X] :=
+noncomputable def intermediateNovelBasisX (i : Fin (ℓ + 1)) (j : Fin (2 ^ (ℓ - i))): L[X] :=
   (Finset.univ: Finset (Fin (ℓ - i)) ).prod (fun k =>
-    (intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate i k) ^ (bit k j))
+    (intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate i k) ^ (bit k j))
 -- NOTE: possibly we state some Basis for `(Xⱼ⁽ⁱ⁾)  `
 
 -- Xⱼ⁽⁰⁾ = Xⱼ
-theorem base_intermediate_novel_basis_X
-  (h_W₀_eq_X : W 𝔽q β 0 = X)
-  (h_β₀_eq_1 : β 0 = 1)
-  (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
-  (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
-  (hβ_lin_indep : LinearIndependent 𝔽q β)
-  (j : Fin (2 ^ ℓ)):
-  intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨0, by
+theorem base_intermediateNovelBasisX
+    (h_W₀_eq_X : W 𝔽q β 0 = X)
+    (h_β₀_eq_1 : β 0 = 1)
+    (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
+    (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
+    (hβ_lin_indep : LinearIndependent 𝔽q β)
+    (j : Fin (2 ^ ℓ)) :
+  intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨0, by
     by_contra ht
     simp only [not_lt, nonpos_iff_eq_zero] at ht
     contradiction
   ⟩ j =
   Xⱼ 𝔽q β ℓ (by omega) j := by
-  unfold intermediate_novel_basis_X Xⱼ
+  unfold intermediateNovelBasisX Xⱼ
   simp only [Fin.mk_zero', Fin.coe_ofNat_eq_mod]
-  have h_res := base_intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+  have h_res := base_intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate
     h_W₀_eq_X h_β₀_eq_1 h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep
   simp only [Fin.mk_zero'] at h_res
   conv_lhs =>
@@ -816,26 +818,26 @@ theorem base_intermediate_novel_basis_X
   congr
 
 omit [DecidableEq L] in
--- X₂ⱼ⁽ⁱ⁾ = Xⱼ⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X)) ∀ j ∈ {0, ..., 2^(ℓ-i)-1}, ∀ i ∈ {0, ..., ℓ-1}
+/-- `X₂ⱼ⁽ⁱ⁾ = Xⱼ⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X)) ∀ j ∈ {0, ..., 2^(ℓ-i)-1}, ∀ i ∈ {0, ..., ℓ-1}` -/
 lemma even_index_intermediate_novel_basis_decomposition (i : Fin ℓ) (j : Fin (2 ^ (ℓ - i - 1))):
-  intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨j * 2, by
+  intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨j * 2, by
     apply mul_two_add_bit_lt_two_pow j (ℓ-i-1) (ℓ-i) ⟨0, by omega⟩ (by omega) (by omega)
-  ⟩  = (intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i+1, by omega⟩ ⟨j, by
+  ⟩  = (intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i+1, by omega⟩ ⟨j, by
     apply lt_two_pow_of_lt_two_pow_exp_le j (ℓ-i-1) (ℓ-(i+1)) (by omega) (by omega)
-  ⟩).comp (q_map 𝔽q β ⟨i, by omega⟩) := by
-  unfold intermediate_novel_basis_X
+  ⟩).comp (qMap 𝔽q β ⟨i, by omega⟩) := by
+  unfold intermediateNovelBasisX
   rw [prod_comp]
   -- ∏ k ∈ Fin (ℓ - i), (Wₖ⁽ⁱ⁾(X))^((2j)ₖ) = ∏ k ∈ Fin (ℓ - (i+1)), (Wₖ⁽ⁱ⁺¹⁾(X))^((j)ₖ) ∘ q⁽ⁱ⁾(X)
   simp only [pow_comp]
   conv_rhs =>
     enter [2, x]
-    rw [intermediate_norm_vpoly_comp_qmap_helper 𝔽q]
+    rw [intermediateNormVpoly_comp_qmap_helper 𝔽q]
 
-  -- ⊢ ∏ x, intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, ⋯⟩ x ^ bit (↑x) (↑j * 2) =
-  -- ∏ x, intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, ⋯⟩ ⟨↑x + 1, ⋯⟩ ^ bit ↑x ↑j
+  -- ⊢ ∏ x, intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, ⋯⟩ x ^ bit (↑x) (↑j * 2) =
+  -- ∏ x, intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, ⋯⟩ ⟨↑x + 1, ⋯⟩ ^ bit ↑x ↑j
 
   set fleft := fun x : Fin (ℓ - ↑i) =>
-    intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ x ^ bit (↑x) (↑j * 2)
+    intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ x ^ bit (↑x) (↑j * 2)
   have h_n_shift: ℓ - (↑i + 1) + 1 = ℓ - ↑i := by omega
   have h_fin_n_shift: Fin (ℓ - (↑i + 1) + 1) = Fin (ℓ - ↑i) := by
     rw [h_n_shift]
@@ -873,15 +875,15 @@ lemma even_index_intermediate_novel_basis_decomposition (i : Fin ℓ) (j : Fin (
   rw [h_exp_eq]
 
 omit [DecidableEq L] in
--- X₂ⱼ₊₁⁽ⁱ⁾ = X * (Xⱼ⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X))) ∀ j ∈ {0, ..., 2^(ℓ-i)-1}, ∀ i ∈ {0, ..., ℓ-1}
+/-- `X₂ⱼ₊₁⁽ⁱ⁾ = X * (Xⱼ⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X))) ∀ j ∈ {0, ..., 2^(ℓ-i)-1}, ∀ i ∈ {0, ..., ℓ-1}` -/
 lemma odd_index_intermediate_novel_basis_decomposition
     (i : Fin ℓ) (j : Fin (2 ^ (ℓ - i - 1))):
-    intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨j * 2 + 1, by
+    intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨j * 2 + 1, by
       apply mul_two_add_bit_lt_two_pow j (ℓ-i-1) (ℓ-i) ⟨1, by omega⟩ (by omega) (by omega)
-    ⟩  = X * (intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i+1, by omega⟩ ⟨j, by
+    ⟩  = X * (intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i+1, by omega⟩ ⟨j, by
       apply lt_two_pow_of_lt_two_pow_exp_le j (ℓ-i-1) (ℓ-(i+1)) (by omega) (by omega)
-    ⟩).comp (q_map 𝔽q β ⟨i, by omega⟩) := by
-  unfold intermediate_novel_basis_X
+    ⟩).comp (qMap 𝔽q β ⟨i, by omega⟩) := by
+  unfold intermediateNovelBasisX
   rw [prod_comp]
   -- ∏ k ∈ Fin (ℓ - i), (Wₖ⁽ⁱ⁾(X))^((2j₊₁)ₖ)
   -- = X * ∏ k ∈ Fin (ℓ - (i+1)), (Wₖ⁽ⁱ⁺¹⁾(X))^((j)ₖ) ∘ q⁽ⁱ⁾(X)
@@ -890,14 +892,14 @@ lemma odd_index_intermediate_novel_basis_decomposition
   conv_rhs =>
     enter [2]
     enter [2, x, 1]
-    rw [intermediate_norm_vpoly_comp_qmap_helper 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+    rw [intermediateNormVpoly_comp_qmap_helper 𝔽q β ℓ R_rate h_ℓ_add_R_rate
       ⟨i, by omega⟩ ⟨x, by simp only; omega⟩]
 
-  -- ⊢ ∏ x, intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, ⋯⟩ x ^ bit (↑x) (↑j * 2 + 1) =
-  -- X * ∏ x, intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, ⋯⟩ ⟨↑x + 1, ⋯⟩ ^ bit ↑x ↑j
+  -- ⊢ ∏ x, intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, ⋯⟩ x ^ bit (↑x) (↑j * 2 + 1) =
+  -- X * ∏ x, intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, ⋯⟩ ⟨↑x + 1, ⋯⟩ ^ bit ↑x ↑j
 
   set fleft := fun x : Fin (ℓ - ↑i) =>
-    intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ x ^ bit (↑x) (↑j * 2 + 1)
+    intermediateNormVpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ x ^ bit (↑x) (↑j * 2 + 1)
   have h_n_shift: ℓ - (↑i + 1) + 1 = ℓ - ↑i := by omega
   have h_fin_n_shift: Fin (ℓ - (↑i + 1) + 1) = Fin (ℓ - ↑i) := by
     rw [h_n_shift]
@@ -920,7 +922,7 @@ lemma odd_index_intermediate_novel_basis_decomposition
       simp only [Nat.shiftRight_zero, Nat.and_one_is_mod, Nat.mul_add_mod_self_right, Nat.mod_succ]
     rw [h_exp]
     simp only [pow_one, Fin.coe_ofNat_eq_mod, Nat.zero_mod]
-    unfold intermediate_norm_vpoly
+    unfold intermediateNormVpoly
     simp only [Fin.foldl_zero]
 
   rw [fleft_0_eq_X]
@@ -942,27 +944,27 @@ lemma odd_index_intermediate_novel_basis_decomposition
   polynomial `P(X)` we need to evaluate,
   and `coeffs` is the list of `2^(ℓ-i)` coefficients of the polynomial.
 -/
-noncomputable def intermediate_evaluation_poly (i : Fin (ℓ + 1))
+noncomputable def intermediateEvaluationPoly (i : Fin (ℓ + 1))
     (coeffs : Fin (2 ^ (ℓ - i)) → L) : L[X] :=
   ∑ (⟨j, hj⟩: Fin (2^(ℓ-i))), C (coeffs ⟨j, by omega⟩) *
-    (intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate i ⟨j, by omega⟩)
+    (intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate i ⟨j, by omega⟩)
 
 /-- The even and odd refinements of `P⁽ⁱ⁾(X)` which are polynomials in the `(i+1)`-th basis.
 `P₀⁽ⁱ⁺¹⁾(Y) = ∑_{j=0}^{2^{ℓ-i-1}-1} a_{2j} ⋅ Xⱼ⁽ⁱ⁺¹⁾(Y)`
 `P₁⁽ⁱ⁺¹⁾(Y) = ∑_{j=0}^{2^{ℓ-i-1}-1} a_{2j+1} ⋅ Xⱼ⁽ⁱ⁺¹⁾(Y)` -/
-noncomputable def even_refinement (i : Fin (ℓ))
+noncomputable def evenRefinement (i : Fin (ℓ))
     (coeffs : Fin (2 ^ (ℓ - i)) → L) : L[X] :=
   ∑ (⟨j, hj⟩: Fin (2^(ℓ-i-1))), C (coeffs ⟨j*2, by
     calc _ < 2 ^ (ℓ - i - 1) * 2 := by omega
       _ = 2 ^ (ℓ - i) := Nat.two_pow_pred_mul_two (w:=ℓ - i) (h:=by omega)
-  ⟩) * (intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i+1, by omega⟩ ⟨j, hj⟩)
+  ⟩) * (intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i+1, by omega⟩ ⟨j, hj⟩)
 
-noncomputable def odd_refinement (i : Fin (ℓ))
+noncomputable def oddRefinement (i : Fin (ℓ))
     (coeffs : Fin (2 ^ (ℓ - i)) → L) : L[X] :=
   ∑ (⟨j, hj⟩: Fin (2^(ℓ-i-1))), C (coeffs ⟨j*2+1, by
     calc _ < 2 ^ (ℓ - i - 1) * 2 := by omega
       _ = 2 ^ (ℓ - i) := Nat.two_pow_pred_mul_two (w:=ℓ - i) (h:=by omega)
-  ⟩) * (intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i+1, by omega⟩ ⟨j, hj⟩)
+  ⟩) * (intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i+1, by omega⟩ ⟨j, hj⟩)
 
 /-- **Key Polynomial Identity (Equation 39)**. This identity is the foundation for the
 butterfly operation in the Additive NTT. It relates a polynomial in the `i`-th basis to
@@ -970,30 +972,29 @@ its even and odd parts expressed in the `(i+1)`-th basis via the quotient map `q
 `∀ i ∈ {0, ..., ℓ-1}, P⁽ⁱ⁾(X) = P₀⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X)) + X ⋅ P₁⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X))` -/
 theorem evaluation_poly_split_identity (i : Fin (ℓ))
     (coeffs : Fin (2 ^ (ℓ - i)) → L) :
-  let P_i: L[X] := intermediate_evaluation_poly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ coeffs
-  let P_even_i_plus_1: L[X] := even_refinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i coeffs
-  let P_odd_i_plus_1: L[X] := odd_refinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i coeffs
-  let q_i: L[X] := q_map 𝔽q β ⟨i, by omega⟩
+  let P_i: L[X] := intermediateEvaluationPoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ coeffs
+  let P_even_i_plus_1: L[X] := evenRefinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i coeffs
+  let P_odd_i_plus_1: L[X] := oddRefinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i coeffs
+  let q_i: L[X] := qMap 𝔽q β ⟨i, by omega⟩
   P_i = (P_even_i_plus_1.comp q_i) + X * (P_odd_i_plus_1.comp q_i) := by
 
-  dsimp only [Lean.Elab.WF.paramLet]
-  simp only [intermediate_evaluation_poly, Fin.eta]
-  simp only [even_refinement, Fin.eta, sum_comp, mul_comp, C_comp, odd_refinement]
+  simp only [intermediateEvaluationPoly, Fin.eta]
+  simp only [evenRefinement, Fin.eta, sum_comp, mul_comp, C_comp, oddRefinement]
 
   set leftEvenTerm := ∑ ⟨j, hj⟩ : Fin (2 ^ (ℓ - ↑i - 1)), C (coeffs ⟨j * 2, by
     exact mul_two_add_bit_lt_two_pow j (ℓ-i-1) (ℓ-i) ⟨0, by omega⟩ (by omega) (by omega)
-  ⟩) * intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ ⟨j * 2, by
+  ⟩) * intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ ⟨j * 2, by
     exact mul_two_add_bit_lt_two_pow j (ℓ-i-1) (ℓ-i) ⟨0, by omega⟩ (by omega) (by omega)
   ⟩
   set leftOddTerm := ∑ ⟨j, hj⟩ : Fin (2 ^ (ℓ - ↑i - 1)), C (coeffs ⟨j * 2 + 1, by
     apply mul_two_add_bit_lt_two_pow j (ℓ-i-1) (ℓ-i) ⟨1, by omega⟩ (by omega) (by omega)
-  ⟩) * intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ ⟨j * 2 + 1, by
+  ⟩) * intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ ⟨j * 2 + 1, by
     exact mul_two_add_bit_lt_two_pow j (ℓ-i-1) (ℓ-i) ⟨1, by omega⟩ (by omega) (by omega)
   ⟩
 
   have h_split_P_i: ∑ ⟨j, hj⟩ : Fin (2 ^ (ℓ - ↑i)), C (coeffs ⟨j, by
     apply lt_two_pow_of_lt_two_pow_exp_le j (ℓ-i) (ℓ-i) (by omega) (by omega)
-  ⟩) * intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ ⟨j, by omega⟩ =
+  ⟩) * intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ ⟨j, by omega⟩ =
   leftEvenTerm + leftOddTerm
   := by
     unfold leftEvenTerm leftOddTerm
@@ -1006,12 +1007,12 @@ theorem evaluation_poly_split_identity (i : Fin (ℓ))
     set f1 := fun x: ℕ => -- => use a single function to represent the sum
       if hx: x < 2 ^ (ℓ - ↑i) then
         C (coeffs ⟨x, hx⟩) *
-          intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ ⟨x, by omega⟩
+          intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ ⟨x, by omega⟩
       else 0
 
     have h_x: ∀ x: Fin (2 ^ (ℓ - ↑i)), f1 x.val =
       C (coeffs ⟨x.val, by omega⟩) *
-        intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩
+        intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩
           ⟨x.val, by simp only; omega⟩ := by
       intro x
       unfold f1
@@ -1026,7 +1027,7 @@ theorem evaluation_poly_split_identity (i : Fin (ℓ))
         calc _ < 2 ^ (ℓ - i - 1) * 2 := by omega
           _ = 2 ^ (ℓ - i) := Nat.two_pow_pred_mul_two (w:=ℓ - i) (h:=by omega)
       ⟩) *
-        intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ ⟨x.val * 2, by
+        intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ ⟨x.val * 2, by
           exact mul_two_add_bit_lt_two_pow x.val (ℓ-i-1) (ℓ-i) ⟨0, by omega⟩ (by omega) (by omega)
         ⟩ := by
       intro x
@@ -1046,7 +1047,7 @@ theorem evaluation_poly_split_identity (i : Fin (ℓ))
         calc _ < 2 ^ (ℓ - i - 1) * 2 := by omega
           _ = 2 ^ (ℓ - i) := Nat.two_pow_pred_mul_two (w:=ℓ - i) (h:=by omega)
       ⟩) *
-        intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ ⟨x.val * 2 + 1, by
+        intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ ⟨x.val * 2 + 1, by
           exact mul_two_add_bit_lt_two_pow x.val (ℓ-i-1) (ℓ-i) ⟨1, by omega⟩ (by omega) (by omega)
         ⟩ := by
       intro x
@@ -1087,9 +1088,9 @@ theorem evaluation_poly_split_identity (i : Fin (ℓ))
         calc _ < 2 ^ (ℓ - i - 1) * 2 := by omega
           _ = 2 ^ (ℓ - i) := Nat.two_pow_pred_mul_two (w:=ℓ - i) (h:=by omega)
       ⟩) *
-        (intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i + 1, by omega⟩ ⟨j, by
+        (intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i + 1, by omega⟩ ⟨j, by
           apply lt_two_pow_of_lt_two_pow_exp_le (x:=j) (i:=ℓ-↑i-1) (j:=ℓ-↑i-1) (by omega) (by omega)
-        ⟩).comp (q_map 𝔽q β ⟨i, by omega⟩)
+        ⟩).comp (qMap 𝔽q β ⟨i, by omega⟩)
 
   set rightOddTerm :=
     X *
@@ -1098,10 +1099,10 @@ theorem evaluation_poly_split_identity (i : Fin (ℓ))
           calc _ < 2 ^ (ℓ - i - 1) * 2 := by omega
             _ = 2 ^ (ℓ - i) := Nat.two_pow_pred_mul_two (w:=ℓ - i) (h:=by omega)
         ⟩) *
-          (intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i + 1, by omega⟩ ⟨j, by
+          (intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i + 1, by omega⟩ ⟨j, by
             apply lt_two_pow_of_lt_two_pow_exp_le (x:=j)
               (i:=ℓ-↑i-1) (j:=ℓ-↑i-1) (by omega) (by omega)
-          ⟩).comp (q_map 𝔽q β ⟨i, by omega⟩)
+          ⟩).comp (qMap 𝔽q β ⟨i, by omega⟩)
 
   conv_rhs => change rightEvenTerm + rightOddTerm
 
@@ -1145,13 +1146,13 @@ lemma intermediate_poly_P_base
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent 𝔽q β)
   (h_ℓ : ℓ ≤ r) (coeffs : Fin (2^ℓ) → L) :
-  intermediate_evaluation_poly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨0, by omega⟩ coeffs =
-    polynomial_from_novel_coeffs 𝔽q β ℓ h_ℓ coeffs := by
-  unfold polynomial_from_novel_coeffs intermediate_evaluation_poly
+  intermediateEvaluationPoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨0, by omega⟩ coeffs =
+    polynomialFromNovelCoeffs 𝔽q β ℓ h_ℓ coeffs := by
+  unfold polynomialFromNovelCoeffs intermediateEvaluationPoly
   simp only [Fin.mk_zero', Fin.coe_ofNat_eq_mod, Fin.eta]
   conv_rhs =>
     enter [2, j]
-    rw [←base_intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate h_W₀_eq_X
+    rw [←base_intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate h_W₀_eq_X
       h_β₀_eq_1 h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep j]
   congr
 
@@ -1167,7 +1168,7 @@ correctness theorem for the Additive NTT algorithm.
 -/
 
 /-- Constructs an evaluation point `ω` in the domain `S⁽ⁱ⁾` from a bit representation.
-This uses the `𝔽q`-basis of `S⁽ⁱ⁾` from `S_domain_basis`.
+This uses the `𝔽q`-basis of `S⁽ⁱ⁾` from `sDomain_basis`.
 `ω_{u,b,i} = b⋅Ŵᵢ(βᵢ) + ∑_{k=0}^{|u|-1} uₖ ⋅ Ŵᵢ(β_{i+1+k})`
 where `(u,b)` is a bit string of length `ℓ + R - i`.
 Computes the twiddle factor `t` for a given stage `i` and high-order bits `u`.
@@ -1188,11 +1189,11 @@ noncomputable def twiddleFactor (i : Fin ℓ) (u : Fin (2 ^ (ℓ + R_rate - i - 
   ∑ (⟨k, hk⟩: Fin (ℓ + R_rate - i - 1)),
     if bit k u.val = 1 then
       -- this branch maps to the above bit = 1 branch
-        -- (of evaluationPointω (i+1)) under (q_map i)(X)
+        -- (of evaluationPointω (i+1)) under (qMap i)(X)
       (normalizedW 𝔽q β ⟨i, by omega⟩).eval (β ⟨i + 1 + k, by omega⟩)
     else 0
       -- 0 maps to the below bit = 0 branch
-        -- (of evaluationPointω (i+1)) under (q_map i)(X)
+        -- (of evaluationPointω (i+1)) under (qMap i)(X)
 
 omit [DecidableEq L] in
 lemma evaluationPointω_eq_twiddleFactor_of_div_2 (i : Fin ℓ) (x : Fin (2 ^ (ℓ + R_rate - i))):
@@ -1259,25 +1260,25 @@ lemma eval_point_ω_eq_next_twiddleFactor_comp_qmap
   eval (twiddleFactor 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨x.val, by
     calc x.val < 2 ^ (ℓ + R_rate - (i.val + 1)) := by omega
       _ = 2 ^ (ℓ + R_rate - i.val - 1) := by rfl
-  ⟩) (q_map 𝔽q β ⟨i, by omega⟩) := by
+  ⟩) (qMap 𝔽q β ⟨i, by omega⟩) := by
   simp [evaluationPointω, twiddleFactor]
   have h_qmap_linear_map :=
-    q_map_is_linear_map 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime (i:=⟨i, by omega⟩)
-  have h_qmap_additive: IsLinearMap 𝔽q fun x ↦ eval x (q_map 𝔽q β ⟨↑i, by omega⟩) :=
-    AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval (f := (q_map 𝔽q β ⟨i, by omega⟩))
+    qMap_is_linear_map 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime (i:=⟨i, by omega⟩)
+  have h_qmap_additive: IsLinearMap 𝔽q fun x ↦ eval x (qMap 𝔽q β ⟨↑i, by omega⟩) :=
+    AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval (f := (qMap 𝔽q β ⟨i, by omega⟩))
     (h_f_linear := h_qmap_linear_map)
 
   set right_inner_func := fun x_1: Fin (ℓ + R_rate - i - 1) => if bit ↑x_1 ↑x = 1
     then eval (β ⟨↑i + 1 + ↑x_1, by omega⟩) (normalizedW 𝔽q β ⟨↑i, by omega⟩) else 0
 
   let eval_qmap_linear : L →ₗ[𝔽q] L := {
-    toFun    := fun x ↦ eval x (q_map 𝔽q β ⟨i, by omega⟩),
+    toFun    := fun x ↦ eval x (qMap 𝔽q β ⟨i, by omega⟩),
     map_add' := h_qmap_additive.map_add,
     map_smul' := h_qmap_additive.map_smul
   }
   have h_rhs: eval (∑ x_1: Fin (ℓ + R_rate - i - 1), right_inner_func x_1)
-      (q_map 𝔽q β ⟨↑i, by omega⟩) = ∑ x_1: Fin (ℓ + R_rate - i - 1),
-      (eval (right_inner_func x_1) (q_map 𝔽q β ⟨↑i, by omega⟩)) := by
+      (qMap 𝔽q β ⟨↑i, by omega⟩) = ∑ x_1: Fin (ℓ + R_rate - i - 1),
+      (eval (right_inner_func x_1) (qMap 𝔽q β ⟨↑i, by omega⟩)) := by
     change eval_qmap_linear (∑ x_1, right_inner_func x_1) = _
     rw [map_sum (g:=eval_qmap_linear) (f:=right_inner_func)
       (s:=(Finset.univ: Finset ( Fin (ℓ + R_rate - i - 1))))]
@@ -1298,8 +1299,8 @@ lemma eval_point_ω_eq_next_twiddleFactor_comp_qmap
 
 --   `q⁽ⁱ⁾ ∘ Ŵᵢ = Ŵᵢ₊₁`. -/
   have h_normalized_comp_qmap: normalizedW 𝔽q β ⟨i + 1, by omega⟩ =
-    (q_map 𝔽q β ⟨i, by omega⟩).comp (normalizedW 𝔽q β ⟨i, by omega⟩) := by
-    have res := q_map_comp_normalizedW 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime
+    (qMap 𝔽q β ⟨i, by omega⟩).comp (normalizedW 𝔽q β ⟨i, by omega⟩) := by
+    have res := qMap_comp_normalizedW 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime
       hβ_lin_indep (i:=⟨i, by omega⟩) (h_i_add_1:=by simp only; omega;)
     rw [res]
     congr
@@ -1313,7 +1314,7 @@ lemma eval_point_ω_eq_next_twiddleFactor_comp_qmap
     have h_0_is_algebra_map: (0: L) = (algebraMap 𝔽q L) 0 := by
       simp only [map_zero]
     conv_rhs => rw [h_0_is_algebra_map]
-    have h_res := q_map_eval_𝔽q_eq_0 𝔽q β (i:=⟨i, by omega⟩) (c:=0)
+    have h_res := qMap_eval_𝔽q_eq_0 𝔽q β (i:=⟨i, by omega⟩) (c:=0)
     rw [h_res]
   · push_neg at h_bit_of_x_eq_0
     have h_bit_lt_2 := bit_lt_2 (k:=x1) (n:=x)
@@ -1449,23 +1450,23 @@ omit [DecidableEq L] in
 Note that the even refinement `P₀, ₍ᵥ₎⁽ⁱ⁺¹⁾(X)` is constructed from the view of
 stage `i`, while the novel polynomial `P₍₀ᵥ₎⁽ⁱ⁺¹⁾(X)` is constructed from the view of stage `i+1`.
 -/
-theorem even_refinement_eq_novel_poly_of_0_leading_suffix (i : Fin ℓ) (v : Fin (2 ^ i.val))
+theorem evenRefinement_eq_novel_poly_of_0_leading_suffix (i : Fin ℓ) (v : Fin (2 ^ i.val))
     (original_coeffs : Fin (2 ^ ℓ) → L):
     have h_v: v.val < 2 ^ (i.val + 1) := by
       calc v.val < 2 ^ i.val := by omega
         _ < 2 ^ (i.val + 1) := by apply Nat.pow_lt_pow_right (by omega) (by omega)
-    even_refinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i (coeffsBySuffix (r:=r) 𝔽q ℓ
+    evenRefinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i (coeffsBySuffix (r:=r) 𝔽q ℓ
       R_rate original_coeffs ⟨i, by omega⟩ v) =
-    intermediate_evaluation_poly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i + 1, by omega⟩
+    intermediateEvaluationPoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i + 1, by omega⟩
       (coeffsBySuffix (r:=r) 𝔽q ℓ R_rate original_coeffs ⟨i + 1, by omega⟩ ⟨v, h_v⟩) := by
-  simp only [even_refinement, Fin.eta, intermediate_evaluation_poly]
+  simp only [evenRefinement, Fin.eta, intermediateEvaluationPoly]
 
   set right_inner_func := fun x: Fin (2^(ℓ - (i.val + 1))) =>
     C (coeffsBySuffix 𝔽q ℓ R_rate original_coeffs ⟨i.val + 1, by omega⟩ ⟨v.val, by
       calc v.val < 2 ^ i.val := by omega
         _ < 2 ^ (i.val + 1) := by apply Nat.pow_lt_pow_right (by omega) (by omega)
     ⟩ x) *
-      intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i + 1, by omega⟩ x
+      intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i + 1, by omega⟩ x
 
   have h_right_sum_eq := Fin.sum_congr' (M:=L[X]) (b:=2^(ℓ - (i.val + 1)))
     (a:=2^(ℓ - i - 1)) (f:=right_inner_func) (h:=by rfl)
@@ -1506,18 +1507,18 @@ omit [DecidableEq L] in
 Note that the odd refinement `P₁,₍ᵥ₎⁽ⁱ⁺¹⁾(X)` is constructed from the view of stage `i`,
 while the novel polynomial `P₍₁ᵥ₎⁽ⁱ⁺¹⁾(X)` is constructed from the view of stage `i+1`.
 -/
-theorem odd_refinement_eq_novel_poly_of_1_leading_suffix (i : Fin ℓ) (v : Fin (2 ^ i.val))
+theorem oddRefinement_eq_novel_poly_of_1_leading_suffix (i : Fin ℓ) (v : Fin (2 ^ i.val))
     (original_coeffs : Fin (2 ^ ℓ) → L):
     have h_v: v.val ||| (1 <<< i.val) < 2 ^ (i.val + 1) := by
       apply Nat.or_lt_two_pow (x:=v.val) (y:=1 <<< i.val) (n:=i.val + 1) (by omega)
       rw [Nat.shiftLeft_eq, one_mul]
       exact Nat.pow_lt_pow_right (by omega) (by omega)
-    odd_refinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i (coeffsBySuffix (r:=r) 𝔽q ℓ
+    oddRefinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i (coeffsBySuffix (r:=r) 𝔽q ℓ
       R_rate original_coeffs ⟨i, by omega⟩ v) =
-    intermediate_evaluation_poly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i + 1, by omega⟩
+    intermediateEvaluationPoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i + 1, by omega⟩
       (coeffsBySuffix (r:=r) 𝔽q ℓ R_rate original_coeffs ⟨i + 1, by omega⟩
         ⟨v ||| (1 <<< i.val), h_v⟩) := by
-  simp only [odd_refinement, Fin.eta, intermediate_evaluation_poly]
+  simp only [oddRefinement, Fin.eta, intermediateEvaluationPoly]
 
   set right_inner_func := fun x: Fin (2^(ℓ - (i.val + 1))) =>
     C (coeffsBySuffix 𝔽q ℓ R_rate original_coeffs
@@ -1528,7 +1529,7 @@ theorem odd_refinement_eq_novel_poly_of_1_leading_suffix (i : Fin ℓ) (v : Fin 
       · rw [Nat.shiftLeft_eq, one_mul]
         exact Nat.pow_lt_pow_right (by omega) (by omega)
     ⟩ x) *
-      intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i + 1, by omega⟩ x
+      intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i + 1, by omega⟩ x
 
   have h_right_sum_eq := Fin.sum_congr' (M:=L[X]) (b:=2^(ℓ - (i.val + 1)))
     (a:=2^(ℓ - i - 1)) (f:=right_inner_func) (h:=by rfl)
@@ -1637,7 +1638,7 @@ def additiveNTT_invariant (evaluation_buffer : Fin (2 ^ (ℓ + R_rate)) → L)
     let u := u_b / 2 -- the remaining high bits
     let coeffs_at_j: Fin (2 ^ (ℓ - i)) → L :=
       coeffsBySuffix (r:=r) 𝔽q ℓ R_rate original_coeffs i v
-    let P_i: L[X] := intermediate_evaluation_poly 𝔽q β ℓ R_rate h_ℓ_add_R_rate i coeffs_at_j
+    let P_i: L[X] := intermediateEvaluationPoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate i coeffs_at_j
     let ω := evaluationPointω 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ (Fin.mk u_b (by omega))
     evaluation_buffer j = P_i.eval ω
 
@@ -1652,7 +1653,7 @@ lemma initial_tiled_coeffs_correctness
     simp only
     intro j
     unfold coeffsBySuffix
-    simp only [tile_coeffs, evaluationPointω, intermediate_evaluation_poly, Fin.eta]
+    simp only [tile_coeffs, evaluationPointω, intermediateEvaluationPoly, Fin.eta]
     have h_ℓ_sub_ℓ: 2^(ℓ - ℓ) = 1 := by norm_num
 
     set f_right: Fin (2^(ℓ - ℓ)) → L[X] :=
@@ -1660,11 +1661,11 @@ lemma initial_tiled_coeffs_correctness
         simp only [tsub_self, pow_zero, Nat.lt_one_iff] at hx
         simp only [hx, Nat.zero_shiftLeft, Nat.zero_or]
         exact get_lsb_lt_two_pow (n:=j.val) (num_lsb_bits:=ℓ)
-      ⟩) * intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨ℓ, by omega⟩ ⟨x, by omega⟩
+      ⟩) * intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨ℓ, by omega⟩ ⟨x, by omega⟩
 
     have h_sum_right : ∑ (x: Fin (2^(ℓ - ℓ))), f_right x =
       C (a ⟨get_lsb (↑j) ℓ, by exact get_lsb_lt_two_pow ℓ⟩) *
-    intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨ℓ, by omega⟩ 0 := by
+    intermediateNovelBasisX 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨ℓ, by omega⟩ 0 := by
       have h_sum_eq := Fin.sum_congr' (b:=2^(ℓ - ℓ)) (a:=1) (f:=f_right) (by omega)
       rw [←h_sum_eq]
       rw [Fin.sum_univ_one]
@@ -1682,15 +1683,15 @@ lemma initial_tiled_coeffs_correctness
 
     simp only [eval_mul, eval_C]
 
-    have h_eval : eval (Finset.univ.sum f_left) (intermediate_novel_basis_X 𝔽q β ℓ R_rate
+    have h_eval : eval (Finset.univ.sum f_left) (intermediateNovelBasisX 𝔽q β ℓ R_rate
       h_ℓ_add_R_rate ⟨ℓ, by omega⟩ 0) = 1 := by
-      have h_base_novel_basis := base_intermediate_novel_basis_X 𝔽q β ℓ R_rate
+      have h_base_novel_basis := base_intermediateNovelBasisX 𝔽q β ℓ R_rate
         h_ℓ_add_R_rate h_W₀_eq_X h_β₀_eq_1 h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep ⟨ℓ, by exact
         Nat.lt_two_pow_self⟩
-      simp only [intermediate_novel_basis_X, Fin.coe_ofNat_eq_mod, tsub_self, pow_zero,
+      simp only [intermediateNovelBasisX, Fin.coe_ofNat_eq_mod, tsub_self, pow_zero,
         Nat.zero_mod]
 
-      set f_inner : Fin (ℓ - ℓ) → L[X] := fun x => intermediate_norm_vpoly 𝔽q β ℓ R_rate
+      set f_inner : Fin (ℓ - ℓ) → L[X] := fun x => intermediateNormVpoly 𝔽q β ℓ R_rate
         h_ℓ_add_R_rate ⟨ℓ, by omega⟩ x ^ bit (x.val) 0
 
       have h_sum_eq := Fin.prod_congr' (b:=ℓ - ℓ) (a:=0) (f:=f_inner) (by omega)
@@ -1745,9 +1746,9 @@ lemma ntt_stage_correctness
 
   simp at h_P_i_split_even_odd
 
-  set P_i := intermediate_evaluation_poly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ cur_coeffs
-  set even_coeffs_poly := even_refinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i cur_coeffs
-  set odd_coeffs_poly := odd_refinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ cur_coeffs
+  set P_i := intermediateEvaluationPoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ cur_coeffs
+  set even_coeffs_poly := evenRefinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i cur_coeffs
+  set odd_coeffs_poly := oddRefinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨↑i, by omega⟩ cur_coeffs
 
   conv_lhs =>
     unfold output_buffer ntt_stage
@@ -1756,15 +1757,15 @@ lemma ntt_stage_correctness
   have h_bit: bit i.val j.val = (j.val / (2 ^ i.val)) % 2 := by
     simp only [bit, Nat.and_one_is_mod, Nat.shiftRight_eq_div_pow]
 
-  have h_qmap_linear_map := q_map_is_linear_map 𝔽q β h_Fq_card_gt_1
+  have h_qmap_linear_map := qMap_is_linear_map 𝔽q β h_Fq_card_gt_1
     h_Fq_char_prime (i:=⟨i, by omega⟩)
 
-  have h_qmap_additive: IsLinearMap 𝔽q fun x ↦ eval x (q_map 𝔽q β ⟨↑i, by omega⟩)
+  have h_qmap_additive: IsLinearMap 𝔽q fun x ↦ eval x (qMap 𝔽q β ⟨↑i, by omega⟩)
     := AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval
-      (f := (q_map 𝔽q β ⟨i, by omega⟩)) (h_f_linear := h_qmap_linear_map)
+      (f := (qMap 𝔽q β ⟨i, by omega⟩)) (h_f_linear := h_qmap_linear_map)
 
   let eval_qmap_linear : L →ₗ[𝔽q] L := {
-    toFun    := fun x ↦ eval x (q_map 𝔽q β ⟨i, by omega⟩),
+    toFun    := fun x ↦ eval x (qMap 𝔽q β ⟨i, by omega⟩),
     map_add' := h_qmap_additive.map_add,
     map_smul' := h_qmap_additive.map_smul
   }
@@ -1787,10 +1788,10 @@ lemma ntt_stage_correctness
     rw [←h_j_div_2_pow_left]
     exact h_j_div_2_pow_i_add_1_lt
 
-  have h_eval_qmap_at_1: eval 1 (q_map 𝔽q β ⟨↑i, by omega⟩) = 0 := by
+  have h_eval_qmap_at_1: eval 1 (qMap 𝔽q β ⟨↑i, by omega⟩) = 0 := by
     have h_1_is_algebra_map: (1: L) = algebraMap 𝔽q L 1 := by rw [map_one]
     rw [h_1_is_algebra_map]
-    apply q_map_eval_𝔽q_eq_0 𝔽q β (i:=⟨i, by omega⟩) (c:=1)
+    apply qMap_eval_𝔽q_eq_0 𝔽q β (i:=⟨i, by omega⟩) (c:=1)
 
   have h_msb_eq_j_xor_lsb: (j.val) / (2 ^ (i.val + 1)) * (2 ^ (i.val + 1))
       = j.val ^^^ get_lsb j.val (i.val + 1) := by
@@ -1823,7 +1824,7 @@ lemma ntt_stage_correctness
 
     -- EVEN REFINEMENT coeffs correspondence at index j of level i--
     have h_even_split: input_buffer j =
-      eval x0 (even_coeffs_poly.comp (q_map 𝔽q β ⟨↑i, by omega⟩)) := by
+      eval x0 (even_coeffs_poly.comp (qMap 𝔽q β ⟨↑i, by omega⟩)) := by
       rw [h_prev j]
 
       have h_twiddle_comp_qmap_eq_left := eval_point_ω_eq_next_twiddleFactor_comp_qmap
@@ -1849,7 +1850,7 @@ lemma ntt_stage_correctness
       congr
 
       simp only [even_coeffs_poly, cur_coeffs]
-      have h_res := even_refinement_eq_novel_poly_of_0_leading_suffix 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+      have h_res := evenRefinement_eq_novel_poly_of_0_leading_suffix 𝔽q β ℓ R_rate h_ℓ_add_R_rate
         ⟨i, by omega⟩ ⟨get_lsb ↑j ↑i, by
           exact get_lsb_lt_two_pow (n:=j.val)  (num_lsb_bits:=i.val)⟩ original_coeffs
       simp only [Fin.eta] at h_res
@@ -1864,7 +1865,7 @@ lemma ntt_stage_correctness
 
     -- ODD REFINEMENT coeffs correspondence at index j of level i--
     have h_odd_split: input_buffer ⟨↑j + 2 ^ i.val, h_j_add_2_pow_i⟩
-      = eval x0 (odd_coeffs_poly.comp (q_map 𝔽q β ⟨↑i, by omega⟩)) := by
+      = eval x0 (odd_coeffs_poly.comp (qMap 𝔽q β ⟨↑i, by omega⟩)) := by
       rw [h_prev ⟨j.val + 2^i.val, by omega⟩]
 
       have h_j_div_2_pow_right: (⟨j.val + 2^i.val, by omega⟩: Fin (2^(ℓ + R_rate))).val
@@ -1916,7 +1917,7 @@ lemma ntt_stage_correctness
         simp only [h_j_div_2_pow_right] -- change the index of lhs to same as rhs
 
       simp only [odd_coeffs_poly, cur_coeffs]
-      have h_res := odd_refinement_eq_novel_poly_of_1_leading_suffix 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+      have h_res := oddRefinement_eq_novel_poly_of_1_leading_suffix 𝔽q β ℓ R_rate h_ℓ_add_R_rate
         ⟨i, by omega⟩ ⟨get_lsb (↑j) ↑i, by
           exact get_lsb_lt_two_pow (n:=j.val)  (num_lsb_bits:=i.val)⟩ original_coeffs
       simp only [Fin.eta] at h_res
@@ -1998,7 +1999,7 @@ lemma ntt_stage_correctness
       exact get_lsb_lt_two_pow (n:=j.val) (num_lsb_bits:=i.val)
 
     have h_even_split: input_buffer ⟨↑j ^^^ 2 ^ i.val, h_j_xor_2_pow_i⟩
-      = eval x1 (even_coeffs_poly.comp (q_map 𝔽q β ⟨↑i, by omega⟩)) := by
+      = eval x1 (even_coeffs_poly.comp (qMap 𝔽q β ⟨↑i, by omega⟩)) := by
       rw [h_prev ⟨j.val ^^^ 2 ^ i.val, by omega⟩]
       -- left (top) is the full poly of level (i+1),
       -- right (bottom) is the even refinement of current level i
@@ -2067,7 +2068,7 @@ lemma ntt_stage_correctness
       -- congr
 
       simp only [even_coeffs_poly, cur_coeffs]
-      have h_res := even_refinement_eq_novel_poly_of_0_leading_suffix 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+      have h_res := evenRefinement_eq_novel_poly_of_0_leading_suffix 𝔽q β ℓ R_rate h_ℓ_add_R_rate
         ⟨i, by omega⟩ ⟨get_lsb ↑j ↑i, by
           exact get_lsb_lt_two_pow (n:=j.val)  (num_lsb_bits:=i.val)⟩ original_coeffs
       simp only [Fin.eta] at h_res
@@ -2101,7 +2102,7 @@ lemma ntt_stage_correctness
       simp_rw [h_v_eq]
 
     have h_odd_split: input_buffer j = eval x1
-      (odd_coeffs_poly.comp (q_map 𝔽q β ⟨↑i, by omega⟩)) := by
+      (odd_coeffs_poly.comp (qMap 𝔽q β ⟨↑i, by omega⟩)) := by
       rw [h_prev j]
       -- left (top) is the full poly of level (i+1),
       -- right (bottom) is the odd refinement of current level i
@@ -2142,7 +2143,7 @@ lemma ntt_stage_correctness
         simp only [h_j_div_2_pow_left] -- change the index of lhs to same as rhs
 
       simp only [odd_coeffs_poly, cur_coeffs]
-      have h_res := odd_refinement_eq_novel_poly_of_1_leading_suffix 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+      have h_res := oddRefinement_eq_novel_poly_of_1_leading_suffix 𝔽q β ℓ R_rate h_ℓ_add_R_rate
         ⟨i, by omega⟩ ⟨get_lsb ↑j ↑i, by
           exact get_lsb_lt_two_pow (n:=j.val)  (num_lsb_bits:=i.val)⟩ original_coeffs
       simp only [Fin.eta] at h_res
@@ -2219,7 +2220,7 @@ theorem additiveNTT_correctness
     (original_coeffs : Fin (2 ^ ℓ) → L)
     (output_buffer : Fin (2 ^ (ℓ + R_rate)) → L)
     (h_alg : output_buffer = additiveNTT 𝔽q β ℓ R_rate h_ℓ_add_R_rate original_coeffs) :
-    let P := polynomial_from_novel_coeffs 𝔽q β ℓ h_ℓ original_coeffs
+    let P := polynomialFromNovelCoeffs 𝔽q β ℓ h_ℓ original_coeffs
     ∀ (j : Fin (2^(ℓ + R_rate))),
       output_buffer j = P.eval (evaluationPointω 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨0, by omega⟩ j) :=
   by

--- a/ArkLib/Data/FieldTheory/AdditiveNTT/AdditiveNTT.lean
+++ b/ArkLib/Data/FieldTheory/AdditiveNTT/AdditiveNTT.lean
@@ -26,10 +26,10 @@ the round `i` in the Additive NTT algorithm
 - `intermediate_evaluation_poly`: The intermediate evaluation polynomial `P⁽ⁱ⁾(X)`
   for the round `i` in the Additive NTT algorithm
 
-- `additive_ntt`: The main implementation of the Additive NTT encoding algorithm.
+- `additiveNTT`: The main implementation of the Additive NTT encoding algorithm.
 - `ntt_stage`: The main implementation of each NTT stage in the Additive NTT encoding algorithm.
-- `additive_ntt_correctness`: Main correctness statement of the encoding algorithm.
-- `additive_ntt_invariant`: Describes the invariant for each loop in the algorithm,
+- `additiveNTT_correctness`: Main correctness statement of the encoding algorithm.
+- `additiveNTT_invariant`: Describes the invariant for each loop in the algorithm,
 which states whether the result of an encoding round is correct
 - `ntt_stage_correctness`: Main correctness statement of each NTT stage in the encoding algorithm,
 this proves that if the previous round satisfies the invariant, then the current round also
@@ -56,10 +56,11 @@ namespace AdditiveNTT
 
 universe u
 
--- We work over a generic field `L` which is an algebra over a ground field 𝔽q of prime characteristic.
+-- We work over a generic field `L` which is an algebra over a ground field `𝔽q` of prime
+-- characteristic.
 variable {r : ℕ} [NeZero r]
 variable {L : Type u} [Field L] [Fintype L] [DecidableEq L]
-variable (𝔽q : Type u) [Field 𝔽q] [Fintype 𝔽q] [DecidableEq 𝔽q]
+variable (𝔽q : Type u) [Field 𝔽q] [Fintype 𝔽q]
 (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q))) (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
 variable [Algebra 𝔽q L]
 
@@ -82,20 +83,20 @@ under the normalized subspace vanishing polynomial `Ŵᵢ(X)`.
 `∀ i ∈ {0, ..., r-1}, S⁽ⁱ⁾` is the image of the subspace `U_{ℓ+R}`
   under the `𝔽q`-linear map `x ↦ Ŵᵢ(x)`. -/
 noncomputable def S_domain (i : Fin r) : Subspace 𝔽q L :=
-  let W_i_norm := normalizedW L 𝔽q β i
+  let W_i_norm := normalizedW 𝔽q β i
   let h_W_i_norm_is_additive : IsLinearMap 𝔽q (fun x : L => W_i_norm.eval x) :=
-    AdditiveNTT.normalizedW_is_additive L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i
+    AdditiveNTT.normalizedW_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i
   Submodule.map (poly_eval_linear_map W_i_norm h_W_i_norm_is_additive)
-    (U L 𝔽q β ⟨ℓ + R_rate, h_ℓ_add_R_rate⟩)
+    (U 𝔽q β ⟨ℓ + R_rate, h_ℓ_add_R_rate⟩)
 
 /-- The quotient map `q⁽ⁱ⁾(X)` that relates successive domains.
 `q⁽ⁱ⁾(X) := (Wᵢ(βᵢ)^q / Wᵢ₊₁(βᵢ₊₁)) * ∏_{c ∈ 𝔽q} (X - c)`. Usable range is `∀ i ∈ {0, ..., r-2}` -/
 noncomputable def q_map (i : Fin r) : L[X] :=
-  let constMultiplier := ((W L 𝔽q β i).eval (β i))^(Fintype.card 𝔽q)
-    / ((W L 𝔽q β (i + 1)).eval (β (i + 1)))
-  C constMultiplier * ∏ c: 𝔽q, ((X: L[X]) - C (algebraMap 𝔽q L c))
+  let constMultiplier := ((W 𝔽q β i).eval (β i))^(Fintype.card 𝔽q)
+    / ((W 𝔽q β (i + 1)).eval (β (i + 1)))
+  C constMultiplier * ∏ c: 𝔽q, (X - C (algebraMap 𝔽q L c))
 
-omit [DecidableEq L] [DecidableEq 𝔽q] in
+omit [DecidableEq L] in
 theorem q_map_eval_𝔽q_eq_0 (i : Fin r):
   ∀ c: 𝔽q, (q_map 𝔽q β i).eval (algebraMap 𝔽q L c) = 0 := by
   intro u
@@ -119,7 +120,7 @@ lemma q_map_comp_normalizedW
   (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
   (h_Fq_char_prime: Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent (R:=𝔽q) (M:=L) (v:=β)) (i : Fin r) (h_i_add_1 : i + 1 < r):
-  (q_map 𝔽q β i).comp (normalizedW L 𝔽q β i) = normalizedW L 𝔽q β (i + 1) := by
+  (q_map 𝔽q β i).comp (normalizedW 𝔽q β i) = normalizedW 𝔽q β (i + 1) := by
   let q := Fintype.card 𝔽q
   -- `q⁽ⁱ⁾ ∘ Ŵᵢ = ((Wᵢ(βᵢ)^q / Wᵢ₊₁(βᵢ₊₁)) * ∏_{c ∈ 𝔽q} (X - c)) ∘ Ŵᵢ`
   -- `= ((Wᵢ(βᵢ)^q / Wᵢ₊₁(βᵢ₊₁)) * (X^q - X)) ∘ Ŵᵢ` -- X^q - X = ∏_{c ∈ 𝔽q} (X - c)
@@ -133,24 +134,24 @@ lemma q_map_comp_normalizedW
 
   -- Define aliases for mathematical objects to improve readability
   set q := Fintype.card 𝔽q
-  set W_i := W L 𝔽q β i with h_W_i
-  set W_i_plus_1 := W L 𝔽q β (i + 1) with h_W_i_plus_1
+  set W_i := W 𝔽q β i with h_W_i
+  set W_i_plus_1 := W 𝔽q β (i + 1) with h_W_i_plus_1
   set val_i := W_i.eval (β i) with h_val_i
   set val_i_plus_1 := W_i_plus_1.eval (β (i + 1)) with h_val_i_plus_1
 
   -- Establish that the denominators in the definitions are non-zero
   have h_val_i_ne_zero : val_i ≠ 0 :=
-    AdditiveNTT.Wᵢ_eval_βᵢ_neq_zero L 𝔽q β hβ_lin_indep i
+    AdditiveNTT.Wᵢ_eval_βᵢ_neq_zero 𝔽q β hβ_lin_indep i
   have h_val_i_plus_1_ne_zero : val_i_plus_1 ≠ 0 :=
-    AdditiveNTT.Wᵢ_eval_βᵢ_neq_zero L 𝔽q β hβ_lin_indep (i + 1)
+    AdditiveNTT.Wᵢ_eval_βᵢ_neq_zero 𝔽q β hβ_lin_indep (i + 1)
 
   -- The proof proceeds by a chain of equalities
   calc
-    (q_map 𝔽q β i).comp (normalizedW L 𝔽q β i)
+    (q_map 𝔽q β i).comp (normalizedW 𝔽q β i)
     _ = C (val_i ^ q / val_i_plus_1)
-    * (∏ c:𝔽q, (X - C (algebraMap 𝔽q L c))).comp (normalizedW L 𝔽q β i) := by
+    * (∏ c:𝔽q, (X - C (algebraMap 𝔽q L c))).comp (normalizedW 𝔽q β i) := by
       rw [q_map, mul_comp, C_comp]
-    _ = C (val_i ^ q / val_i_plus_1) * ((normalizedW L 𝔽q β i) ^ q - normalizedW L 𝔽q β i) := by
+    _ = C (val_i ^ q / val_i_plus_1) * ((normalizedW 𝔽q β i) ^ q - normalizedW 𝔽q β i) := by
       simp_rw [prod_comp, sub_comp, X_comp, C_comp]
       rw [prod_poly_sub_C_eq_poly_pow_card_sub_poly_in_L h_Fq_card_gt_1]
     _ = C (1 / val_i_plus_1) * (W_i ^ q - C (val_i ^ (q - 1)) * W_i) := by
@@ -178,17 +179,17 @@ lemma q_map_comp_normalizedW
         rw [mul_inv_cancel₀ (h:=h_val_i_ne_zero), mul_one]
       rw [h_mul_2, C_pow]
     _ = C (1 / val_i_plus_1) * W_i_plus_1 := by -- `W_i^q - C(val_i^(q-1)) * W_i` = `W_{i+1}`
-      have W_linear := AdditiveNTT.W_linear_comp_decomposition L 𝔽q β h_Fq_card_gt_1
+      have W_linear := AdditiveNTT.W_linear_comp_decomposition 𝔽q β h_Fq_card_gt_1
         h_Fq_char_prime hβ_lin_indep i (p:=X)
       simp_rw [comp_X] at W_linear
       simp_rw [q, val_i, W_i, W_i_plus_1]
       rw [W_linear]
       · simp only [one_div, map_pow]
       · omega
-    _ = normalizedW L 𝔽q β (i + 1) := by -- Q.E.D.
+    _ = normalizedW 𝔽q β (i + 1) := by -- Q.E.D.
       rw [normalizedW]
 
-omit [DecidableEq L] [DecidableEq 𝔽q] in
+omit [DecidableEq L] in
 /-- The evaluation of the quotient map `q⁽ⁱ⁾(X)` is an `𝔽q`-linear map.
   Usable range is `∀ i ∈ {0, ..., r-2}`. -/
 theorem q_map_is_linear_map
@@ -197,7 +198,7 @@ theorem q_map_is_linear_map
   (i : Fin r):
   IsLinearMap 𝔽q (f:=fun inner_p ↦ (q_map 𝔽q β i).comp inner_p) := by
   set q := Fintype.card 𝔽q
-  set constMultiplier := ((W L 𝔽q β i).eval (β i))^q / ((W L 𝔽q β (i + 1)).eval (β (i + 1)))
+  set constMultiplier := ((W 𝔽q β i).eval (β i))^q / ((W 𝔽q β (i + 1)).eval (β (i + 1)))
   have h_q_poly_form : q_map 𝔽q β i = C constMultiplier * (X ^ q - X) := by
     rw [q_map, prod_poly_sub_C_eq_poly_pow_card_sub_poly_in_L h_Fq_card_gt_1 (p:=X)]
   -- Linearity of `x ↦ c * (x^q - x)` over `𝔽q`
@@ -292,16 +293,16 @@ by
   rw [←Submodule.map_comp] -- for two nested maps (composition) over the same subspace
   -- The goal becomes `q_i_map ∘ₗ Ŵᵢ_map = Ŵᵢ₊₁`
   congr
-  -- ⊢ poly_eval_linear_map (q_map 𝔽q β i) ⋯ ∘ₗ poly_eval_linear_map (normalizedW L 𝔽q β i) ⋯ =
-  -- poly_eval_linear_map (normalizedW L 𝔽q β (i + 1)) ⋯
+  -- ⊢ poly_eval_linear_map (q_map 𝔽q β i) ⋯ ∘ₗ poly_eval_linear_map (normalizedW 𝔽q β i) ⋯ =
+  -- poly_eval_linear_map (normalizedW 𝔽q β (i + 1)) ⋯
 
   -- We now have `(q_map ...).eval ((normalizedW ... i).eval x) = (normalizedW ... (i + 1)).eval x`.
   -- The `Polynomial.eval_comp` lemma states `p.eval (q.eval x) = (p.comp q).eval x`.
   set f := poly_eval_linear_map (q_map 𝔽q β i) q_eval_linear_map
-  set g := poly_eval_linear_map (normalizedW L 𝔽q β i)
-    (normalizedW_is_additive L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)
-  set t := poly_eval_linear_map (normalizedW L 𝔽q β (i + 1))
-    (normalizedW_is_additive L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep (i + 1))
+  set g := poly_eval_linear_map (normalizedW 𝔽q β i)
+    (normalizedW_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)
+  set t := poly_eval_linear_map (normalizedW 𝔽q β (i + 1))
+    (normalizedW_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep (i + 1))
   change f ∘ₗ g = t -- equality on composition of linear maps
   ext x
   -- => equality on evaluation at x
@@ -312,7 +313,7 @@ by
   -- unfold the linearmaps into their definitions (toFun, map_add, map_smul)
   simp only [LinearMap.coe_mk, AddHom.coe_mk]
   -- NOTE: `LinearMap.coe_mk` and `AddHom.coe_mk` convert linear maps into their functions
-  -- ⊢ eval (eval x (normalizedW L 𝔽q β i)) (q_map 𝔽q β i) = eval x (normalizedW L 𝔽q β (i + 1))
+  -- ⊢ eval (eval x (normalizedW 𝔽q β i)) (q_map 𝔽q β i) = eval x (normalizedW 𝔽q β (i + 1))
   rw [←Polynomial.eval_comp]
   rw [q_map_comp_normalizedW 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i h_i_add_1]
 
@@ -322,7 +323,7 @@ noncomputable def q_composition_chain (i : Fin r) : L[X] :=
   | ⟨0, _⟩ => X
   | ⟨k + 1, h_k_add_1⟩ => (q_map 𝔽q β ⟨k, by omega⟩).comp (q_composition_chain ⟨k, by omega⟩)
 
-omit [DecidableEq L] [DecidableEq 𝔽q] in
+omit [DecidableEq L] in
 /-- Prove the equality between the recursive definition
 of `q_composition_chain` and the Fin.foldl form. -/
 lemma q_composition_chain_eq_foldl
@@ -351,7 +352,7 @@ lemma q_composition_chain_eq_foldl
 (with the convention that for `i = 0`, this is just `X`).
 -/
 lemma normalizedW_eq_q_map_composition
-  (h_W₀_eq_X : W L 𝔽q β 0 = X)
+  (h_W₀_eq_X : W 𝔽q β 0 = X)
   (h_β₀_eq_1 : β 0 = 1)
   -- We also need the hypotheses for q_map_comp_normalizedW
   (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
@@ -359,7 +360,7 @@ lemma normalizedW_eq_q_map_composition
   (hβ_lin_indep : LinearIndependent 𝔽q β)
   (ℓ R_rate : ℕ)
   (i : Fin r) :
-  normalizedW L 𝔽q β i = q_composition_chain 𝔽q β (ℓ:=ℓ) (R_rate:=R_rate) i :=
+  normalizedW 𝔽q β i = q_composition_chain 𝔽q β (ℓ:=ℓ) (R_rate:=R_rate) i :=
 by
   -- We proceed by induction on i.
   induction i using Fin.succRecOnSameFinType with
@@ -384,14 +385,14 @@ by
       exact k_h
     simp only [h_eq.symm, Nat.succ_eq_add_one, Fin.eta]
     have h_res := q_map_comp_normalizedW 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep k k_h
-    -- ⊢ normalizedW L 𝔽q β ⟨↑k + 1, k_h⟩ = (q_map 𝔽q β k).comp (q_composition_chain 𝔽q β k)
+    -- ⊢ normalizedW 𝔽q β ⟨↑k + 1, k_h⟩ = (q_map 𝔽q β k).comp (q_composition_chain 𝔽q β k)
     rw [←i_h]
     rw [h_res]
     simp only [h_eq]
 
 /-- The vectors `y_j^{(i)} = Ŵᵢ(β_j)` for `j ∈ {i, ..., ℓ+R-1}`. -/
 noncomputable def s_domain_basis_vectors (i : Fin r) : Fin (ℓ + R_rate - i) → L :=
-  fun k => (normalizedW L 𝔽q β i).eval (β ⟨i + k.val, by omega⟩)
+  fun k => (normalizedW 𝔽q β i).eval (β ⟨i + k.val, by omega⟩)
 
 /-- The vectors `s_domain_basis_vectors` are indeed elements of the subspace `S_domain`,
   `∀ i ∈ {0, ..., r-1}`. -/
@@ -414,7 +415,7 @@ lemma s_domain_basis_vectors_mem_S_domain
   -- We must show it's in the image of U_{ℓ+R} under `eval Ŵᵢ`.
   -- This is true if the input `β (i + k.val)` is in `U_{ℓ+R}`.
   apply Submodule.mem_map_of_mem
-  -- ⊢ β (i + ↑k) ∈ U L 𝔽q β (ℓ + R_rate)
+  -- ⊢ β (i + ↑k) ∈ U 𝔽q β (ℓ + R_rate)
   have h_β_i_in_U: β ⟨i + k.val, h_i_add_k_lt_r⟩ ∈ β '' Set.Ico 0 ⟨ℓ + R_rate, h_ℓ_add_R_rate⟩ := by
     exact Set.mem_image_of_mem β (Set.mem_Ico.mpr ⟨by norm_num, by omega⟩)
   exact Submodule.subset_span h_β_i_in_U
@@ -422,7 +423,7 @@ lemma s_domain_basis_vectors_mem_S_domain
 def S_basis (i : Fin r) (h_i : i < ℓ + R_rate): Fin (ℓ + R_rate - i) → L :=
   fun (k : Fin (ℓ + R_rate - i)) => β ⟨i + k.val, by omega⟩
 
-omit [NeZero r] [Field L] [Fintype L] [DecidableEq L] [Field 𝔽q] [DecidableEq 𝔽q] [Algebra 𝔽q L] in
+omit [NeZero r] [Field L] [Fintype L] [DecidableEq L] [Field 𝔽q] [Algebra 𝔽q L] in
 lemma S_basis_range_eq (i : Fin r) (h_i : i < ℓ + R_rate):
     β '' Set.Ico i ⟨ℓ + R_rate, h_ℓ_add_R_rate⟩
     = Set.range (S_basis 𝔽q β ℓ R_rate h_ℓ_add_R_rate i h_i):= by
@@ -468,8 +469,8 @@ lemma S_basis_range_eq (i : Fin r) (h_i : i < ℓ + R_rate):
   Usable range is `∀ i ∈ {0, ..., ℓ+R-1}`. -/
 lemma S_domain_eq_image_of_upper_span (i: Fin r) (h_i: i < ℓ + R_rate):
     let V_i := Submodule.span 𝔽q (Set.range (S_basis 𝔽q β ℓ R_rate h_ℓ_add_R_rate i h_i))
-    let W_i_map := poly_eval_linear_map (normalizedW L 𝔽q β i)
-      (normalizedW_is_additive L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)
+    let W_i_map := poly_eval_linear_map (normalizedW 𝔽q β i)
+      (normalizedW_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)
     S_domain 𝔽q h_Fq_char_prime h_Fq_card_gt_1 β hβ_lin_indep ℓ R_rate h_ℓ_add_R_rate i
     = Submodule.map W_i_map V_i :=
 by
@@ -480,12 +481,12 @@ by
 
   -- Define V_i and W_i_map for use in the proof
   set V_i := Submodule.span 𝔽q (Set.range (S_basis 𝔽q β ℓ R_rate h_ℓ_add_R_rate i h_i))
-  set W_i_map := poly_eval_linear_map (normalizedW L 𝔽q β i)
-    (normalizedW_is_additive L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)
+  set W_i_map := poly_eval_linear_map (normalizedW 𝔽q β i)
+    (normalizedW_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)
 
   -- First, show that U_{ℓ+R} = U_i ⊔ V_i (direct sum)
-  have h_span_supremum_decomposition : U L 𝔽q β ⟨ℓ + R_rate, h_ℓ_add_R_rate⟩
-    = U L 𝔽q β i ⊔ V_i := by
+  have h_span_supremum_decomposition : U 𝔽q β ⟨ℓ + R_rate, h_ℓ_add_R_rate⟩
+    = U 𝔽q β i ⊔ V_i := by
     unfold U
     -- U_{ℓ+R} is the span of {β₀, ..., β_{ℓ+R-1}}
     -- U_i is the span of {β₀, ..., β_{i-1}}
@@ -516,15 +517,15 @@ by
   rw [S_domain, h_span_supremum_decomposition, Submodule.map_sup]
 
   -- The image of U_i under W_i_map is {0} because W_i vanishes on U_i
-  have h_U_i_image : Submodule.map W_i_map (U L 𝔽q β i) = ⊥ := by
+  have h_U_i_image : Submodule.map W_i_map (U 𝔽q β i) = ⊥ := by
     -- Show that any element in the image is 0
     apply (Submodule.eq_bot_iff _).mpr
     intro x hx
-    -- x ∈ Submodule.map W_i_map (U L 𝔽q β i) means x = W_i_map(y) for some y ∈ U_i
+    -- x ∈ Submodule.map W_i_map (U 𝔽q β i) means x = W_i_map(y) for some y ∈ U_i
     rcases Submodule.mem_map.mp hx with ⟨y, hy, rfl⟩
     -- Show that W_i_map y = 0 for any y ∈ U_i
-    have h_eval_zero : (normalizedW L 𝔽q β i).eval y = 0 :=
-      normalizedWᵢ_vanishing L 𝔽q β i y hy
+    have h_eval_zero : (normalizedW 𝔽q β i).eval y = 0 :=
+      normalizedWᵢ_vanishing 𝔽q β i y hy
     exact h_eval_zero
 
   -- Combine the results: ⊥ ⊔ V = V
@@ -538,10 +539,10 @@ noncomputable def S_domain_basis (i : Fin r) (h_i : i < ℓ + R_rate) :
   -- Let V_i be the "upper" subspace spanned by {βᵢ, ..., β_{ℓ+R-1}}.
   let V_i := Submodule.span 𝔽q (Set.range (S_basis 𝔽q β ℓ R_rate h_ℓ_add_R_rate i h_i))
   -- Let W_i_map be the linear map given by evaluating the polynomial Ŵᵢ.
-  let W_i_map := poly_eval_linear_map (normalizedW L 𝔽q β i) (
-      normalizedW_is_additive L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)
+  let W_i_map := poly_eval_linear_map (normalizedW 𝔽q β i) (
+      normalizedW_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)
 
-  have h_disjoint : Disjoint (U L 𝔽q β i) V_i := by
+  have h_disjoint : Disjoint (U 𝔽q β i) V_i := by
     -- Uᵢ is span of β over Ico 0 i
     -- Vᵢ is span of β over Ico i (ℓ + R_rate)
     -- The index sets are disjoint.
@@ -558,8 +559,8 @@ noncomputable def S_domain_basis (i : Fin r) (h_i : i < ℓ + R_rate) :
     rw [S_basis_range_eq 𝔽q β ℓ R_rate h_ℓ_add_R_rate i h_i] at h_res
     exact h_res
 
-  have h_ker_eq_U : LinearMap.ker W_i_map = U L 𝔽q β i := by
-    rw [kernel_normalizedW_eq_U L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i]
+  have h_ker_eq_U : LinearMap.ker W_i_map = U 𝔽q β i := by
+    rw [kernel_normalizedW_eq_U 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i]
 
   -- The vectors {βᵢ, ...} form a basis for Vᵢ because β is linearly independent.
   let V_i_basis : Basis (Fin (ℓ + R_rate - i)) 𝔽q V_i :=
@@ -592,8 +593,8 @@ noncomputable def S_domain_basis (i : Fin r) (h_i : i < ℓ + R_rate) :
               h_Fq_card_gt_1 β hβ_lin_indep ℓ R_rate h_ℓ_add_R_rate i h_i]
             exact
               Submodule.apply_coe_mem_map
-                (poly_eval_linear_map (normalizedW L 𝔽q β i)
-                  (normalizedW_is_additive L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i))
+                (poly_eval_linear_map (normalizedW 𝔽q β i)
+                  (normalizedW_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i))
                 x
           exact h_x_in_S_i
         )) (by
@@ -615,12 +616,12 @@ noncomputable def S_domain_basis (i : Fin r) (h_i : i < ℓ + R_rate) :
             have h_mem_ker : ↑(v1 - v2) ∈ LinearMap.ker W_i_map := h_v1_v2
             -- The kernel of the evaluation map is the vanishing subspace `Uᵢ`.
             -- Add this before the have h_mem_U line:
-            have h_mem_U : ↑(v1 - v2) ∈ U L 𝔽q β i := h_ker_eq_U ▸ h_mem_ker
+            have h_mem_U : ↑(v1 - v2) ∈ U 𝔽q β i := h_ker_eq_U ▸ h_mem_ker
             -- The element `v1 - v2` is in `Vᵢ` since it's a submodule.
             have h_mem_V : ↑(v1 - v2) ∈ V_i := Submodule.sub_mem V_i v1.property v2.property
             -- Thus, the element is in the intersection of `Uᵢ` and `Vᵢ`.
             -- Thus, the element is in the intersection of `Uᵢ` and `Vᵢ`.
-            have h_mem_inf : ↑(v1 - v2) ∈ (U L 𝔽q β i) ⊓ V_i :=
+            have h_mem_inf : ↑(v1 - v2) ∈ (U 𝔽q β i) ⊓ V_i :=
               Submodule.mem_inf.mpr ⟨h_mem_U, h_mem_V⟩
 
             -- The subspaces `Uᵢ` and `Vᵢ` are disjoint because they are spanned by
@@ -680,7 +681,7 @@ noncomputable def intermediate_norm_vpoly
 -- (with the convention that for `i = 0`, this is just `X`).
 -- -/
 -- lemma normalizedW_eq_q_map_composition
---   (h_W₀_eq_X : W L 𝔽q β 0 = X)
+--   (h_W₀_eq_X : W 𝔽q β 0 = X)
 --   (h_β₀_eq_1 : β 0 = 1)
 --   -- We also need the hypotheses for q_map_comp_normalizedW
 --   (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
@@ -688,12 +689,12 @@ noncomputable def intermediate_norm_vpoly
 --   (hβ_lin_indep : LinearIndependent 𝔽q β)
 --   (ℓ R_rate : ℕ)
 --   (i : Fin r) :
---   normalizedW L 𝔽q β i = q_composition_chain 𝔽q β (ℓ:=ℓ) (R_rate:=R_rate) i :=
+--   normalizedW 𝔽q β i = q_composition_chain 𝔽q β (ℓ:=ℓ) (R_rate:=R_rate) i :=
 -- by
 
 -- Ŵₖ⁽⁰⁾(X) = Ŵ(X)
 theorem base_intermediate_norm_vpoly
-  (h_W₀_eq_X : W L 𝔽q β 0 = X)
+  (h_W₀_eq_X : W 𝔽q β 0 = X)
   (h_β₀_eq_1 : β 0 = 1)
   (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
@@ -704,7 +705,7 @@ theorem base_intermediate_norm_vpoly
     simp only [not_lt, nonpos_iff_eq_zero] at ht
     contradiction
   ⟩ k =
-  normalizedW L 𝔽q β ⟨k, by omega⟩ := by
+  normalizedW 𝔽q β ⟨k, by omega⟩ := by
   unfold intermediate_norm_vpoly
   simp only [Fin.mk_zero', Fin.coe_ofNat_eq_mod, zero_add]
   rw [normalizedW_eq_q_map_composition 𝔽q β h_W₀_eq_X
@@ -748,7 +749,7 @@ theorem Polynomial.comp_same_inner_eq_if_same_outer (f g : L[X]) (h_f_eq_g : f =
   intro x
   rw [h_f_eq_g]
 
-omit [DecidableEq L] [DecidableEq 𝔽q] in
+omit [DecidableEq L] in
 -- ∀ i ∈ {0, ..., ℓ-1}, ∀ k ∈ {0, ..., ℓ-i-2}, `Ŵₖ₊₁⁽ⁱ⁾ = Ŵₖ⁽ⁱ⁺¹⁾ ∘ q⁽ⁱ⁾`
 theorem intermediate_norm_vpoly_comp_qmap (i : Fin (ℓ))
     (k : Fin (ℓ - i - 1)):
@@ -771,7 +772,7 @@ theorem intermediate_norm_vpoly_comp_qmap (i : Fin (ℓ))
   have h_id_eq: i.val + (j.val + 1) = i.val + 1 + j.val := by omega
   simp_rw [h_id_eq]
 
-omit [DecidableEq L] [DecidableEq 𝔽q] in
+omit [DecidableEq L] in
 -- A helper derivation for intermediate_norm_vpoly_comp_qmap
 -- i is now in Fin (ℓ-1) instead of Fin ℓ, and k is in Fin (ℓ - (↑i + 1))
 theorem intermediate_norm_vpoly_comp_qmap_helper (i : Fin (ℓ))
@@ -792,7 +793,7 @@ noncomputable def intermediate_novel_basis_X (i : Fin (ℓ + 1)) (j : Fin (2 ^ (
 
 -- Xⱼ⁽⁰⁾ = Xⱼ
 theorem base_intermediate_novel_basis_X
-  (h_W₀_eq_X : W L 𝔽q β 0 = X)
+  (h_W₀_eq_X : W 𝔽q β 0 = X)
   (h_β₀_eq_1 : β 0 = 1)
   (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
@@ -803,7 +804,7 @@ theorem base_intermediate_novel_basis_X
     simp only [not_lt, nonpos_iff_eq_zero] at ht
     contradiction
   ⟩ j =
-  Xⱼ L 𝔽q β ℓ (by omega) j := by
+  Xⱼ 𝔽q β ℓ (by omega) j := by
   unfold intermediate_novel_basis_X Xⱼ
   simp only [Fin.mk_zero', Fin.coe_ofNat_eq_mod]
   have h_res := base_intermediate_norm_vpoly 𝔽q β ℓ R_rate h_ℓ_add_R_rate
@@ -814,7 +815,7 @@ theorem base_intermediate_novel_basis_X
     rw [h_res]
   congr
 
-omit [DecidableEq L] [DecidableEq 𝔽q] in
+omit [DecidableEq L] in
 -- X₂ⱼ⁽ⁱ⁾ = Xⱼ⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X)) ∀ j ∈ {0, ..., 2^(ℓ-i)-1}, ∀ i ∈ {0, ..., ℓ-1}
 lemma even_index_intermediate_novel_basis_decomposition (i : Fin ℓ) (j : Fin (2 ^ (ℓ - i - 1))):
   intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨j * 2, by
@@ -871,7 +872,7 @@ lemma even_index_intermediate_novel_basis_decomposition (i : Fin ℓ) (j : Fin (
     apply bit_eq_succ_bit_of_mul_two (k:=↑x) (n:=↑j)
   rw [h_exp_eq]
 
-omit [DecidableEq L] [DecidableEq 𝔽q] in
+omit [DecidableEq L] in
 -- X₂ⱼ₊₁⁽ⁱ⁾ = X * (Xⱼ⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X))) ∀ j ∈ {0, ..., 2^(ℓ-i)-1}, ∀ i ∈ {0, ..., ℓ-1}
 lemma odd_index_intermediate_novel_basis_decomposition
     (i : Fin ℓ) (j : Fin (2 ^ (ℓ - i - 1))):
@@ -963,11 +964,10 @@ noncomputable def odd_refinement (i : Fin (ℓ))
       _ = 2 ^ (ℓ - i) := Nat.two_pow_pred_mul_two (w:=ℓ - i) (h:=by omega)
   ⟩) * (intermediate_novel_basis_X 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i+1, by omega⟩ ⟨j, hj⟩)
 
-omit [DecidableEq 𝔽q] in
 /-- **Key Polynomial Identity (Equation 39)**. This identity is the foundation for the
 butterfly operation in the Additive NTT. It relates a polynomial in the `i`-th basis to
 its even and odd parts expressed in the `(i+1)`-th basis via the quotient map `q⁽ⁱ⁾`.
-∀ i ∈ {0, ..., ℓ-1}, `P⁽ⁱ⁾(X) = P₀⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X)) + X ⋅ P₁⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X))` -/
+`∀ i ∈ {0, ..., ℓ-1}, P⁽ⁱ⁾(X) = P₀⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X)) + X ⋅ P₁⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X))` -/
 theorem evaluation_poly_split_identity (i : Fin (ℓ))
     (coeffs : Fin (2 ^ (ℓ - i)) → L) :
   let P_i: L[X] := intermediate_evaluation_poly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ coeffs
@@ -1139,14 +1139,14 @@ theorem evaluation_poly_split_identity (i : Fin (ℓ))
 
 -- P⁽⁰⁾(X) = P(X)
 lemma intermediate_poly_P_base
-  (h_W₀_eq_X : W L 𝔽q β 0 = X)
+  (h_W₀_eq_X : W 𝔽q β 0 = X)
   (h_β₀_eq_1 : β 0 = 1)
   (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent 𝔽q β)
   (h_ℓ : ℓ ≤ r) (coeffs : Fin (2^ℓ) → L) :
   intermediate_evaluation_poly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨0, by omega⟩ coeffs =
-    polynomial_from_novel_coeffs L 𝔽q β ℓ h_ℓ coeffs := by
+    polynomial_from_novel_coeffs 𝔽q β ℓ h_ℓ coeffs := by
   unfold polynomial_from_novel_coeffs intermediate_evaluation_poly
   simp only [Fin.mk_zero', Fin.coe_ofNat_eq_mod, Fin.eta]
   conv_rhs =>
@@ -1174,48 +1174,41 @@ Computes the twiddle factor `t` for a given stage `i` and high-order bits `u`.
 `t := Σ_{k=0}^{ℓ+R-i-1} u_k ⋅ Ŵᵢ(β_{i+k})`.
 This corresponds to the `x₀` term in the recursive butterfly identity.
 -/
-noncomputable def evaluation_point_ω (i : Fin (ℓ + 1))
+noncomputable def evaluationPointω (i : Fin (ℓ + 1))
     (x : Fin (2 ^ (ℓ + R_rate - i))) : L := -- x = u || b
     -- Add the linear combination of the remaining basis vectors
   ∑ (⟨k, hk⟩: Fin (ℓ + R_rate - i)),
     if bit k x.val = 1 then
-      (normalizedW L 𝔽q β ⟨i, by omega⟩).eval (β ⟨i + k, by
-        calc i + k < i + (ℓ + R_rate - i) := by omega
-          _ = ℓ + R_rate := by omega
-          _ ≤ r := by omega
-      ⟩)
+      (normalizedW 𝔽q β ⟨i, by omega⟩).eval (β ⟨i + k, by omega⟩)
     else
       0
 
-noncomputable def twiddle_factor (i : Fin ℓ) (u : Fin (2 ^ (ℓ + R_rate - i - 1))) : L :=
+/-- The twiddle factor -/
+noncomputable def twiddleFactor (i : Fin ℓ) (u : Fin (2 ^ (ℓ + R_rate - i - 1))) : L :=
   ∑ (⟨k, hk⟩: Fin (ℓ + R_rate - i - 1)),
     if bit k u.val = 1 then
       -- this branch maps to the above bit = 1 branch
-        -- (of evaluation_point_ω (i+1)) under (q_map i)(X)
-      (normalizedW L 𝔽q β ⟨i, by omega⟩).eval (β ⟨i + 1 + k, by
-        calc i + 1 + k < i + (ℓ + R_rate - i) := by omega
-          _ = ℓ + R_rate := by omega
-          _ ≤ r := by omega
-      ⟩)
+        -- (of evaluationPointω (i+1)) under (q_map i)(X)
+      (normalizedW 𝔽q β ⟨i, by omega⟩).eval (β ⟨i + 1 + k, by omega⟩)
     else 0
       -- 0 maps to the below bit = 0 branch
-        -- (of evaluation_point_ω (i+1)) under (q_map i)(X)
+        -- (of evaluationPointω (i+1)) under (q_map i)(X)
 
-omit [DecidableEq L] [DecidableEq 𝔽q] in
-lemma evaluation_point_ω_eq_twiddle_factor_of_div_2 (i : Fin ℓ) (x : Fin (2 ^ (ℓ + R_rate - i))):
-  evaluation_point_ω 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ x =
-  twiddle_factor 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨x/2, by
+omit [DecidableEq L] in
+lemma evaluationPointω_eq_twiddleFactor_of_div_2 (i : Fin ℓ) (x : Fin (2 ^ (ℓ + R_rate - i))):
+  evaluationPointω 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ x =
+  twiddleFactor 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨x/2, by
     have h := div_two_pow_lt_two_pow (x:=x) (i:=ℓ + R_rate - i - 1) (j:=1) (by
       rw [Nat.sub_add_cancel (by omega)]; omega)
     simp only [pow_one] at h
     calc _ < 2 ^ (ℓ + R_rate - i - 1) := by omega
       _ = _ := by rfl
-  ⟩ + (x.val % 2: ℕ) * eval (β ⟨i, by omega⟩) (normalizedW L 𝔽q β ⟨i, by omega⟩) := by
-  unfold evaluation_point_ω twiddle_factor
+  ⟩ + (x.val % 2: ℕ) * eval (β ⟨i, by omega⟩) (normalizedW 𝔽q β ⟨i, by omega⟩) := by
+  unfold evaluationPointω twiddleFactor
   simp only
   --
   set f_left := fun x_1: Fin (ℓ + R_rate - i) => if bit x_1 x = 1
-    then eval (β ⟨i + x_1, by omega⟩) (normalizedW L 𝔽q β ⟨i, by omega⟩) else 0
+    then eval (β ⟨i + x_1, by omega⟩) (normalizedW 𝔽q β ⟨i, by omega⟩) else 0
   conv_lhs =>
   -- ℓ + R_rate - ↑i
     rw [←Fin.sum_congr' (b:=ℓ + R_rate - i) (a:=ℓ + R_rate - (i + 1) + 1) (f:=f_left) (h:=by omega)]
@@ -1235,7 +1228,7 @@ lemma evaluation_point_ω_eq_twiddle_factor_of_div_2 (i : Fin ℓ) (x : Fin (2 ^
     simp only [h_sum_eq x_1]
 
   set f_right := fun x_1: Fin (ℓ + R_rate - (↑i + 1)) => if bit (↑x_1) (↑x / 2) = 1
-    then eval (β ⟨↑i + 1 + ↑x_1, by omega⟩) (normalizedW L 𝔽q β ⟨↑i, by omega⟩) else 0
+    then eval (β ⟨↑i + 1 + ↑x_1, by omega⟩) (normalizedW 𝔽q β ⟨↑i, by omega⟩) else 0
   rw [←Fin.sum_congr' (b:=ℓ + R_rate - (↑i + 1)) (a:=ℓ + R_rate - i - 1) (f:=f_right) (h:=by omega)]
   unfold f_right
   simp only [Fin.cast_eq_self] -- remove Fin.cast
@@ -1256,18 +1249,18 @@ lemma evaluation_point_ω_eq_twiddle_factor_of_div_2 (i : Fin ℓ) (x : Fin (2 ^
     simp only [ne_eq, Nat.mod_two_not_eq_zero] at h_lsb_of_x_eq_0
     simp only [h_lsb_of_x_eq_0, ↓reduceIte, Nat.cast_one, one_mul]
 
-lemma eval_point_ω_eq_next_twiddle_factor_comp_qmap
+lemma eval_point_ω_eq_next_twiddleFactor_comp_qmap
   (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent 𝔽q β)
   (i : Fin ℓ) (x : Fin (2 ^ (ℓ + R_rate - (i+1)))):
   -- `j = u||b||v` => x here means u at level i
-  evaluation_point_ω 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i.val+1, by omega⟩ x =
-  eval (twiddle_factor 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨x.val, by
+  evaluationPointω 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i.val+1, by omega⟩ x =
+  eval (twiddleFactor 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨x.val, by
     calc x.val < 2 ^ (ℓ + R_rate - (i.val + 1)) := by omega
       _ = 2 ^ (ℓ + R_rate - i.val - 1) := by rfl
   ⟩) (q_map 𝔽q β ⟨i, by omega⟩) := by
-  simp [evaluation_point_ω, twiddle_factor]
+  simp [evaluationPointω, twiddleFactor]
   have h_qmap_linear_map :=
     q_map_is_linear_map 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime (i:=⟨i, by omega⟩)
   have h_qmap_additive: IsLinearMap 𝔽q fun x ↦ eval x (q_map 𝔽q β ⟨↑i, by omega⟩) :=
@@ -1275,7 +1268,7 @@ lemma eval_point_ω_eq_next_twiddle_factor_comp_qmap
     (h_f_linear := h_qmap_linear_map)
 
   set right_inner_func := fun x_1: Fin (ℓ + R_rate - i - 1) => if bit ↑x_1 ↑x = 1
-    then eval (β ⟨↑i + 1 + ↑x_1, by omega⟩) (normalizedW L 𝔽q β ⟨↑i, by omega⟩) else 0
+    then eval (β ⟨↑i + 1 + ↑x_1, by omega⟩) (normalizedW 𝔽q β ⟨↑i, by omega⟩) else 0
 
   let eval_qmap_linear : L →ₗ[𝔽q] L := {
     toFun    := fun x ↦ eval x (q_map 𝔽q β ⟨i, by omega⟩),
@@ -1293,7 +1286,7 @@ lemma eval_point_ω_eq_next_twiddle_factor_comp_qmap
   rw [h_rhs]
 
   set left_inner_func := fun x_1: Fin (ℓ + R_rate - (i.val + 1)) => if bit ↑x_1 ↑x = 1
-    then eval (β ⟨↑i + 1 + ↑x_1, by omega⟩) (normalizedW L 𝔽q β ⟨↑i + 1, by omega⟩) else 0
+    then eval (β ⟨↑i + 1 + ↑x_1, by omega⟩) (normalizedW 𝔽q β ⟨↑i + 1, by omega⟩) else 0
 
   conv_lhs =>
     rw [←Fin.sum_congr' (b:=ℓ + R_rate - (i.val + 1))
@@ -1304,8 +1297,8 @@ lemma eval_point_ω_eq_next_twiddle_factor_comp_qmap
   funext x1
 
 --   `q⁽ⁱ⁾ ∘ Ŵᵢ = Ŵᵢ₊₁`. -/
-  have h_normalized_comp_qmap: normalizedW L 𝔽q β ⟨i + 1, by omega⟩ =
-    (q_map 𝔽q β ⟨i, by omega⟩).comp (normalizedW L 𝔽q β ⟨i, by omega⟩) := by
+  have h_normalized_comp_qmap: normalizedW 𝔽q β ⟨i + 1, by omega⟩ =
+    (q_map 𝔽q β ⟨i, by omega⟩).comp (normalizedW 𝔽q β ⟨i, by omega⟩) := by
     have res := q_map_comp_normalizedW 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime
       hβ_lin_indep (i:=⟨i, by omega⟩) (h_i_add_1:=by simp only; omega;)
     rw [res]
@@ -1385,10 +1378,10 @@ noncomputable def ntt_stage (i : Fin ℓ) (b : Fin (2 ^ (ℓ + R_rate)) → L) :
         rw [Nat.sub_add_cancel (by omega)]
         omega
       )
-    let twiddle_factor: L := twiddle_factor 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨u, by
+    let twiddleFactor: L := twiddleFactor 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ ⟨u, by
       simp only; exact h_u_lt_2_pow
     ⟩
-    let x0 := twiddle_factor -- since the last bit of u||0 is 0
+    let x0 := twiddleFactor -- since the last bit of u||0 is 0
     let x1: L := x0 + 1 -- since the last bit of u||1 is 1 and 1 * Ŵᵢ(βᵢ) = 1
 
     have h_b_bit : b_bit = bit i.val j.val := by
@@ -1423,16 +1416,16 @@ noncomputable def ntt_stage (i : Fin ℓ) (b : Fin (2 ^ (ℓ + R_rate)) → L) :
 Computes the Additive NTT on a given set of coefficients from the novel basis.
 - `a`: The initial coefficient array `(a₀, ..., a_{2^ℓ-1})`.
 -/
-noncomputable def additive_ntt (a : Fin (2 ^ ℓ) → L) : Fin (2^(ℓ + R_rate)) → L :=
+noncomputable def additiveNTT (a : Fin (2 ^ ℓ) → L) : Fin (2^(ℓ + R_rate)) → L :=
   let b: Fin (2^(ℓ + R_rate)) → L := tile_coeffs ℓ R_rate a -- Note: can optimize on this
   Fin.foldl (n:=ℓ) (f:= fun current_b i  =>
     ntt_stage 𝔽q β ℓ R_rate h_ℓ_add_R_rate (i:=⟨ℓ - 1 - i, by omega⟩) current_b
   ) (init:=b)
 
--- `∀ i ∈ {0, ..., ℓ}, coeffs_by_suffix a i` represents the list of `2^(ℓ-i)` novel coefficients.
+-- `∀ i ∈ {0, ..., ℓ}, coeffsBySuffix a i` represents the list of `2^(ℓ-i)` novel coefficients.
 -- Note that `i=ℓ` means the result of the initial coefficient tiling process at the beginning.
 -- for a specific suffix (LSBs) `v` of `i` bits at the `i-th` NTT stage
-def coeffs_by_suffix (a : Fin (2 ^ ℓ) → L) (i : Fin (ℓ + 1)) (v : Fin (2 ^ i.val)):
+def coeffsBySuffix (a : Fin (2 ^ ℓ) → L) (i : Fin (ℓ + 1)) (v : Fin (2 ^ i.val)):
   Fin (2 ^ (ℓ - i)) → L :=
   fun ⟨j, hj⟩ => by
     set originalIndex := (j <<< i.val) ||| v;
@@ -1444,14 +1437,14 @@ def coeffs_by_suffix (a : Fin (2 ^ ℓ) → L) (i : Fin (ℓ + 1)) (v : Fin (2 ^
       exact res
     exact a ⟨originalIndex, h_originalIndex_lt_2_pow_ℓ⟩
 
-omit [NeZero r] [Field L] [Fintype L] [DecidableEq L] [Field 𝔽q] [DecidableEq 𝔽q] [Algebra 𝔽q L] in
-lemma base_coeffs_by_suffix (a : Fin (2 ^ ℓ) → L):
-  coeffs_by_suffix (r:=r) 𝔽q ℓ R_rate a 0 0 = a := by
-  unfold coeffs_by_suffix
+omit [NeZero r] [Field L] [Fintype L] [DecidableEq L] [Field 𝔽q] [Algebra 𝔽q L] in
+lemma base_coeffsBySuffix (a : Fin (2 ^ ℓ) → L):
+  coeffsBySuffix (r:=r) 𝔽q ℓ R_rate a 0 0 = a := by
+  unfold coeffsBySuffix
   simp only [Fin.coe_ofNat_eq_mod, Nat.zero_mod, Nat.shiftLeft_zero, Fin.isValue,
     Nat.or_zero, Fin.eta]
 
-omit [DecidableEq L] [DecidableEq 𝔽q] in
+omit [DecidableEq L] in
 /-- `P₀, ₍ᵥ₎⁽ⁱ⁺¹⁾(X) = P₍₀ᵥ₎⁽ⁱ⁺¹⁾(X)`, where `v` consists of exactly `i` bits
 Note that the even refinement `P₀, ₍ᵥ₎⁽ⁱ⁺¹⁾(X)` is constructed from the view of
 stage `i`, while the novel polynomial `P₍₀ᵥ₎⁽ⁱ⁺¹⁾(X)` is constructed from the view of stage `i+1`.
@@ -1461,14 +1454,14 @@ theorem even_refinement_eq_novel_poly_of_0_leading_suffix (i : Fin ℓ) (v : Fin
     have h_v: v.val < 2 ^ (i.val + 1) := by
       calc v.val < 2 ^ i.val := by omega
         _ < 2 ^ (i.val + 1) := by apply Nat.pow_lt_pow_right (by omega) (by omega)
-    even_refinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i (coeffs_by_suffix (r:=r) 𝔽q ℓ
+    even_refinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i (coeffsBySuffix (r:=r) 𝔽q ℓ
       R_rate original_coeffs ⟨i, by omega⟩ v) =
     intermediate_evaluation_poly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i + 1, by omega⟩
-      (coeffs_by_suffix (r:=r) 𝔽q ℓ R_rate original_coeffs ⟨i + 1, by omega⟩ ⟨v, h_v⟩) := by
+      (coeffsBySuffix (r:=r) 𝔽q ℓ R_rate original_coeffs ⟨i + 1, by omega⟩ ⟨v, h_v⟩) := by
   simp only [even_refinement, Fin.eta, intermediate_evaluation_poly]
 
   set right_inner_func := fun x: Fin (2^(ℓ - (i.val + 1))) =>
-    C (coeffs_by_suffix 𝔽q ℓ R_rate original_coeffs ⟨i.val + 1, by omega⟩ ⟨v.val, by
+    C (coeffsBySuffix 𝔽q ℓ R_rate original_coeffs ⟨i.val + 1, by omega⟩ ⟨v.val, by
       calc v.val < 2 ^ i.val := by omega
         _ < 2 ^ (i.val + 1) := by apply Nat.pow_lt_pow_right (by omega) (by omega)
     ⟩ x) *
@@ -1486,7 +1479,7 @@ theorem even_refinement_eq_novel_poly_of_0_leading_suffix (i : Fin ℓ) (v : Fin
   funext x
   simp only [right_inner_func]
 
-  have h_coeffs_eq: coeffs_by_suffix (r:=r) 𝔽q ℓ R_rate
+  have h_coeffs_eq: coeffsBySuffix (r:=r) 𝔽q ℓ R_rate
       original_coeffs (i:=⟨i.val, by omega⟩) v ⟨↑x * 2, by
     have h_x_mul_2_lt := mul_two_add_bit_lt_two_pow x.val (ℓ-i-1) (ℓ-i)
       ⟨0, by omega⟩ (by omega) (by omega)
@@ -1494,11 +1487,11 @@ theorem even_refinement_eq_novel_poly_of_0_leading_suffix (i : Fin ℓ) (v : Fin
     simp only [gt_iff_lt]
     exact h_x_mul_2_lt
   ⟩
-    = coeffs_by_suffix (r:=r) 𝔽q ℓ R_rate original_coeffs (i:=⟨i.val + 1, by omega⟩) (v:=⟨v, by
+    = coeffsBySuffix (r:=r) 𝔽q ℓ R_rate original_coeffs (i:=⟨i.val + 1, by omega⟩) (v:=⟨v, by
       calc v.val < 2 ^ i.val := by omega
         _ < 2 ^ (i.val + 1) := by apply Nat.pow_lt_pow_right (by omega) (by omega)
     ⟩) x := by
-    simp only [coeffs_by_suffix]
+    simp only [coeffsBySuffix]
     -- ⊢ original_coeffs ⟨(↑x * 2) <<< ↑i ||| ↑v, ⋯⟩ = original_coeffs ⟨↑x <<< (↑i + 1) ||| ↑v, ⋯⟩
     have h_index_eq: (x.val * 2) <<< i.val ||| v.val = x.val <<< (i.val + 1) ||| v.val := by
       change (x.val * 2^1) <<< i.val ||| v.val = x.val <<< (i.val + 1) ||| v.val
@@ -1508,7 +1501,7 @@ theorem even_refinement_eq_novel_poly_of_0_leading_suffix (i : Fin ℓ) (v : Fin
 
   rw [h_coeffs_eq]
 
-omit [DecidableEq L] [DecidableEq 𝔽q] in
+omit [DecidableEq L] in
 /-- `P₁, ₍ᵥ₎⁽ⁱ⁺¹⁾(X) = P₍₁ᵥ₎⁽ⁱ⁺¹⁾(X)`, where `v` consists of exactly `i` bits
 Note that the odd refinement `P₁,₍ᵥ₎⁽ⁱ⁺¹⁾(X)` is constructed from the view of stage `i`,
 while the novel polynomial `P₍₁ᵥ₎⁽ⁱ⁺¹⁾(X)` is constructed from the view of stage `i+1`.
@@ -1519,15 +1512,15 @@ theorem odd_refinement_eq_novel_poly_of_1_leading_suffix (i : Fin ℓ) (v : Fin 
       apply Nat.or_lt_two_pow (x:=v.val) (y:=1 <<< i.val) (n:=i.val + 1) (by omega)
       rw [Nat.shiftLeft_eq, one_mul]
       exact Nat.pow_lt_pow_right (by omega) (by omega)
-    odd_refinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i (coeffs_by_suffix (r:=r) 𝔽q ℓ
+    odd_refinement 𝔽q β ℓ R_rate h_ℓ_add_R_rate i (coeffsBySuffix (r:=r) 𝔽q ℓ
       R_rate original_coeffs ⟨i, by omega⟩ v) =
     intermediate_evaluation_poly 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i + 1, by omega⟩
-      (coeffs_by_suffix (r:=r) 𝔽q ℓ R_rate original_coeffs ⟨i + 1, by omega⟩
+      (coeffsBySuffix (r:=r) 𝔽q ℓ R_rate original_coeffs ⟨i + 1, by omega⟩
         ⟨v ||| (1 <<< i.val), h_v⟩) := by
   simp only [odd_refinement, Fin.eta, intermediate_evaluation_poly]
 
   set right_inner_func := fun x: Fin (2^(ℓ - (i.val + 1))) =>
-    C (coeffs_by_suffix 𝔽q ℓ R_rate original_coeffs
+    C (coeffsBySuffix 𝔽q ℓ R_rate original_coeffs
       ⟨i.val + 1, by omega⟩ ⟨v.val ||| (1 <<< i.val), by
       simp only;
       apply Nat.or_lt_two_pow
@@ -1549,7 +1542,7 @@ theorem odd_refinement_eq_novel_poly_of_1_leading_suffix (i : Fin ℓ) (v : Fin 
   funext x
   simp only [right_inner_func]
 
-  have h_coeffs_eq: coeffs_by_suffix (r:=r) 𝔽q ℓ R_rate original_coeffs
+  have h_coeffs_eq: coeffsBySuffix (r:=r) 𝔽q ℓ R_rate original_coeffs
       (i:=⟨i.val, by omega⟩) v ⟨↑x * 2 + 1, by
     have h_x_mul_2_lt := mul_two_add_bit_lt_two_pow x.val (ℓ-i-1) (ℓ-i)
       ⟨1, by omega⟩ (by omega) (by omega)
@@ -1557,14 +1550,14 @@ theorem odd_refinement_eq_novel_poly_of_1_leading_suffix (i : Fin ℓ) (v : Fin 
     simp only [gt_iff_lt]
     exact h_x_mul_2_lt
   ⟩
-    = coeffs_by_suffix (r:=r) 𝔽q ℓ R_rate original_coeffs (i:=⟨i.val + 1, by omega⟩)
+    = coeffsBySuffix (r:=r) 𝔽q ℓ R_rate original_coeffs (i:=⟨i.val + 1, by omega⟩)
       (v:=⟨v.val ||| (1 <<< i.val), by
       simp only
       apply Nat.or_lt_two_pow (x:=v.val) (y:=1 <<< i.val) (n:=i.val + 1) (by omega)
       rw [Nat.shiftLeft_eq, one_mul]
       exact Nat.pow_lt_pow_right (by omega) (by omega)
     ⟩) x := by
-    simp only [coeffs_by_suffix]
+    simp only [coeffsBySuffix]
     -- ⊢ original_coeffs ⟨(↑x * 2 + 1) <<< ↑i ||| ↑v, ⋯⟩
     -- = original_coeffs ⟨↑x <<< (↑i + 1) ||| (↑v ||| 1 <<< ↑i), ⋯⟩
     have h_index_eq: (x.val * 2 + 1) <<< i.val ||| v.val
@@ -1590,7 +1583,7 @@ theorem odd_refinement_eq_novel_poly_of_1_leading_suffix (i : Fin ℓ) (v : Fin 
   rw [h_coeffs_eq]
 
 /--
-The main loop invariant for the `additive_ntt` algorithm: the evaluation buffer `b`
+The main loop invariant for the `additiveNTT` algorithm: the evaluation buffer `b`
 at the end of stage `i` (`i ∈ {0, ..., ℓ}`, `i=ℓ` means the initial tiled buffer)
 holds the value `P⁽ⁱ⁾(ω_{u, b, v})` for all bit mask index `(u||b||v) ∈ {0, ..., 2^(ℓ+R_rate)-1}`,
 where the points `ω_{u, b, v}` are in the domain `S⁽ⁱ⁾`.
@@ -1621,7 +1614,7 @@ let `u_b_v := j.val` (as a natural number),
 then:
   b j = P⁽ⁱ⁾(ω_{u, b, i})
 -/
-def additive_ntt_invariant (evaluation_buffer : Fin (2 ^ (ℓ + R_rate)) → L)
+def additiveNTT_invariant (evaluation_buffer : Fin (2 ^ (ℓ + R_rate)) → L)
     (original_coeffs : Fin (2 ^ ℓ) → L) (i : Fin (ℓ + 1)): Prop :=
   ∀ (j : Fin (2^(ℓ + R_rate))),
     let u_b_v := j.val
@@ -1643,23 +1636,23 @@ def additive_ntt_invariant (evaluation_buffer : Fin (2 ^ (ℓ + R_rate)) → L)
     let b_bit := get_lsb u_b_v 1 -- the LSB of the high bits, i.e. the `i`-th bit
     let u := u_b / 2 -- the remaining high bits
     let coeffs_at_j: Fin (2 ^ (ℓ - i)) → L :=
-      coeffs_by_suffix (r:=r) 𝔽q ℓ R_rate original_coeffs i v
+      coeffsBySuffix (r:=r) 𝔽q ℓ R_rate original_coeffs i v
     let P_i: L[X] := intermediate_evaluation_poly 𝔽q β ℓ R_rate h_ℓ_add_R_rate i coeffs_at_j
-    let ω := evaluation_point_ω 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ (Fin.mk u_b (by omega))
+    let ω := evaluationPointω 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ (Fin.mk u_b (by omega))
     evaluation_buffer j = P_i.eval ω
 
 lemma initial_tiled_coeffs_correctness
-    (h_W₀_eq_X : W L 𝔽q β 0 = X) (h_β₀_eq_1 : β 0 = 1)
+    (h_W₀_eq_X : W 𝔽q β 0 = X) (h_β₀_eq_1 : β 0 = 1)
     (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1) (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
     (hβ_lin_indep : LinearIndependent 𝔽q β) (h_ℓ : ℓ ≤ r)
     (a : Fin (2 ^ ℓ) → L) :
     let b: Fin (2^(ℓ + R_rate)) → L := tile_coeffs ℓ R_rate a
-    additive_ntt_invariant 𝔽q β ℓ R_rate h_ℓ_add_R_rate b a (i:=⟨ℓ, by omega⟩) := by
-    unfold additive_ntt_invariant
+    additiveNTT_invariant 𝔽q β ℓ R_rate h_ℓ_add_R_rate b a (i:=⟨ℓ, by omega⟩) := by
+    unfold additiveNTT_invariant
     simp only
     intro j
-    unfold coeffs_by_suffix
-    simp only [tile_coeffs, evaluation_point_ω, intermediate_evaluation_poly, Fin.eta]
+    unfold coeffsBySuffix
+    simp only [tile_coeffs, evaluationPointω, intermediate_evaluation_poly, Fin.eta]
     have h_ℓ_sub_ℓ: 2^(ℓ - ℓ) = 1 := by norm_num
 
     set f_right: Fin (2^(ℓ - ℓ)) → L[X] :=
@@ -1684,7 +1677,7 @@ lemma initial_tiled_coeffs_correctness
 
     set f_left: Fin (ℓ + R_rate - ℓ) → L := fun x =>
       if bit (x.val) (j.val / 2 ^ ℓ) = 1 then
-        eval (β ⟨ℓ + x.val, by omega⟩) (normalizedW L 𝔽q β ⟨ℓ, by omega⟩)
+        eval (β ⟨ℓ + x.val, by omega⟩) (normalizedW 𝔽q β ⟨ℓ, by omega⟩)
       else 0
 
     simp only [eval_mul, eval_C]
@@ -1721,29 +1714,29 @@ lemma ntt_stage_correctness
     (hβ_lin_indep : LinearIndependent 𝔽q β)
     (i : Fin (ℓ))
     (input_buffer: Fin (2^(ℓ + R_rate)) → L) (original_coeffs : Fin (2 ^ ℓ) → L) :
-    additive_ntt_invariant 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+    additiveNTT_invariant 𝔽q β ℓ R_rate h_ℓ_add_R_rate
     (evaluation_buffer:=input_buffer) (original_coeffs:=original_coeffs) (i:=⟨i.val+1, by omega⟩) →
-    additive_ntt_invariant 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+    additiveNTT_invariant 𝔽q β ℓ R_rate h_ℓ_add_R_rate
     (evaluation_buffer:=ntt_stage 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ input_buffer)
     (original_coeffs:=original_coeffs) ⟨i, by omega⟩ :=
   by
   -- This proof is the core of the work, using the `key_polynomial_identity`.
   intro h_prev
-  simp [additive_ntt_invariant] at h_prev
+  simp [additiveNTT_invariant] at h_prev
   -- unfold ntt_stage
   set output_buffer := ntt_stage 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨i, by omega⟩ input_buffer
-  unfold additive_ntt_invariant at *
+  unfold additiveNTT_invariant at *
   simp only at *
   intro j
   -- prove that at any `j ∈ {0, ..., 2^(ℓ+R_rate)-1}`,
-  -- output_buffer j = P⁽ⁱ⁾(ω_{u, b, i}) where coeffs of P⁽ⁱ⁾ at j = `coeffs_by_suffix a i v`
+  -- output_buffer j = P⁽ⁱ⁾(ω_{u, b, i}) where coeffs of P⁽ⁱ⁾ at j = `coeffsBySuffix a i v`
 
   have h_j_div_2_pow_i_lt := div_two_pow_lt_two_pow (x:=j.val)
     (i:=ℓ + R_rate - i.val) (j:=i.val) (by
     rw [Nat.sub_add_cancel (by omega)]; omega)
-  set cur_evaluation_point := evaluation_point_ω 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+  set cur_evaluation_point := evaluationPointω 𝔽q β ℓ R_rate h_ℓ_add_R_rate
     ⟨↑i, by omega⟩ ⟨↑j / 2 ^ i.val, by simp only; exact h_j_div_2_pow_i_lt⟩ -- ω_{u, b, i}
-  set cur_coeffs := coeffs_by_suffix 𝔽q ℓ R_rate original_coeffs ⟨↑i, by omega⟩
+  set cur_coeffs := coeffsBySuffix 𝔽q ℓ R_rate original_coeffs ⟨↑i, by omega⟩
     ⟨get_lsb ↑j ↑i, by exact get_lsb_lt_two_pow (num_lsb_bits:=i.val)⟩ -- coeffs of P⁽ⁱ⁾ at j
 
   -- identity (39): `P⁽ⁱ⁾(X) = P₀⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X)) + X ⋅ P₁⁽ⁱ⁺¹⁾(q⁽ⁱ⁾(X))`
@@ -1818,7 +1811,7 @@ lemma ntt_stage_correctness
   · simp only [h_b_bit_eq_0, ↓reduceDIte]
     simp only at h_b_bit_eq_0
     have bit_i_j_eq_0: bit i.val j.val = 0 := by omega
-    set x0 := twiddle_factor 𝔽q β ℓ R_rate h_ℓ_add_R_rate i ⟨j.val / 2 ^ i.val / 2, by
+    set x0 := twiddleFactor 𝔽q β ℓ R_rate h_ℓ_add_R_rate i ⟨j.val / 2 ^ i.val / 2, by
       rw [h_j_div_2_pow_left.symm]; exact h_j_div_2_pow_i_add_1_lt⟩
 
     have h_j_add_2_pow_i: j.val + 2 ^ i.val < 2 ^ (ℓ + R_rate):= by
@@ -1833,7 +1826,7 @@ lemma ntt_stage_correctness
       eval x0 (even_coeffs_poly.comp (q_map 𝔽q β ⟨↑i, by omega⟩)) := by
       rw [h_prev j]
 
-      have h_twiddle_comp_qmap_eq_left := eval_point_ω_eq_next_twiddle_factor_comp_qmap
+      have h_twiddle_comp_qmap_eq_left := eval_point_ω_eq_next_twiddleFactor_comp_qmap
         𝔽q β ℓ R_rate h_ℓ_add_R_rate h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep
           (i:=⟨i, by omega⟩) (x:=⟨j.val / 2 ^ i.val / 2, by
         rw [←h_j_div_2_pow_left]; simp only [h_j_div_2_pow_i_add_1_lt]
@@ -1846,7 +1839,7 @@ lemma ntt_stage_correctness
         simp only [x0]
         rw [←h_twiddle_comp_qmap_eq_left]
 
-      -- ⊢ eval (ω_ᵢ₊₁(j / 2 ^ (i + 1))) (Pᵢ₊₁ (coeffs_by_suffix (i+1) (get_lsb (j) (i+1)))) =
+      -- ⊢ eval (ω_ᵢ₊₁(j / 2 ^ (i + 1))) (Pᵢ₊₁ (coeffsBySuffix (i+1) (get_lsb (j) (i+1)))) =
       -- eval (ω_ᵢ₊₁(j / 2 ^ i /2)) even_coeffs_poly => `h_j_div_2_pow_left` is dervied for this
 
       conv_lhs =>
@@ -1905,7 +1898,7 @@ lemma ntt_stage_correctness
           apply Nat.add_lt_add_left;
           exact get_lsb_lt_two_pow (n:=j.val) (num_lsb_bits:=i.val)
 
-      have h_twiddle_comp_qmap_eq_right := eval_point_ω_eq_next_twiddle_factor_comp_qmap
+      have h_twiddle_comp_qmap_eq_right := eval_point_ω_eq_next_twiddleFactor_comp_qmap
         𝔽q β ℓ R_rate h_ℓ_add_R_rate h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep
           (i:=⟨i, by omega⟩) (x:=⟨j.val / 2 ^ i.val / 2, by exact h_j_div_2_pow_div_2_left_lt⟩)
       simp only [Fin.eta] at h_twiddle_comp_qmap_eq_right
@@ -1916,7 +1909,7 @@ lemma ntt_stage_correctness
         simp only [x0]
         rw [←h_twiddle_comp_qmap_eq_right]
       -- ⊢ eval (ω_ᵢ₊₁((⟨j.val + 2 ^ i.val, h_j_add_2_pow_i⟩: Fin (2^(ℓ + R_rate))).val
-      -- / 2 ^ (↑i + 1), ⋯⟩))) (Pᵢ₊₁ (coeffs_by_suffix (i+1) (get_lsb (j + 2^i) (i+1)))) =
+      -- / 2 ^ (↑i + 1), ⋯⟩))) (Pᵢ₊₁ (coeffsBySuffix (i+1) (get_lsb (j + 2^i) (i+1)))) =
       -- eval (ω_ᵢ₊₁(↑⟨j.val / 2 ^ i.val / 2, ⋯⟩))) odd_coeffs_poly
       conv_lhs =>
         enter [1]
@@ -1969,7 +1962,7 @@ lemma ntt_stage_correctness
     have h_x0_eq_cur_evaluation_point: x0 = cur_evaluation_point := by
       unfold x0 cur_evaluation_point
       simp only
-      rw [evaluation_point_ω_eq_twiddle_factor_of_div_2 𝔽q]
+      rw [evaluationPointω_eq_twiddleFactor_of_div_2 𝔽q]
       simp only [Fin.eta, h_b_bit_eq_0, Nat.cast_zero, zero_mul, add_zero]
 
     rw [h_x0_eq_cur_evaluation_point]
@@ -1978,7 +1971,7 @@ lemma ntt_stage_correctness
     push_neg at h_b_bit_eq_0
     have bit_i_j_eq_1: bit i.val j.val = 1 := by omega
     simp only [ne_eq, Nat.mod_two_not_eq_zero] at h_b_bit_eq_0
-    set x1 := twiddle_factor 𝔽q β ℓ R_rate h_ℓ_add_R_rate i
+    set x1 := twiddleFactor 𝔽q β ℓ R_rate h_ℓ_add_R_rate i
       ⟨j.val / 2 ^ i.val / 2, by exact h_j_div_2_pow_div_2_left_lt⟩ + 1
 
     have h_j_xor_2_pow_i: j.val ^^^ 2 ^ i.val < 2 ^ (ℓ + R_rate):= by
@@ -2040,7 +2033,7 @@ lemma ntt_stage_correctness
           -- ⊢ ↑j ^^^ 2 ^ ↑i < ↑j + (2 ^ ↑i - get_lsb ↑j ↑i)
           omega
 
-      have h_twiddle_comp_qmap_eq_left := eval_point_ω_eq_next_twiddle_factor_comp_qmap
+      have h_twiddle_comp_qmap_eq_left := eval_point_ω_eq_next_twiddleFactor_comp_qmap
         𝔽q β ℓ R_rate h_ℓ_add_R_rate h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep
           (i:=⟨i, by omega⟩) (x:=⟨j.val / 2 ^ i.val / 2, by exact h_j_div_2_pow_div_2_left_lt⟩)
       simp only [Fin.eta] at h_twiddle_comp_qmap_eq_left
@@ -2050,7 +2043,7 @@ lemma ntt_stage_correctness
         rw [eval_comp]
         simp only [x1]
 
-      set t := twiddle_factor (r:=r) 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+      set t := twiddleFactor (r:=r) 𝔽q β ℓ R_rate h_ℓ_add_R_rate
         (i:=i) (u:=⟨j.val / 2 ^ i.val / 2, by
         exact h_j_div_2_pow_div_2_left_lt⟩) with ht
 
@@ -2063,7 +2056,7 @@ lemma ntt_stage_correctness
         simp only [LinearMap.coe_mk, AddHom.coe_mk, eval_qmap_linear]
         rw [←h_twiddle_comp_qmap_eq_left]
 
-      -- ⊢ eval (ω_ᵢ₊₁(j / 2 ^ (i + 1))) (Pᵢ₊₁ (coeffs_by_suffix (i+1) (get_lsb (j) (i+1)))) =
+      -- ⊢ eval (ω_ᵢ₊₁(j / 2 ^ (i + 1))) (Pᵢ₊₁ (coeffsBySuffix (i+1) (get_lsb (j) (i+1)))) =
       -- eval (ω_ᵢ₊₁(j / 2 ^ i /2)) even_coeffs_poly => `h_j_div_2_pow_left` is dervied for this
 
       conv_lhs =>
@@ -2113,7 +2106,7 @@ lemma ntt_stage_correctness
       -- left (top) is the full poly of level (i+1),
       -- right (bottom) is the odd refinement of current level i
 
-      have h_twiddle_comp_qmap_eq_left := eval_point_ω_eq_next_twiddle_factor_comp_qmap
+      have h_twiddle_comp_qmap_eq_left := eval_point_ω_eq_next_twiddleFactor_comp_qmap
         𝔽q β ℓ R_rate h_ℓ_add_R_rate h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep
           (i:=⟨i, by omega⟩) (x:=⟨j.val / 2 ^ i.val / 2, by
         rw [←h_j_div_2_pow_left]
@@ -2129,7 +2122,7 @@ lemma ntt_stage_correctness
         rw [eval_comp]
         simp only [x1]
 
-      set t := twiddle_factor (r:=r) 𝔽q β ℓ R_rate h_ℓ_add_R_rate (i:=i)
+      set t := twiddleFactor (r:=r) 𝔽q β ℓ R_rate h_ℓ_add_R_rate (i:=i)
         (u:=⟨j.val / 2 ^ i.val / 2, by exact h_j_div_2_pow_div_2_left_lt⟩) with ht
 
       have hh := eval_qmap_linear.map_add' (x:=t) (y:=1)
@@ -2141,7 +2134,7 @@ lemma ntt_stage_correctness
         simp only [LinearMap.coe_mk, AddHom.coe_mk, eval_qmap_linear]
         rw [←h_twiddle_comp_qmap_eq_left]
 
-      -- ⊢ eval (ω_ᵢ₊₁(j / 2 ^ (i + 1))) (Pᵢ₊₁ (coeffs_by_suffix (i+1) (get_lsb (j) (i+1)))) =
+      -- ⊢ eval (ω_ᵢ₊₁(j / 2 ^ (i + 1))) (Pᵢ₊₁ (coeffsBySuffix (i+1) (get_lsb (j) (i+1)))) =
       -- eval (ω_ᵢ₊₁(j / 2 ^ i /2)) even_coeffs_poly => `h_j_div_2_pow_left` is dervied for this
 
       conv_lhs =>
@@ -2172,21 +2165,21 @@ lemma ntt_stage_correctness
     have h_x1_eq_cur_evaluation_point: x1 = cur_evaluation_point := by
       unfold x1 cur_evaluation_point
       simp only
-      rw [evaluation_point_ω_eq_twiddle_factor_of_div_2 𝔽q]
+      rw [evaluationPointω_eq_twiddleFactor_of_div_2 𝔽q]
       simp only [Fin.eta, h_b_bit_eq_0, Nat.cast_one, one_mul, add_right_inj]
-      rw [normalizedWᵢ_eval_βᵢ L 𝔽q β hβ_lin_indep]
+      rw [normalizedWᵢ_eval_βᵢ 𝔽q β hβ_lin_indep]
 
     rw [h_x1_eq_cur_evaluation_point]
     simp only [eval_comp, eval_add, eval_mul, eval_X]
 
--- foldl k times would result in the additive_ntt_invariant holding for the `ℓ - k`-th stage
+-- foldl k times would result in the additiveNTT_invariant holding for the `ℓ - k`-th stage
 lemma foldl_ntt_stage_inductive_aux
-    (h_W₀_eq_X : W L 𝔽q β 0 = X) (h_β₀_eq_1 : β 0 = 1)
+    (h_W₀_eq_X : W 𝔽q β 0 = X) (h_β₀_eq_1 : β 0 = 1)
     (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1) (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
     (hβ_lin_indep : LinearIndependent 𝔽q β)
     (h_ℓ : ℓ ≤ r) (k : Fin (ℓ + 1))
     (original_coeffs : Fin (2 ^ ℓ) → L):
-    additive_ntt_invariant 𝔽q β ℓ R_rate h_ℓ_add_R_rate
+    additiveNTT_invariant 𝔽q β ℓ R_rate h_ℓ_add_R_rate
     (Fin.foldl k (fun current_b i ↦ ntt_stage 𝔽q β ℓ R_rate h_ℓ_add_R_rate
       ⟨ℓ - i -1, by omega⟩ current_b) (tile_coeffs ℓ R_rate original_coeffs))
     original_coeffs ⟨ℓ - k, by omega⟩ := by
@@ -2215,29 +2208,29 @@ lemma foldl_ntt_stage_inductive_aux
 /--
 **Main Correctness Theorem for Additive NTT**
 
-If `b` is the output of `additive_ntt` on input `a`, then for all `j`, `b j`
+If `b` is the output of `additiveNTT` on input `a`, then for all `j`, `b j`
 is the evaluation of the polynomial `P` (from the novel basis coefficients `a`)
 at the evaluation point `ω_{0, j}` in the domain `S⁰`.
 -/
-theorem additive_ntt_correctness
-    (h_W₀_eq_X : W L 𝔽q β 0 = X) (h_β₀_eq_1 : β 0 = 1)
+theorem additiveNTT_correctness
+    (h_W₀_eq_X : W 𝔽q β 0 = X) (h_β₀_eq_1 : β 0 = 1)
     (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1) (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
     (hβ_lin_indep : LinearIndependent 𝔽q β) (h_ℓ : ℓ ≤ r)
     (original_coeffs : Fin (2 ^ ℓ) → L)
     (output_buffer : Fin (2 ^ (ℓ + R_rate)) → L)
-    (h_alg : output_buffer = additive_ntt 𝔽q β ℓ R_rate h_ℓ_add_R_rate original_coeffs) :
-    let P := polynomial_from_novel_coeffs L 𝔽q β ℓ h_ℓ original_coeffs
+    (h_alg : output_buffer = additiveNTT 𝔽q β ℓ R_rate h_ℓ_add_R_rate original_coeffs) :
+    let P := polynomial_from_novel_coeffs 𝔽q β ℓ h_ℓ original_coeffs
     ∀ (j : Fin (2^(ℓ + R_rate))),
-      output_buffer j = P.eval (evaluation_point_ω 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨0, by omega⟩ j) :=
+      output_buffer j = P.eval (evaluationPointω 𝔽q β ℓ R_rate h_ℓ_add_R_rate ⟨0, by omega⟩ j) :=
   by
   simp only [Fin.zero_eta]
   intro j
   simp only [h_alg]
-  unfold additive_ntt
+  unfold additiveNTT
   set output_foldl := Fin.foldl ℓ (fun current_b i ↦ ntt_stage 𝔽q β ℓ R_rate
     h_ℓ_add_R_rate ⟨ℓ - i -1, by omega⟩ current_b) (tile_coeffs ℓ R_rate original_coeffs)
 
-  have output_foldl_correctness : additive_ntt_invariant 𝔽q β ℓ R_rate
+  have output_foldl_correctness : additiveNTT_invariant 𝔽q β ℓ R_rate
     h_ℓ_add_R_rate output_foldl original_coeffs ⟨0, by omega⟩ := by
     have res := foldl_ntt_stage_inductive_aux 𝔽q β ℓ R_rate h_ℓ_add_R_rate h_W₀_eq_X h_β₀_eq_1
       h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep h_ℓ
@@ -2249,11 +2242,11 @@ theorem additive_ntt_correctness
     have h_j_mod_2_eq_0: j.val % 2 < 2 := by omega
     exact Nat.div_add_mod' (↑j) 2
 
-  simp only [additive_ntt_invariant] at output_foldl_correctness
+  simp only [additiveNTT_invariant] at output_foldl_correctness
   have res := output_foldl_correctness j
   unfold output_foldl at res
   simp only [Fin.zero_eta, Nat.sub_zero, pow_zero, Nat.div_one, Fin.eta,
-    Nat.pow_zero, get_zero_lsb_eq_zero (n := j.val), Fin.isValue, base_coeffs_by_suffix] at res
+    Nat.pow_zero, get_zero_lsb_eq_zero (n := j.val), Fin.isValue, base_coeffsBySuffix] at res
   simp only [←
     intermediate_poly_P_base 𝔽q β ℓ R_rate h_ℓ_add_R_rate h_W₀_eq_X h_β₀_eq_1 h_Fq_card_gt_1
       h_Fq_char_prime hβ_lin_indep h_ℓ original_coeffs,

--- a/ArkLib/Data/FieldTheory/AdditiveNTT/NovelPolynomialBasis.lean
+++ b/ArkLib/Data/FieldTheory/AdditiveNTT/NovelPolynomialBasis.lean
@@ -51,7 +51,7 @@ variable [Algebra 𝔽q L]
 variable (h_dim : Module.finrank 𝔽q L = r)
 
 -- We assume an `𝔽q`-basis for `L`, denoted by `(β₀, β₁, ..., β_{r-1})`, indexed by natural numbers.
-variable (β : Fin r → L) (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+variable (β : Fin r → L) (hβ_lin_indep : LinearIndependent 𝔽q β)
 
 section LinearSubspaces
 
@@ -123,7 +123,7 @@ noncomputable instance fintype_U (i : Fin r) : Fintype (U 𝔽q β i) := by
   exact Fintype.ofFinite (U 𝔽q β i)
 
 -- The cardinality of the subspace `Uᵢ` is `2ⁱ`, which follows from its dimension.
-lemma U_card (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+lemma U_card (hβ_lin_indep : LinearIndependent 𝔽q β)
   (i : Fin r):
     Fintype.card (U 𝔽q β i) = (Fintype.card 𝔽q)^i.val := by
   -- The cardinality of a vector space V is |F|^(dim V).
@@ -329,7 +329,7 @@ example (i : Fin r) (h_i_eq_0 : i = 0) : Set.Ico 0 i = ∅ := by
 
 omit [DecidableEq L] [Fintype 𝔽q]  in
 /-- The evaluation of `Wᵢ(X)` at `βᵢ` is non-zero. -/
-lemma Wᵢ_eval_βᵢ_neq_zero (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+lemma Wᵢ_eval_βᵢ_neq_zero (hβ_lin_indep : LinearIndependent 𝔽q β)
     (i : Fin r): (W 𝔽q β i).eval (β i) ≠ 0 := by
   -- Since `βᵢ ∉ Uᵢ`, `eval (Wᵢ(X)) (βᵢ)` cannot be zero.
   -- `eval(P*Q, x) = eval(P,x) * eval(Q,x)`. A product is non-zero iff all factors are non-zero.
@@ -748,7 +748,7 @@ The generic product form of the recursion for `Wᵢ`.
 This follows the first line of the proof for (i) in the description.
 `Wᵢ(X) = ∏_{c ∈ 𝔽q} Wᵢ₋₁ ∘ (X - cβᵢ₋₁)`.
 -/
-lemma W_prod_comp_decomposition (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+lemma W_prod_comp_decomposition (hβ_lin_indep : LinearIndependent 𝔽q β)
     (i : Fin r) (hi : i > 0) :
     (W 𝔽q β i) = ∏ c: 𝔽q, (W 𝔽q β (i-1)).comp (X - C (c • β (i-1))) := by
   -- ⊢ W 𝔽q β i = ∏ c, (W 𝔽q β (i - 1)).comp (X - C (c • β (i - 1)))
@@ -825,7 +825,7 @@ lemma comp_sub_C_of_linear_eval (p : L[X])
   exact comp_C
 
 lemma inductive_rec_form_W_comp (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
-    (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+    (hβ_lin_indep : LinearIndependent 𝔽q β)
     (i : Fin r) (h_i_add_1: i + 1 < r)
     (h_prev_linear_map: IsLinearMap (R := 𝔽q) (M := L[X]) (M₂ := L[X])
       (f := fun inner_p ↦ (W 𝔽q β i).comp inner_p))
@@ -961,7 +961,7 @@ lemma inductive_rec_form_W_comp (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
 
 lemma inductive_linear_map_W (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
     (h_Fq_char_prime: Fact (Nat.Prime (ringChar 𝔽q)))
-  (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+  (hβ_lin_indep : LinearIndependent 𝔽q β)
     (i : Fin r) (h_i_add_1: i + 1 < r)
     (h_prev_linear_map: IsLinearMap 𝔽q (f := fun inner_p ↦ (W 𝔽q β i).comp inner_p))
     : IsLinearMap 𝔽q (f := fun inner_p ↦ (W 𝔽q β (i + 1)).comp inner_p) := by
@@ -1060,7 +1060,7 @@ lemma inductive_linear_map_W (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
 theorem W_linearity
     (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
     (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
-    (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+    (hβ_lin_indep : LinearIndependent 𝔽q β)
     (i : Fin r)
       : IsLinearMap 𝔽q (f := fun inner_p ↦ (W 𝔽q β i).comp inner_p) := by
   induction i using Fin.succRecOnSameFinType with
@@ -1095,7 +1095,7 @@ theorem W_linearity
     exact h_linear_map
 
 /-- Helper function to create a linear map from a polynomial whose evaluation is additive. -/
-noncomputable def poly_eval_linear_map {L 𝔽q : Type*} [Field L] [Field 𝔽q] [Algebra 𝔽q L]
+noncomputable def polyEvalLinearMap {L 𝔽q : Type*} [Field L] [Field 𝔽q] [Algebra 𝔽q L]
   (p : L[X]) (hp_add : IsLinearMap 𝔽q (fun x : L => p.eval x)) : L →ₗ[𝔽q] L :=
 {
   toFun    := fun x => p.eval x,
@@ -1105,7 +1105,7 @@ noncomputable def poly_eval_linear_map {L 𝔽q : Type*} [Field L] [Field 𝔽q]
 
 theorem W_linear_comp_decomposition (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
     (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
-    (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+    (hβ_lin_indep : LinearIndependent 𝔽q β)
     (i : Fin r) (h_i_add_1 : i + 1 < r):
     ∀ p: L[X], (W 𝔽q β (i + 1)).comp p =
       ((W 𝔽q β i).comp p) ^ Fintype.card 𝔽q -
@@ -1117,7 +1117,7 @@ theorem W_linear_comp_decomposition (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
 lemma W_is_additive
   (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
   (h_Fq_char_prime: Fact (Nat.Prime (ringChar 𝔽q)))
-  (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+  (hβ_lin_indep : LinearIndependent 𝔽q β)
   (i : Fin r):
   IsLinearMap (R := 𝔽q) (M := L) (M₂ := L) (f := fun x ↦ (W 𝔽q β i).eval x) := by
   exact AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval (f := (W 𝔽q β i))
@@ -1126,13 +1126,13 @@ lemma W_is_additive
 theorem kernel_W_eq_U
   (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
-  (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+  (hβ_lin_indep : LinearIndependent 𝔽q β)
   (i : Fin r):
-  LinearMap.ker (poly_eval_linear_map (W 𝔽q β i)
+  LinearMap.ker (polyEvalLinearMap (W 𝔽q β i)
     (W_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)) = U 𝔽q β i := by
   ext x
   -- Unfold the definition of kernel membership and polynomial evaluation.
-  simp_rw [LinearMap.mem_ker, poly_eval_linear_map]
+  simp_rw [LinearMap.mem_ker, polyEvalLinearMap]
   simp only [LinearMap.coe_mk, AddHom.coe_mk] -- simp?
   simp only [eval_W_eq_zero_iff_in_U]
 
@@ -1140,7 +1140,7 @@ theorem kernel_W_eq_U
 lemma W_add_U_invariant
   (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
   (h_Fq_char_prime: Fact (Nat.Prime (ringChar 𝔽q)))
-  (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+  (hβ_lin_indep : LinearIndependent 𝔽q β)
   (i : Fin r):
   ∀ x : L, ∀ y ∈ U 𝔽q β i, (W 𝔽q β i).eval (x + y) = (W 𝔽q β i).eval x := by
   intro x y hy
@@ -1154,7 +1154,7 @@ noncomputable def normalizedW (i : Fin r) : L[X] :=
 omit [DecidableEq L] [Fintype 𝔽q]  in
 /-- The evaluation of the normalized polynomial `Ŵᵢ(X)` at `βᵢ` is 1. -/
 lemma normalizedWᵢ_eval_βᵢ {i : Fin r}
-  (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β)):
+  (hβ_lin_indep : LinearIndependent 𝔽q β):
     (normalizedW (𝔽q := 𝔽q) (β := β) (i :=i)).eval (β i) = 1 := by
   rw [normalizedW, eval_mul, eval_C]
   -- This simplifies to `(1 / y) * y`, which is `1`.
@@ -1189,7 +1189,7 @@ lemma eval_normalizedW_succ_at_beta_prev (i : Fin r) (h_i_add_1 : i + 1 < r):
 
 /-- The degree of `Ŵᵢ(X)` remains `|𝔽q|ⁱ`. -/
 lemma degree_normalizedW
-  (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+  (hβ_lin_indep : LinearIndependent 𝔽q β)
   (i : Fin r):
     (normalizedW 𝔽q β i).degree = (Fintype.card 𝔽q)^(i.val) := by
    -- Multiplication by a non-zero constant does not change the degree of a polynomial.
@@ -1217,7 +1217,7 @@ lemma normalizedWᵢ_vanishing (i : Fin r) :
 theorem normalizedW_is_linear_map
   (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
-  (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+  (hβ_lin_indep : LinearIndependent 𝔽q β)
   (i : Fin r):
   IsLinearMap 𝔽q (f := fun inner_p ↦ (normalizedW 𝔽q β i).comp inner_p) := by
   let c := 1 / (W 𝔽q β i).eval (β i)
@@ -1276,7 +1276,7 @@ theorem normalizedW_is_linear_map
 theorem normalizedW_is_additive
   (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
-  (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+  (hβ_lin_indep : LinearIndependent 𝔽q β)
   (i : Fin r):
   IsLinearMap 𝔽q (f := fun x ↦ (normalizedW 𝔽q β i).eval x) := by
   exact AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval (f := (normalizedW 𝔽q β i))
@@ -1286,14 +1286,14 @@ theorem normalizedW_is_additive
 theorem kernel_normalizedW_eq_U
     (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
     (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
-    (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+    (hβ_lin_indep : LinearIndependent 𝔽q β)
     (i : Fin r):
-    LinearMap.ker (poly_eval_linear_map (normalizedW 𝔽q β i)
+    LinearMap.ker (polyEvalLinearMap (normalizedW 𝔽q β i)
     (normalizedW_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i))
     = U 𝔽q β i := by
   ext x
   -- Unfold the definition of kernel membership and polynomial evaluation.
-  simp_rw [LinearMap.mem_ker, poly_eval_linear_map]
+  simp_rw [LinearMap.mem_ker, polyEvalLinearMap]
   simp_rw [normalizedW, Polynomial.eval_mul, Polynomial.eval_C]
   simp only [one_div, LinearMap.coe_mk, AddHom.coe_mk, mul_eq_zero, inv_eq_zero] -- simp?
   simp only [AdditiveNTT.Wᵢ_eval_βᵢ_neq_zero 𝔽q β hβ_lin_indep i, false_or]
@@ -1405,7 +1405,7 @@ noncomputable instance finiteDimensionalCoeffVecSpace (ℓ : ℕ) :
   exact inferInstance
 
 /-- The linear map from polynomials (in the subtype) to their coefficient vectors. -/
-def to_coeffs_vec (ℓ : Nat) : L⦃<2^ℓ⦄[X] →ₗ[L] CoeffVecSpace L ℓ where
+def toCoeffsVec (ℓ : Nat) : L⦃<2^ℓ⦄[X] →ₗ[L] CoeffVecSpace L ℓ where
   toFun := fun p => fun i => p.val.coeff i.val
   map_add' := fun p q => by ext i; simp [coeff_add]
   map_smul' := fun c p => by ext i; simp [coeff_smul, smul_eq_mul]
@@ -1423,10 +1423,10 @@ lemma linearIndependent_rows_of_lower_triangular_ne_zero_diag
     intro i _; exact h_diag i
   exact Matrix.linearIndependent_rows_of_det_ne_zero (A := A) h_det
 
-noncomputable def change_of_basis_matrix (hF₂ : Fintype.card 𝔽q = 2)
-  (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+noncomputable def changeOfBasisMatrix (hF₂ : Fintype.card 𝔽q = 2)
+  (hβ_lin_indep : LinearIndependent 𝔽q β)
   (ℓ : Nat) (h_ℓ : ℓ ≤ r) : Matrix (Fin (2^ℓ)) (Fin (2^ℓ)) L :=
-    fun j i => (to_coeffs_vec (L := L) (ℓ := ℓ) (
+    fun j i => (toCoeffsVec (L := L) (ℓ := ℓ) (
       basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ j)) i
 
 /--
@@ -1435,18 +1435,16 @@ This is proven by showing that the change-of-basis matrix to the monomial basis
 is lower-triangular with a non-zero diagonal.
 -/
 lemma coeff_vectors_linear_independent (hF₂ : Fintype.card 𝔽q = 2)
-  (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
-  (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
-  LinearIndependent L (to_coeffs_vec (L := L) (ℓ := ℓ) ∘
-    (basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ)) := by
+  (hβ_lin_indep : LinearIndependent 𝔽q β) (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
+    LinearIndependent L (toCoeffsVec (ℓ := ℓ) ∘ (basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ)) := by
   -- Let `A` be the `2^ℓ x 2^ℓ` change-of-basis matrix.
-  set A := change_of_basis_matrix 𝔽q β hF₂ hβ_lin_indep ℓ h_ℓ
+  set A := changeOfBasisMatrix 𝔽q β hF₂ hβ_lin_indep ℓ h_ℓ
   -- The `i`-th row of `A` is the coefficient vector of `Xᵢ` in the novel basis.
   -- Apply the lemma about triangular matrices.
   apply linearIndependent_rows_of_lower_triangular_ne_zero_diag A
   · -- ⊢ A.BlockTriangular ⇑OrderDual.toDual => Prove the matrix A is lower-triangular.
     intro i j hij
-    dsimp only [to_coeffs_vec, basisVectors, LinearMap.coe_mk, AddHom.coe_mk, A]
+    dsimp only [toCoeffsVec, basisVectors, LinearMap.coe_mk, AddHom.coe_mk, A]
     -- ⊢ (Xⱼ β ℓ ↑i).coeff ↑j = 0
     have deg_X : (Xⱼ 𝔽q β ℓ h_ℓ i).degree = i :=
       degree_Xⱼ 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ i
@@ -1461,7 +1459,7 @@ lemma coeff_vectors_linear_independent (hF₂ : Fintype.card 𝔽q = 2)
     exact h_res
   · -- ⊢ ∀ (i : Fin (2 ^ ℓ)), A i i ≠ 0 => All diagonal entries are non-zero.
     intro i
-    dsimp [A, to_coeffs_vec, basisVectors]
+    dsimp [A, toCoeffsVec, basisVectors]
     -- `A i i` is the `i`-th (also the leading) coefficient of `Xⱼ`, which is non-zero.
     have h_deg : (Xⱼ 𝔽q β ℓ h_ℓ i).degree = i := degree_Xⱼ 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ i
     have h_natDegree : (Xⱼ 𝔽q β ℓ h_ℓ i).natDegree = i := natDegree_eq_of_degree_eq_some h_deg
@@ -1471,17 +1469,17 @@ lemma coeff_vectors_linear_independent (hF₂ : Fintype.card 𝔽q = 2)
 
 /-- The basis vectors are linearly independent over `L`. -/
 theorem basisVectors_linear_independent (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
-  LinearIndependent L (basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ) := by
+    LinearIndependent L (basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ) := by
   -- We have proved that the image of our basis vectors under the linear map
-  -- `to_coeffs_vec` is a linearly independent family.
+  -- `toCoeffsVec` is a linearly independent family.
   have h_comp_li := coeff_vectors_linear_independent 𝔽q β hF₂ hβ_lin_indep ℓ h_ℓ
   -- `LinearIndependent.of_comp` states that if the image of a family of vectors under
   -- a linear map is linearly independent, then so is the original family.
-  exact LinearIndependent.of_comp (to_coeffs_vec (L := L) (ℓ := ℓ)) h_comp_li
+  exact LinearIndependent.of_comp (toCoeffsVec (L := L) (ℓ := ℓ)) h_comp_li
 
 /-- The basis vectors span the space of polynomials with degree less than `2^ℓ`. -/
 theorem basisVectors_span (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
-  Submodule.span L (Set.range (basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ)) = ⊤ := by
+    Submodule.span L (Set.range (basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ)) = ⊤ := by
   have h_li := basisVectors_linear_independent 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ
   let n := 2 ^ ℓ
   have h_n: n = 2 ^ ℓ := by omega
@@ -1512,15 +1510,13 @@ end NovelPolynomialBasisProof
 
 /-- The polynomial `P(X)` derived from coefficients `a` in the novel polynomial basis `(Xⱼ)`,
 `P(X) := ∑_{j=0}^{2^ℓ-1} aⱼ ⋅ Xⱼ(X)` -/
-noncomputable def polynomialFromNovelCoeffs (ℓ : ℕ) (h_ℓ : ℓ ≤ r)
-    (a : Fin (2 ^ ℓ) → L) : L[X] :=
+noncomputable def polynomialFromNovelCoeffs (ℓ : ℕ) (h_ℓ : ℓ ≤ r) (a : Fin (2 ^ ℓ) → L) : L[X] :=
   ∑ j, C (a j) * (Xⱼ 𝔽q β ℓ h_ℓ j)
 
 /-- Proof that the novel polynomial basis is indeed the indicated basis vectors -/
-theorem novelPolynomialBasis_is_basisVectors (hF₂ : Fintype.card 𝔽q = 2)
-  (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
-  (novelPolynomialBasis 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ)
-  = basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ := by
+theorem novelPolynomialBasis_is_basisVectors (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
+    (novelPolynomialBasis 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ)
+    = basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ := by
   simp only [novelPolynomialBasis, Basis.coe_mk]
 
 end AdditiveNTT

--- a/ArkLib/Data/FieldTheory/AdditiveNTT/NovelPolynomialBasis.lean
+++ b/ArkLib/Data/FieldTheory/AdditiveNTT/NovelPolynomialBasis.lean
@@ -9,19 +9,18 @@ import ArkLib.Data.FieldTheory.AdditiveNTT.Prelude
 /-!
 # Novel Polynomial Basis
 
-This file defines the components of a novel polynomial basis over a field `L`
-with degree `r` as an algebra over its prime-characteristic subfield `𝔽q`, and an `𝔽q`-basis `β` for `L`.
+This file defines the components of a novel polynomial basis over a field `L` with degree `r` as an
+algebra over its prime-characteristic subfield `𝔽q`, and an `𝔽q`-basis `β` for `L`.
 
 ## Main Definitions
 - `Uᵢ`: `𝔽q`-linear span of the initial `i` vectors of our basis `β`
 - `Wᵢ(X)`: subspace vanishing polynomial over `Uᵢ`, with normalized form `Ŵᵢ(X)`
-- `{Xⱼ(X), j ∈ Fin 2^ℓ}`: basis vectors of `L⦃<2^ℓ⦄[X]` over `L`
-  constructed from `Ŵᵢ(X)`
-- `novel_polynomial_basis`: the novel polynomial basis for `L⦃<2^ℓ⦄[X]`
-- `W_prod_comp_decomposition`: decomposition of `Wᵢ` into a product of compositions
-  `Π c ∈ Uᵢ, (Wᵢ₋₁ ∘ (X - c • βᵢ₋₁))`
-- `W_linearity`: `Wᵢ` is `𝔽q`-linear and satisfies the recursion formula
-  `Wᵢ = (Wᵢ₋₁)^|𝔽q| - ((Wᵢ₋₁)(βᵢ₋₁))^(|𝔽q|-1) * Wᵢ₋₁`
+- `{Xⱼ(X), j ∈ Fin 2^ℓ}`: basis vectors of `L⦃<2^ℓ⦄[X]` over `L` constructed from `Ŵᵢ(X)`
+- `novelPolynomialBasis`: the novel polynomial basis for `L⦃<2^ℓ⦄[X]`
+- `W_prod_comp_decomposition`: decomposition of `Wᵢ` into a product of compositions `Π c ∈ Uᵢ, (Wᵢ₋₁
+  ∘ (X - c • βᵢ₋₁))`
+- `W_linearity`: `Wᵢ` is `𝔽q`-linear and satisfies the recursion formula `Wᵢ = (Wᵢ₋₁)^|𝔽q| -
+  ((Wᵢ₋₁)(βᵢ₋₁))^(|𝔽q|-1) * Wᵢ₋₁`
 
 ## TODOs
 - Computable novel polynomial basis
@@ -32,9 +31,9 @@ with degree `r` as an algebra over its prime-characteristic subfield `𝔽q`, an
   Application to Reed–Solomon Erasure Codes". In: IEEE 55th Annual Symposium on Foundations of
   Computer Science. 2014, pp. 316–325. doi : 10.1109/FOCS.2014.41.
 
-- [GGJ96] J. von zur Gathen and J. Gerhard, "Arithmetic and factorization of polynomial
-  over F2 (extended abstract)", in Proceedings of the 1996 International Symposium on
-  Symbolic and Algebraic Computation, Zurich, Switzerland, 1996, pp. 1–9.
+- [GGJ96] J. von zur Gathen and J. Gerhard, "Arithmetic and factorization of polynomial over F2
+  (extended abstract)", in Proceedings of the 1996 International Symposium on Symbolic and Algebraic
+  Computation, Zurich, Switzerland, 1996, pp. 1–9.
 -/
 
 open AdditiveNTT Polynomial FiniteDimensional Finset
@@ -44,8 +43,8 @@ universe u
 
 -- Fix a field `L` of degree `r` as an algebra over its prime-characteristic subfield `𝔽q`
 variable {r : ℕ} [NeZero r]
-variable (L : Type u) [Field L] [Fintype L] [DecidableEq L]
-variable (𝔽q : Type u) [Field 𝔽q] [Fintype 𝔽q] [DecidableEq 𝔽q]
+variable {L : Type u} [Field L] [Fintype L] [DecidableEq L]
+variable (𝔽q : Type u) [Field 𝔽q] [Fintype 𝔽q]
 variable [Algebra 𝔽q L]
 variable (h_dim : Module.finrank 𝔽q L = r)
 
@@ -54,22 +53,24 @@ variable (β : Fin r → L) (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M :
 
 section LinearSubspaces
 
--- # 𝔽q-linear subspaces `Uᵢ`
--- `∀ i ∈ {0, ..., r-1}`, we define `Uᵢ:= <β₀, ..., βᵢ₋₁>_{𝔽q}`
--- as the `𝔽q`-linear span of the initial `i` vectors of our basis `β`.
--- NOTE: We might allow `i = r` in the future if needed.
-def U (i : Fin r) : Subspace 𝔽q L := Submodule.span 𝔽q (Set.image β (Set.Ico 0 i))
+/-- **𝔽q-linear subspaces `Uᵢ`**
 
-instance {i : Fin r} : Module (R := 𝔽q) (M := U L 𝔽q β i) := Submodule.module _
-instance {i : Fin r} : DecidableEq (U L 𝔽q β i) := by exact instDecidableEqOfLawfulBEq
-noncomputable instance {i : Fin r} (x : L): Decidable (x ∈ (U L 𝔽q β i : Set L)) := by
-  exact Classical.propDecidable (x ∈ ↑(U L 𝔽q β i))
+`∀ i ∈ {0, ..., r-1}`, we define `Uᵢ:= <β₀, ..., βᵢ₋₁>_{𝔽q}`
+as the `𝔽q`-linear span of the initial `i` vectors of our basis `β`.
+
+NOTE: We might allow `i = r` in the future if needed. -/
+def U (i : Fin r) : Subspace 𝔽q L := Submodule.span 𝔽q (β '' (Set.Ico 0 i))
+
+instance {i : Fin r} : Module (R := 𝔽q) (M := U 𝔽q β i) := Submodule.module _
+instance {i : Fin r} : DecidableEq (U 𝔽q β i) := by exact instDecidableEqOfLawfulBEq
+noncomputable instance {i : Fin r} (x : L) : Decidable (x ∈ (U 𝔽q β i : Set L)) := by
+  exact Classical.propDecidable (x ∈ ↑(U 𝔽q β i))
 -- e.g. prop => boolean
 
 -- The dimension of `U i` is `i`.
-omit [Fintype L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [Fintype L] [Fintype 𝔽q] in
 lemma finrank_U (hβ_lin_indep : LinearIndependent 𝔽q β) (i : Fin r):
-  Module.finrank (R := 𝔽q) (M := (U L 𝔽q β i)) = i := by
+  Module.finrank 𝔽q (U 𝔽q β i) = i := by
   -- The dimension of the span of linearly independent vectors is the number of vectors.
   unfold U
   set basisUᵢ := β '' Set.Ico 0 i
@@ -116,27 +117,26 @@ lemma finrank_U (hβ_lin_indep : LinearIndependent 𝔽q β) (i : Fin r):
   rw [Set.toFinset_card]
   exact h_basis_card
 
-noncomputable instance fintype_U (i : Fin r) : Fintype (U L 𝔽q β i) := by
-  exact Fintype.ofFinite (U L 𝔽q β i)
+noncomputable instance fintype_U (i : Fin r) : Fintype (U 𝔽q β i) := by
+  exact Fintype.ofFinite (U 𝔽q β i)
 
 -- The cardinality of the subspace `Uᵢ` is `2ⁱ`, which follows from its dimension.
-omit [DecidableEq 𝔽q] in
 lemma U_card (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
   (i : Fin r):
-    Fintype.card (U L 𝔽q β i) = (Fintype.card 𝔽q)^i.val := by
+    Fintype.card (U 𝔽q β i) = (Fintype.card 𝔽q)^i.val := by
   -- The cardinality of a vector space V is |F|^(dim V).
-  rw [Module.card_eq_pow_finrank (K := 𝔽q) (V := U (𝔽q := 𝔽q) (β := β) (i :=i))]
-  rw [finrank_U (𝔽q := 𝔽q) (β := β) (i :=i) (hβ_lin_indep := hβ_lin_indep)]
+  rw [Module.card_eq_pow_finrank (K := 𝔽q) (V := U 𝔽q β i)]
+  rw [finrank_U (hβ_lin_indep := hβ_lin_indep)]
 
-omit [Fintype L] [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [Fintype L] [DecidableEq L] [Fintype 𝔽q] in
 /--
 An essential helper lemma showing that `Uᵢ` is the union of all cosets of `Uᵢ₋₁`
 generated by scaling `βᵢ₋₁` by elements of `𝔽q`.
 -/
 lemma U_i_is_union_of_cosets (i : Fin r) (hi : 0 < i) :
-    (U L 𝔽q β i : Set L) = ⋃ (c : 𝔽q), (fun u => c • β (i-1) + u) '' (U L 𝔽q β (i - 1)) := by
+    (U 𝔽q β i : Set L) = ⋃ (c : 𝔽q), (fun u => c • β (i-1) + u) '' (U 𝔽q β (i - 1)) := by
 
-  have h_decomp : U L 𝔽q β i = U L 𝔽q β (i-1) ⊔ Submodule.span 𝔽q {β (i-1)} := by
+  have h_decomp : U 𝔽q β i = U 𝔽q β (i-1) ⊔ Submodule.span 𝔽q {β (i-1)} := by
     unfold U
     have h_ico : Set.Ico 0 i = Set.Ico 0 (i - 1) ∪ {i - 1} := by
       ext k;
@@ -164,11 +164,11 @@ lemma U_i_is_union_of_cosets (i : Fin r) (hi : 0 < i) :
     -- ⊢ ∃ x ∈ ↑(U 𝔽q β (i - 1)), ∃ y ∈ ↑(Submodule.span 𝔽q {β (i - 1)}), x + y = u + c • β (i - 1)
     exact ⟨u, hu, c • β (i-1), Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self _), rfl⟩
 
-omit [Fintype L] [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [Fintype L] [DecidableEq L] [Fintype 𝔽q]  in
 /-- The basis vector `βᵢ` is not an element of the subspace `Uᵢ`. -/
 lemma βᵢ_not_in_Uᵢ
-    (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β)) (i : Fin r):
-    β i ∉ U L 𝔽q β i := by
+    (hβ_lin_indep : LinearIndependent 𝔽q β) (i : Fin r):
+    β i ∉ U 𝔽q β i := by
   -- `βᵢ` cannot be expressed as a linear combination of `<β₀, ..., βᵢ₋₁>`.
   -- This follows from the definition of linear independence of `β`
   have h_li := linearIndependent_iff_notMem_span.mp hβ_lin_indep i
@@ -200,12 +200,12 @@ lemma βᵢ_not_in_Uᵢ
 
 -- The main theorem
 omit [Fintype L] [DecidableEq L] [Fintype 𝔽q] in
-theorem root_U_lift_down (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+theorem root_U_lift_down (hβ_lin_indep : LinearIndependent 𝔽q β)
   (i : Fin r) (h_i_add_1 : i + 1 < r) (a : L):
-  a ∈ (U L 𝔽q β (i+1)) → ∃! x: 𝔽q, a - x • β i ∈ (U L 𝔽q β i) := by
+  a ∈ (U 𝔽q β (i+1)) → ∃! x: 𝔽q, a - x • β i ∈ (U 𝔽q β i) := by
   intro h_a_mem_U_i_plus_1
   apply existsUnique_of_exists_of_unique
-  · -- PART 1: Existence -- ⊢ ∃ x, a - x • β i ∈ U L 𝔽q β i
+  · -- PART 1: Existence -- ⊢ ∃ x, a - x • β i ∈ U 𝔽q β i
     have h_ico : Set.Ico 0 (i+1) = Set.Ico 0 i ∪ {i} := by
       ext k; simp only [Set.mem_Ico, Fin.zero_le, true_and, Set.union_singleton,
         Set.Ico_insert_right, Set.mem_Icc]
@@ -217,8 +217,8 @@ theorem root_U_lift_down (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L
     rcases h_a_mem_U_i_plus_1 with ⟨u, h_u_mem_U_i, v, h_v_mem, h_a_eq⟩
     rw [Submodule.mem_span_singleton] at h_v_mem
     rcases h_v_mem with ⟨x, rfl⟩
-    -- ⊢ ∃ x, a - x • β i ∈ U L 𝔽q β i
-    use x -- ⊢ a - x • β i ∈ U L 𝔽q β i, h_a_eq : u + x • β i = a
+    -- ⊢ ∃ x, a - x • β i ∈ U 𝔽q β i
+    use x -- ⊢ a - x • β i ∈ U 𝔽q β i, h_a_eq : u + x • β i = a
     have h_a_sub_x_smul_β_i_mem_U_i : a - x • β i = u := by
       rw [h_a_eq.symm]
       norm_num
@@ -232,10 +232,10 @@ theorem root_U_lift_down (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L
     -- Since `U i` is a subspace, the difference of these two vectors is also in `U i`.
     let u_x := a - x • β i
     let u_y := a - y • β i
-    have h_diff_mem : u_y - u_x ∈ U L 𝔽q β i := Submodule.sub_mem (U L 𝔽q β i) hy hx
+    have h_diff_mem : u_y - u_x ∈ U 𝔽q β i := Submodule.sub_mem (U 𝔽q β i) hy hx
 
     -- Let's simplify the difference: `(a - y•βi) - (a - x•βi) = x•βi - y•βi = (x-y)•βi`.
-    rw [sub_sub_sub_cancel_left] at h_diff_mem -- h_diff_mem : x • β i - y • β i ∈ U L 𝔽q β i
+    rw [sub_sub_sub_cancel_left] at h_diff_mem -- h_diff_mem : x • β i - y • β i ∈ U 𝔽q β i
     rw [←sub_smul] at h_diff_mem
     -- So, we have `(x - y) • β i ∈ U i`.
     by_cases h_eq : x - y = 0
@@ -247,9 +247,9 @@ theorem root_U_lift_down (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L
       have h_β_i_not_in_U_i := βᵢ_not_in_Uᵢ (hβ_lin_indep := hβ_lin_indep) (i :=i)
       exact h_β_i_not_in_U_i h_β_i_mem
 
-omit [Fintype L] [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [Fintype L] [DecidableEq L] [Fintype 𝔽q] in
 theorem root_U_lift_up (i : Fin r) (h_i_add_1 : i + 1 < r) (a : L) (x : 𝔽q):
-  a - x • β i ∈ (U L 𝔽q β i) → a ∈ (U L 𝔽q β (i+1)) := by
+  a - x • β i ∈ (U 𝔽q β i) → a ∈ (U 𝔽q β (i+1)) := by
   intro h_a_sub_x_smul_β_i_mem_U_i
    -- We want to show `a ∈ U(i+1)`. We can rewrite `a` as `(a - x • β i) + x • β i`.
   rw [← sub_add_cancel a (x • β i)]
@@ -278,14 +278,13 @@ The degree of `Wᵢ(X)` is `|Uᵢ| = 2^i`.
 - For all `y ∈ Uᵢ`, `Wᵢ(x + y) = Wᵢ(x)` (Equation (14)).
 -/
 noncomputable def W (i : Fin r) : L[X] :=
-  univ.prod (fun u : U L 𝔽q β i => X - C u.val)
+  ∏ u : U 𝔽q β i, (X - C u.val)
 
-omit [DecidableEq 𝔽q] in
 /-- The degree of the subspace vanishing polynomial `Wᵢ(X)` is `2ⁱ`. -/
-lemma degree_W (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+lemma degree_W (hβ_lin_indep : LinearIndependent 𝔽q β)
   (i : Fin r):
-    (W L 𝔽q β i).degree = (Fintype.card 𝔽q)^i.val := by
-  have h_monic : ∀ (u: U L 𝔽q β i), Monic (X - C u.val) :=
+    (W 𝔽q β i).degree = (Fintype.card 𝔽q)^i.val := by
+  have h_monic : ∀ (u: U 𝔽q β i), Monic (X - C u.val) :=
     fun _ => Polynomial.monic_X_sub_C _
   have h_monic_Fin_univ: ∀ u ∈ (univ (α := U (𝔽q := 𝔽q) (β := β) (i :=i))),
     Monic (X - C u.val) := by
@@ -303,17 +302,16 @@ lemma degree_W (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β
   rw [U_card (𝔽q := 𝔽q) (β := β) (i :=i) (hβ_lin_indep := hβ_lin_indep)]
   rfl
 
-omit [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [DecidableEq L] [Fintype 𝔽q]  in
 /-- The subspace vanishing polynomial `Wᵢ(X)` is monic. -/
-lemma W_monic (i : Fin r):
-  (W L 𝔽q β i).Monic := by
+lemma W_monic (i : Fin r): (W 𝔽q β i).Monic := by
   unfold W
   apply Polynomial.monic_prod_of_monic
   intros u hu
   exact Polynomial.monic_X_sub_C u.val
 
-omit [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
-lemma W_ne_zero (i : Fin r) : (W L 𝔽q β i) ≠ 0 := by
+omit [DecidableEq L] [Fintype 𝔽q]  in
+lemma W_ne_zero (i : Fin r) : (W 𝔽q β i) ≠ 0 := by
   unfold W
   by_contra h_zero
   rw [prod_eq_zero_iff] at h_zero
@@ -327,17 +325,17 @@ example (i : Fin r) (h_i_eq_0 : i = 0) : Set.Ico 0 i = ∅ := by
   simp only [Set.Ico_eq_empty_iff]
   exact Nat.not_lt_zero 0
 
-omit [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [DecidableEq L] [Fintype 𝔽q]  in
 /-- The evaluation of `Wᵢ(X)` at `βᵢ` is non-zero. -/
 lemma Wᵢ_eval_βᵢ_neq_zero (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
-    (i : Fin r): (W L 𝔽q β i).eval (β i) ≠ 0 := by
+    (i : Fin r): (W 𝔽q β i).eval (β i) ≠ 0 := by
   -- Since `βᵢ ∉ Uᵢ`, `eval (Wᵢ(X)) (βᵢ)` cannot be zero.
   -- `eval(P*Q, x) = eval(P,x) * eval(Q,x)`. A product is non-zero iff all factors are non-zero.
   rw [W, eval_prod, prod_ne_zero_iff]
   intro u _
   -- We need to show `(β i - u.val) ≠ 0`, which is `β i ≠ u.val`.
   -- This is true because `βᵢ ∉ Uᵢ`.
-  have h := βᵢ_not_in_Uᵢ L 𝔽q β (hβ_lin_indep := hβ_lin_indep) i
+  have h := βᵢ_not_in_Uᵢ 𝔽q β (hβ_lin_indep := hβ_lin_indep) i
   intro eq
   have : β i = u.val := by
     have poly_eq: ((X - C u.val) : L[X]) = (1: L[X]) * (X - C u.val) := by
@@ -349,10 +347,10 @@ lemma Wᵢ_eval_βᵢ_neq_zero (hβ_lin_indep : LinearIndependent (R := 𝔽q) (
     exact eq
   exact h (this ▸ u.2)
 
-omit [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [DecidableEq L] [Fintype 𝔽q]  in
 -- `Wᵢ(X)` vanishes on `Uᵢ`
 lemma Wᵢ_vanishing (i : Fin r):
-  ∀ u ∈ U L 𝔽q β i, (W L 𝔽q β i).eval u = 0 := by
+  ∀ u ∈ U 𝔽q β i, (W 𝔽q β i).eval u = 0 := by
   -- The roots of `Wᵢ(X)` are precisely the elements of `Uᵢ`.
    -- For any `u ∈ Uᵢ`, the product `Wᵢ(X)` contains the factor `(X - u)`.
   intro u hu
@@ -361,14 +359,14 @@ lemma Wᵢ_vanishing (i : Fin r):
   use ⟨u, hu⟩
   simp only [mem_univ, eval_sub, eval_X, eval_C, sub_self, and_self]
 
-omit [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
-lemma W₀_eq_X : W L 𝔽q β 0 = X := by
+omit [DecidableEq L] [Fintype 𝔽q]  in
+lemma W₀_eq_X : W 𝔽q β 0 = X := by
   -- By definition, U ... 0 = {0}, so the vanishing polynomial is X
   rw [W]
-  have : (univ : Finset (U L 𝔽q β 0)) = {0} := by
+  have : (univ : Finset (U 𝔽q β 0)) = {0} := by
     ext x
     simp only [U, Set.Ico, mem_univ, mem_singleton, true_iff]
-    --x : ↥(U L 𝔽q β 0), ⊢ x = 0
+    --x : ↥(U 𝔽q β 0), ⊢ x = 0
     unfold U at x
     have h_empty : Set.Ico 0 (0: Fin r) = ∅ := by
       exact Set.Ico_self 0
@@ -391,9 +389,9 @@ including their recursive structure and `𝔽q`-linearity as described in Lemma 
 The proofs are done by simultaneous induction on `i`.
 -/
 
-omit [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [DecidableEq L] [Fintype 𝔽q]  in
 /-- The subspace vanishing polynomial `Wᵢ(X)` splits into linear factors over `L`. -/
-lemma W_splits (i : Fin r) : (W L 𝔽q β i).Splits (RingHom.id L) := by
+lemma W_splits (i : Fin r) : (W 𝔽q β i).Splits (RingHom.id L) := by
   unfold W
   -- The `W` polynomial is a product of factors. A product splits if every factor splits.
   apply Polynomial.splits_prod
@@ -403,19 +401,19 @@ lemma W_splits (i : Fin r) : (W L 𝔽q β i).Splits (RingHom.id L) := by
   -- The lemma for this is `Polynomial.splits_X_sub_C`.
   apply Polynomial.splits_X_sub_C
 
-omit [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [Fintype 𝔽q]  in
 /-- The roots of `Wᵢ(X)` are precisely the elements of the subspace `Uᵢ`. -/
 lemma roots_W (i : Fin r): -- converts root Multiset into (univ: Uᵢ.val.map)
-  (W L 𝔽q β i).roots = (univ : Finset (U L 𝔽q β i)).val.map (fun u => u.val) := by
+  (W 𝔽q β i).roots = (univ : Finset (U 𝔽q β i)).val.map (fun u => u.val) := by
   unfold W -- must unfold to reason on the form of `prod (X-C)`
-  let f_inner : U L 𝔽q β i → L := Subtype.val
+  let f_inner : U 𝔽q β i → L := Subtype.val
   let f_outer : L → L[X] := fun y => X - C y
   have h_inj : Function.Injective f_inner := Subtype.val_injective
   -- ⊢ (∏ u, (X - C ↑u)).roots = Multiset.map (fun u ↦ ↑u) univ.val
   rw [← prod_image (g := f_inner) (f := f_outer)]
   · -- ⊢ (∏ x ∈ image f_inner univ, f_outer x).roots =
     -- Multiset.map (fun u ↦ ↑u) univ.val
-    let s := (univ : Finset (U L 𝔽q β i)).image f_inner
+    let s := (univ : Finset (U 𝔽q β i)).image f_inner
     rw [Polynomial.roots_prod_X_sub_C (s := s)]
     -- ⊢ s.val = Multiset.map (fun u ↦ ↑u) univ.val
     apply image_val_of_injOn -- (H : Set.InjOn f s) : (image f s).1 = s.1.map f
@@ -501,38 +499,38 @@ lemma roots_comp_X_sub_C (p : L[X]) (a : L) :
 
 -- The main helper lemma, now proven using the multiplicity lemma above.
 
-omit [DecidableEq L] [DecidableEq 𝔽q] in
+omit [DecidableEq L]  in
 lemma Prod_W_comp_X_sub_C_ne_zero (i : Fin r) :
-    (univ : Finset 𝔽q).prod (fun c => (W L 𝔽q β i).comp (X - C (c • β i))) ≠ 0 := by
+    (univ : Finset 𝔽q).prod (fun c => (W 𝔽q β i).comp (X - C (c • β i))) ≠ 0 := by
   by_contra h_zero
   rw [prod_eq_zero_iff] at h_zero
   rcases h_zero with ⟨c, hc, h_zero⟩
   rw [Polynomial.comp_eq_zero_iff] at h_zero
   cases h_zero with
   | inl h1 =>
-    exact (W_ne_zero L 𝔽q β i) h1
+    exact (W_ne_zero 𝔽q β i) h1
   | inr h1 =>
     simp only [coeff_sub, coeff_X_zero, coeff_C_zero, zero_sub, map_neg, sub_eq_neg_self,
       X_ne_zero, and_false] at h1
 
-omit [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [Fintype 𝔽q]  in
 /--
 The polynomial `Wᵢ(X)` has simple roots (multiplicity 1) for each element in the
 subspace `Uᵢ`, and no other roots.
 -/
 lemma rootMultiplicity_W (i : Fin r) (a : L) :
-    rootMultiplicity a (W L 𝔽q β i) = if a ∈ (U L 𝔽q β i : Set L) then 1 else 0 := by
+    rootMultiplicity a (W 𝔽q β i) = if a ∈ (U 𝔽q β i : Set L) then 1 else 0 := by
   -- The multiplicity of root `a` is its count in the multiset of roots.
   rw [←Polynomial.count_roots, roots_W]
   -- The roots of `W` are the image of `Subtype.val` over the elements of the subspace `Uᵢ`.
   -- So we need to count `a` in the multiset `map Subtype.val ...`
   rw [Multiset.count_map]
-  -- ⊢ (Multiset.filter (fun a_1 ↦ a = ↑a_1) univ.val).card = if a ∈ ↑(U L 𝔽q β i) then 1 else 0
+  -- ⊢ (Multiset.filter (fun a_1 ↦ a = ↑a_1) univ.val).card = if a ∈ ↑(U 𝔽q β i) then 1 else 0
 -- The goal is now:
   -- ⊢ (Multiset.filter (fun u ↦ a = u.val) ...).card = if a ∈ Uᵢ then 1 else 0
 
   -- We prove this by cases, depending on whether `a` is in the subspace `Uᵢ`.
-  by_cases h_mem : a ∈ U L 𝔽q β i
+  by_cases h_mem : a ∈ U 𝔽q β i
 
   · -- Case 1: `a` is in the subspace `Uᵢ`.
     -- The RHS of our goal becomes 1.
@@ -544,7 +542,7 @@ lemma rootMultiplicity_W (i : Fin r) (a : L) :
     -- ⊢ (Multiset.filter (fun a_1 ↦ a = ↑a_1) univ.val).card = 1
 
     -- Since `a ∈ Uᵢ`, there exists some `u : Uᵢ` such that `u.val = a`
-    have h_exists : ∃ u : U L 𝔽q β i, u.val = a := by
+    have h_exists : ∃ u : U 𝔽q β i, u.val = a := by
       exact CanLift.prf a h_mem
     rcases h_exists with ⟨u, rfl⟩ -- This gives us the `u` such that `u.val = a`.
 
@@ -573,12 +571,12 @@ lemma rootMultiplicity_W (i : Fin r) (a : L) :
     simp only [SetLike.mem_coe, h_mem, ↓reduceIte]
 
     -- Since `a ∈ Uᵢ`, there exists some `u : Uᵢ` such that `u.val = a`
-    have h_ne_exists_a : ¬∃ u : U L 𝔽q β i, u.val = a := by
+    have h_ne_exists_a : ¬∃ u : U 𝔽q β i, u.val = a := by
       by_contra h_u_val_eq_a -- h_u_val_eq_a : ∃ u, ↑u = a
       rcases h_u_val_eq_a with ⟨u, rfl⟩ -- This gives us the `u` such that `u.val = a`.
-      exact h_mem u.property -- lift from `U L 𝔽q β i` to `L` to get a contradiction
+      exact h_mem u.property -- lift from `U 𝔽q β i` to `L` to get a contradiction
     have h_filter_eq_empty :
-      Multiset.filter (fun (u₁ : U L 𝔽q β i) => a = u₁.val) univ.val = 0 := by
+      Multiset.filter (fun (u₁ : U 𝔽q β i) => a = u₁.val) univ.val = 0 := by
       -- Use count-based equality for multisets
       ext v
       -- ⊢ count v (filter (fun u₁ => a = u₁.val) univ.val) = count v 0
@@ -589,51 +587,51 @@ lemma rootMultiplicity_W (i : Fin r) (a : L) :
       exact h_ne_exists_a ⟨v, h_v_eq_a.symm⟩
     rw [h_filter_eq_empty, Multiset.card_zero]
 
-omit [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [Fintype 𝔽q]  in
 lemma eval_W_eq_zero_iff_in_U (i : Fin r) (a : L) :
-  (W L 𝔽q β i).eval a = 0 ↔ a ∈ U L 𝔽q β i := by
+  (W 𝔽q β i).eval a = 0 ↔ a ∈ U 𝔽q β i := by
   constructor
   · -- Forward direction: Wᵢ(a) = 0 → a ∈ Uᵢ
-    intro h_eval_zero -- h_eval_zero : eval a (W L 𝔽q β i) = 0
+    intro h_eval_zero -- h_eval_zero : eval a (W 𝔽q β i) = 0
     -- If Wᵢ(a) = 0, then a is a root of Wᵢ
-    have h_root_W : (W L 𝔽q β i).IsRoot a := by
+    have h_root_W : (W 𝔽q β i).IsRoot a := by
       rw [IsRoot.def]
       exact h_eval_zero
     -- theorem rootMultiplicity_pos {p : R[X]} (hp : p ≠ 0) {x : R} :
     -- 0 < rootMultiplicity x p ↔ IsRoot p x :=
-    have h_root_W_pos : 0 < rootMultiplicity a (W L 𝔽q β i) := by
+    have h_root_W_pos : 0 < rootMultiplicity a (W 𝔽q β i) := by
       simp only [rootMultiplicity_pos', ne_eq, IsRoot.def]
       constructor
-      · push_neg; exact W_ne_zero L 𝔽q β i
+      · push_neg; exact W_ne_zero 𝔽q β i
       · exact h_root_W
     rw [rootMultiplicity_W] at h_root_W_pos
-    by_cases h_a_in_U : a ∈ U L 𝔽q β i
+    by_cases h_a_in_U : a ∈ U 𝔽q β i
     · simp only [h_a_in_U]
     · simp only [SetLike.mem_coe, h_a_in_U, ↓reduceIte, lt_self_iff_false] at h_root_W_pos
   · -- Reverse direction: a ∈ Uᵢ → Wᵢ(a) = 0
     intro h_a_in_U
     -- This is exactly what Wᵢ_vanishing proves
-    exact Wᵢ_vanishing L 𝔽q β i a h_a_in_U
+    exact Wᵢ_vanishing 𝔽q β i a h_a_in_U
 
 lemma rootMultiplicity_prod_W_comp_X_sub_C
-  (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+  (hβ_lin_indep : LinearIndependent 𝔽q β)
     (i : Fin r) (h_i_add_1: i + 1 < r) (a : L) :
-    rootMultiplicity a ((univ : Finset 𝔽q).prod (fun c => (W L 𝔽q β i).comp (X - C (c • β i)))) =
-    if a ∈ (U L 𝔽q β (i+1) : Set L) then 1 else 0 := by
+    rootMultiplicity a ((univ : Finset 𝔽q).prod (fun c => (W 𝔽q β i).comp (X - C (c • β i)))) =
+    if a ∈ (U 𝔽q β (i+1) : Set L) then 1 else 0 := by
   rw [←Polynomial.count_roots]
-  set f := fun c: 𝔽q => (W L 𝔽q β i).comp (X - C (c • β i)) with hf
-  -- ⊢ Multiset.count a (univ.prod f).roots = if a ∈ ↑(U L 𝔽q β (i + 1)) then 1 else 0
-  have h_prod_ne_zero: univ.prod f ≠ 0 := Prod_W_comp_X_sub_C_ne_zero L 𝔽q β i
+  set f := fun c: 𝔽q => (W 𝔽q β i).comp (X - C (c • β i)) with hf
+  -- ⊢ Multiset.count a (univ.prod f).roots = if a ∈ ↑(U 𝔽q β (i + 1)) then 1 else 0
+  have h_prod_ne_zero: univ.prod f ≠ 0 := Prod_W_comp_X_sub_C_ne_zero 𝔽q β i
   rw [roots_prod (f := f) (s := univ (α := 𝔽q)) h_prod_ne_zero]
   set roots_f := fun c: 𝔽q => (f c).roots with hroots_f
   rw [Multiset.count_bind]
   -- ⊢ (Multiset.map (fun b ↦ Multiset.count a (roots_f b)) univ.val).sum
-  -- = if a ∈ ↑(U L 𝔽q β (i + 1)) then 1 else 0
+  -- = if a ∈ ↑(U 𝔽q β (i + 1)) then 1 else 0
   have h_roots_f_eq_roots_W : ∀ b : 𝔽q,
-    roots_f b = (W L 𝔽q β i).roots.map (fun r => r + (b • β i)) := by
+    roots_f b = (W 𝔽q β i).roots.map (fun r => r + (b • β i)) := by
     intro b
     rw [hroots_f, hf]
-    exact roots_comp_X_sub_C (p := (W L 𝔽q β i)) (a := (b • β i))
+    exact roots_comp_X_sub_C (p := (W 𝔽q β i)) (a := (b • β i))
   simp_rw [h_roots_f_eq_roots_W]
 
   set shift_up := fun x: 𝔽q => fun r: L => r + x • β i with hshift_up
@@ -652,15 +650,15 @@ lemma rootMultiplicity_prod_W_comp_X_sub_C
     enter [1]
     enter [r]
     rw [←h_shift_up_all x r] -- rewrite to another notation
-  -- ⊢ ∑ x, Multiset.count (shift_up x (a - x • β i)) (Multiset.map (shift_up x) (W L 𝔽q β i).roots)
-  -- = if a ∈ ↑(U L 𝔽q β (i + 1)) then 1 else 0
+  -- ⊢ ∑ x, Multiset.count (shift_up x (a - x • β i)) (Multiset.map (shift_up x) (W 𝔽q β i).roots)
+  -- = if a ∈ ↑(U 𝔽q β (i + 1)) then 1 else 0
   have h_shift_up_inj: ∀ x: 𝔽q, Function.Injective (shift_up x) := by
     intro x
     unfold shift_up
     exact add_left_injective (x • β i)
   have h_count_map: ∀ x: 𝔽q,
-    Multiset.count (shift_up x (a - x • β i)) (Multiset.map (shift_up x) (W L 𝔽q β i).roots) =
-    Multiset.count (a - x • β i) (W L 𝔽q β i).roots := by
+    Multiset.count (shift_up x (a - x • β i)) (Multiset.map (shift_up x) (W 𝔽q β i).roots) =
+    Multiset.count (a - x • β i) (W 𝔽q β i).roots := by
     -- transform to counting (a - x • β i) in the roots of Wᵢ
     intro x
     have h_shift_up_inj_x: Function.Injective (shift_up x) := h_shift_up_inj x
@@ -668,40 +666,41 @@ lemma rootMultiplicity_prod_W_comp_X_sub_C
   conv_lhs =>
     enter [2, x]
     rw [h_count_map x]
-  -- ⊢ ∑ x, Multiset.count (a - x • β i) (W L 𝔽q β i).roots
-  -- = if a ∈ ↑(U L 𝔽q β (i + 1)) then 1 else 0
-  have h_root_lift_down := root_U_lift_down L 𝔽q β hβ_lin_indep i h_i_add_1 a
-  have h_root_lift_up := root_U_lift_up L 𝔽q β i h_i_add_1 a
+  -- ⊢ ∑ x, Multiset.count (a - x • β i) (W 𝔽q β i).roots
+  -- = if a ∈ ↑(U 𝔽q β (i + 1)) then 1 else 0
+  have h_root_lift_down := root_U_lift_down 𝔽q β hβ_lin_indep i h_i_add_1 a
+  have h_root_lift_up := root_U_lift_up 𝔽q β i h_i_add_1 a
   conv_lhs =>
     enter [2, x]
     simp only [count_roots]
     rw [rootMultiplicity_W]
-  by_cases h_a_mem_U_i : a ∈ ↑(U L 𝔽q β (i + 1))
-  · -- ⊢ (∑ x, if a - x • β i ∈ ↑(U L 𝔽q β i) then 1 else 0)
-    -- = if a ∈ ↑(U L 𝔽q β (i + 1)) then 1 else 0
-    have h_true: (a ∈ ↑(U L 𝔽q β (i + 1))) = True := by simp only [h_a_mem_U_i]
+  by_cases h_a_mem_U_i : a ∈ ↑(U 𝔽q β (i + 1))
+  · -- ⊢ (∑ x, if a - x • β i ∈ ↑(U 𝔽q β i) then 1 else 0)
+    -- = if a ∈ ↑(U 𝔽q β (i + 1)) then 1 else 0
+    have h_true: (a ∈ ↑(U 𝔽q β (i + 1))) = True := by simp only [h_a_mem_U_i]
     rcases h_root_lift_down h_a_mem_U_i with ⟨x0, hx0, hx0_unique⟩
     conv =>
       rhs
-      -- | if a ∈ ↑(U L 𝔽q β (i + 1)) then 1 else 0 => reduce this to 1
+      -- | if a ∈ ↑(U 𝔽q β (i + 1)) then 1 else 0 => reduce this to 1
       enter [1]
       exact h_true -- maybe there can be a better way to do this
     rw [ite_true]
-    -- ⊢ (∑ x, if a - x • β i ∈ ↑(U L 𝔽q β i) then 1 else 0) = 1
+    classical
+    -- ⊢ (∑ x, if a - x • β i ∈ ↑(U 𝔽q β i) then 1 else 0) = 1
     have h_true: ∀ x: 𝔽q,
-      if x = x0 then a - x • β i ∈ ↑(U L 𝔽q β i) else a - x • β i ∉ ↑(U L 𝔽q β i) := by
+      if x = x0 then a - x • β i ∈ ↑(U 𝔽q β i) else a - x • β i ∉ ↑(U 𝔽q β i) := by
       intro x
       by_cases h_x_eq_x0 : x = x0
-      · rw [if_pos h_x_eq_x0] -- ⊢ a - x • β i ∈ U L 𝔽q β i
+      · rw [if_pos h_x_eq_x0] -- ⊢ a - x • β i ∈ U 𝔽q β i
         rw [←h_x_eq_x0] at hx0
         exact hx0
-      · rw [if_neg h_x_eq_x0] -- ⊢ a - x • β i ∉ U L 𝔽q β i
+      · rw [if_neg h_x_eq_x0] -- ⊢ a - x • β i ∉ U 𝔽q β i
         by_contra h_mem
         have h1 := hx0_unique x
         simp only [h_mem, forall_const] at h1
         contradiction
 
-    have h_true_x: ∀ x: 𝔽q, (a - x • β i ∈ ↑(U L 𝔽q β i)) = if x = x0 then True else False := by
+    have h_true_x: ∀ x: 𝔽q, (a - x • β i ∈ ↑(U 𝔽q β i)) = if x = x0 then True else False := by
       intro x
       by_cases h_x_eq_x0 : x = x0
       · rw [if_pos h_x_eq_x0]
@@ -720,19 +719,19 @@ lemma rootMultiplicity_prod_W_comp_X_sub_C
       simp only [SetLike.mem_coe, h_true_x x, if_false_right, and_true]
     rw [sum_ite_eq']
     simp only [mem_univ, ↓reduceIte]
-  · -- ⊢ (∑ x, if a - x • β i ∈ ↑(U L 𝔽q β i) then 1 else 0)
-    -- = if a ∈ ↑(U L 𝔽q β (i + 1)) then 1 else 0
-    have h_false: (a ∈ ↑(U L 𝔽q β (i + 1))) = False := by simp only [h_a_mem_U_i]
+  · -- ⊢ (∑ x, if a - x • β i ∈ ↑(U 𝔽q β i) then 1 else 0)
+    -- = if a ∈ ↑(U 𝔽q β (i + 1)) then 1 else 0
+    have h_false: (a ∈ ↑(U 𝔽q β (i + 1))) = False := by simp only [h_a_mem_U_i]
     conv =>
-      rhs -- | if a ∈ ↑(U L 𝔽q β (i + 1)) then 1 else 0 => reduce this to 1
+      rhs -- | if a ∈ ↑(U 𝔽q β (i + 1)) then 1 else 0 => reduce this to 1
       enter [1]
       exact h_false -- maybe there can be a better way to do this
     rw [ite_false]
 
-    have h_zero_x: ∀ x: 𝔽q, (a - x • β i ∈ ↑(U L 𝔽q β i)) = False := by
+    have h_zero_x: ∀ x: 𝔽q, (a - x • β i ∈ ↑(U 𝔽q β i)) = False := by
       intro x
       by_contra h_mem
-      simp only [eq_iff_iff, iff_false, not_not] at h_mem -- h_mem : a - x • β i ∈ U L 𝔽q β i
+      simp only [eq_iff_iff, iff_false, not_not] at h_mem -- h_mem : a - x • β i ∈ U 𝔽q β i
       have h_a_mem_U_i := h_root_lift_up x h_mem
       contradiction
 
@@ -749,11 +748,11 @@ This follows the first line of the proof for (i) in the description.
 -/
 lemma W_prod_comp_decomposition (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
     (i : Fin r) (hi : i > 0) :
-    (W L 𝔽q β i) = ∏ c: 𝔽q, (W L 𝔽q β (i-1)).comp (X - C (c • β (i-1))) := by
+    (W 𝔽q β i) = ∏ c: 𝔽q, (W 𝔽q β (i-1)).comp (X - C (c • β (i-1))) := by
   -- ⊢ W 𝔽q β i = ∏ c, (W 𝔽q β (i - 1)).comp (X - C (c • β (i - 1)))
   -- Define P and Q for clarity
-  set P := W L 𝔽q β i
-  set Q := ∏ c: 𝔽q, (W L 𝔽q β (i-1)).comp (X - C (c • β (i-1)))
+  set P := W 𝔽q β i
+  set Q := ∏ c: 𝔽q, (W 𝔽q β (i-1)).comp (X - C (c • β (i-1)))
 
 -- c : 𝔽q => univ
 -- c ∈ finsetX
@@ -771,7 +770,7 @@ lemma W_prod_comp_decomposition (hβ_lin_indep : LinearIndependent (R := 𝔽q) 
     · conv_lhs => rw [natDegree_sub_C, natDegree_X]
       norm_num
   -- 2. Show P and Q SPLIT over L.
-  have hP_splits : P.Splits (RingHom.id L) := W_splits L 𝔽q β i
+  have hP_splits : P.Splits (RingHom.id L) := W_splits 𝔽q β i
   have hQ_splits : Q.Splits (RingHom.id L) := by
     apply Polynomial.splits_prod
     intro c _
@@ -780,7 +779,7 @@ lemma W_prod_comp_decomposition (hβ_lin_indep : LinearIndependent (R := 𝔽q) 
     apply Splits.comp_of_degree_le_one
     · exact degree_X_sub_C_le (c • β (i - 1))
     · -- ⊢ Splits (RingHom.id L) (W 𝔽q β (i - 1))
-      exact W_splits L 𝔽q β (i-1)
+      exact W_splits 𝔽q β (i-1)
 
   -- 3. Show P and Q have the same ROOTS.
   have h_roots_eq : P.roots = Q.roots := by
@@ -794,7 +793,7 @@ lemma W_prod_comp_decomposition (hβ_lin_indep : LinearIndependent (R := 𝔽q) 
         rw [Fin.val_sub_one (a := i) (h_a_sub_1 := by omega)]
         omega
       )]
-    -- ⊢ (if u ∈ ↑(U L 𝔽q β i) then 1 else 0) = if u ∈ ↑(U L 𝔽q β (i - 1 + 1)) then 1 else 0
+    -- ⊢ (if u ∈ ↑(U 𝔽q β i) then 1 else 0) = if u ∈ ↑(U 𝔽q β (i - 1 + 1)) then 1 else 0
     have h_i : i - 1 + 1 = i := by simp only [sub_add_cancel]
     rw [h_i]
 
@@ -803,7 +802,7 @@ lemma W_prod_comp_decomposition (hβ_lin_indep : LinearIndependent (R := 𝔽q) 
   have hQ_eq_prod := Polynomial.eq_prod_roots_of_monic_of_splits_id hQ_monic hQ_splits
   rw [hP_eq_prod, hQ_eq_prod, h_roots_eq]
 
-omit [Fintype L] [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [Fintype L] [DecidableEq L] [Fintype 𝔽q]  in
 -- A helper lemma that IsLinearMap implies the composition property.
 -- This follows from the fact that a polynomial whose evaluation map is linear
 -- must be a "linearized polynomial" (or q-polynomial).
@@ -827,19 +826,19 @@ lemma inductive_rec_form_W_comp (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
     (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
     (i : Fin r) (h_i_add_1: i + 1 < r)
     (h_prev_linear_map: IsLinearMap (R := 𝔽q) (M := L[X]) (M₂ := L[X])
-      (f := fun inner_p ↦ (W L 𝔽q β i).comp inner_p))
-    : ∀ p: L[X], (W L 𝔽q β (i + 1)).comp p =
-      ((W L 𝔽q β i).comp p) ^ Fintype.card 𝔽q -
-        C (eval (β i) (W L 𝔽q β i)) ^ (Fintype.card 𝔽q - 1) * ((W L 𝔽q β i).comp p) := by
+      (f := fun inner_p ↦ (W 𝔽q β i).comp inner_p))
+    : ∀ p: L[X], (W 𝔽q β (i + 1)).comp p =
+      ((W 𝔽q β i).comp p) ^ Fintype.card 𝔽q -
+        C (eval (β i) (W 𝔽q β i)) ^ (Fintype.card 𝔽q - 1) * ((W 𝔽q β i).comp p) := by
   intro p
-  set W_i := W L 𝔽q β i
+  set W_i := W 𝔽q β i
   set q := Fintype.card 𝔽q
   set v := W_i.eval (β i)
 
   -- First, we must prove that v is non-zero to use its inverse.
   have hv_ne_zero : v ≠ 0 := by
     unfold v W_i
-    exact Wᵢ_eval_βᵢ_neq_zero L 𝔽q β hβ_lin_indep i
+    exact Wᵢ_eval_βᵢ_neq_zero 𝔽q β hβ_lin_indep i
 
   -- Proof flow:
   -- `Wᵢ₊₁(X) = ∏_{c ∈ 𝔽q} (Wᵢ ∘ (X - c • βᵢ))` -- from W_prod_comp_decomposition
@@ -859,9 +858,9 @@ lemma inductive_rec_form_W_comp (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
     exact h_v_smul_v_inv_eq_one
   -- The main proof using a chain of equalities (the `calc` block).
   calc
-    (W L 𝔽q β (i + 1)).comp p
+    (W 𝔽q β (i + 1)).comp p
     _ = (∏ c: 𝔽q, (W_i).comp (X - C (c • β i))).comp p := by
-      have h_res := W_prod_comp_decomposition L 𝔽q β hβ_lin_indep (i+1) (by
+      have h_res := W_prod_comp_decomposition 𝔽q β hβ_lin_indep (i+1) (by
         apply Fin.mk_lt_of_lt_val
         rw [Fin.val_add_one (a := i) (h_a_add_1 := h_i_add_1), Nat.zero_mod]
         omega
@@ -886,7 +885,7 @@ lemma inductive_rec_form_W_comp (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
       congr
       -- ⊢ eval (c • β i) W_i = c • v
       -- Use the linearity of the evaluation map, not the composition map
-      have h_eval_linear := AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval (f := (W L 𝔽q β i))
+      have h_eval_linear := AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval (f := (W 𝔽q β i))
         (h_f_linear := h_prev_linear_map)
       exact h_eval_linear.map_smul c (β i)
     -- Step 4: Perform the final algebraic transformation.
@@ -962,14 +961,14 @@ lemma inductive_linear_map_W (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
     (h_Fq_char_prime: Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
     (i : Fin r) (h_i_add_1: i + 1 < r)
-    (h_prev_linear_map: IsLinearMap 𝔽q (f := fun inner_p ↦ (W L 𝔽q β i).comp inner_p))
-    : IsLinearMap 𝔽q (f := fun inner_p ↦ (W L 𝔽q β (i + 1)).comp inner_p) := by
+    (h_prev_linear_map: IsLinearMap 𝔽q (f := fun inner_p ↦ (W 𝔽q β i).comp inner_p))
+    : IsLinearMap 𝔽q (f := fun inner_p ↦ (W 𝔽q β (i + 1)).comp inner_p) := by
 
   have h_rec_form := inductive_rec_form_W_comp (h_Fq_card_gt_1 := h_Fq_card_gt_1)
     (hβ_lin_indep := hβ_lin_indep) (h_prev_linear_map := h_prev_linear_map) (i :=i)
 
   set q := Fintype.card 𝔽q
-  set v := (W L 𝔽q β i).eval (β i)
+  set v := (W 𝔽q β i).eval (β i)
 
   -- `∀ f(X), f(X) ∈ L[X]`:
   constructor
@@ -981,21 +980,21 @@ lemma inductive_linear_map_W (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
     -- `= (Wᵢ(f(X))² - v • Wᵢ(f(X))) + (Wᵢ(g(X))² - v • Wᵢ(g(X)))` -- h_rec_form
     -- `= Wᵢ₊₁(f(X)) + Wᵢ₊₁(g(X))` -- Q.E.D.
 
-    -- ⊢ (W L 𝔽q β (i + 1)).comp (x + y) = (W L 𝔽q β (i + 1)).comp x + (W L 𝔽q β (i + 1)).comp y
+    -- ⊢ (W 𝔽q β (i + 1)).comp (x + y) = (W 𝔽q β (i + 1)).comp x + (W 𝔽q β (i + 1)).comp y
     calc
-      _ = ((W L 𝔽q β i).comp (f + g))^q - C v ^ (q - 1) * ((W L 𝔽q β i).comp (f + g)) := by
+      _ = ((W 𝔽q β i).comp (f + g))^q - C v ^ (q - 1) * ((W 𝔽q β i).comp (f + g)) := by
         rw [h_rec_form h_i_add_1]
-      _ = ((W L 𝔽q β i).comp f)^q + ((W L 𝔽q β i).comp g)^q
-        - C v ^ (q - 1) * ((W L 𝔽q β i).comp f) - C v ^ (q - 1) * ((W L 𝔽q β i).comp g) := by
+      _ = ((W 𝔽q β i).comp f)^q + ((W 𝔽q β i).comp g)^q
+        - C v ^ (q - 1) * ((W 𝔽q β i).comp f) - C v ^ (q - 1) * ((W 𝔽q β i).comp g) := by
         rw [h_prev_linear_map.map_add]
         rw [AdditiveNTT.frobenius_identity_in_algebra (h_Fq_char_prime := h_Fq_char_prime)]
         rw [left_distrib]
         unfold q
         abel_nf
-      _ = (((W L 𝔽q β i).comp f)^q - C v ^ (q - 1) * ((W L 𝔽q β i).comp f))
-        + (((W L 𝔽q β i).comp g)^q - C v ^ (q - 1) * ((W L 𝔽q β i).comp g)) := by
+      _ = (((W 𝔽q β i).comp f)^q - C v ^ (q - 1) * ((W 𝔽q β i).comp f))
+        + (((W 𝔽q β i).comp g)^q - C v ^ (q - 1) * ((W 𝔽q β i).comp g)) := by
         abel_nf
-      _ = (W L 𝔽q β (i+1)).comp f + (W L 𝔽q β (i+1)).comp g := by
+      _ = (W 𝔽q β (i+1)).comp f + (W 𝔽q β (i+1)).comp g := by
         unfold q
         rw [h_rec_form h_i_add_1 f]
         rw [h_rec_form h_i_add_1 g]
@@ -1012,39 +1011,39 @@ lemma inductive_linear_map_W (h_Fq_card_gt_1: Fintype.card 𝔽q > 1)
       intro t
       rw [h_c_smul_to_algebraMap_smul]
       exact smul_eq_C_mul ((algebraMap 𝔽q L) c)
-    -- ⊢ (W L 𝔽q β (i + 1)).comp (c • x) = c • (W L 𝔽q β (i + 1)).comp x
+    -- ⊢ (W 𝔽q β (i + 1)).comp (c • x) = c • (W 𝔽q β (i + 1)).comp x
     calc
-      _ = ((W L 𝔽q β i).comp (c • f))^q - C v ^ (q - 1) * ((W L 𝔽q β i).comp (c • f)) := by
+      _ = ((W 𝔽q β i).comp (c • f))^q - C v ^ (q - 1) * ((W 𝔽q β i).comp (c • f)) := by
         rw [h_rec_form h_i_add_1 (c • f)]
-      _ = (C (algebraMap 𝔽q L c) * (W L 𝔽q β i).comp f)^q
-        - C v ^ (q - 1) * (C (algebraMap 𝔽q L c) * (W L 𝔽q β i).comp f) := by
+      _ = (C (algebraMap 𝔽q L c) * (W 𝔽q β i).comp f)^q
+        - C v ^ (q - 1) * (C (algebraMap 𝔽q L c) * (W 𝔽q β i).comp f) := by
         rw [h_prev_linear_map.map_smul]
         rw [mul_pow]
         simp_rw [h_c_smul_to_C_algebraMap_mul]
         congr
         rw [mul_pow]
-      _ = C (algebraMap 𝔽q L (c^q)) * ((W L 𝔽q β i).comp f)^q
-        - C v ^ (q - 1) * (C (algebraMap 𝔽q L c) * (W L 𝔽q β i).comp f) := by
+      _ = C (algebraMap 𝔽q L (c^q)) * ((W 𝔽q β i).comp f)^q
+        - C v ^ (q - 1) * (C (algebraMap 𝔽q L c) * (W 𝔽q β i).comp f) := by
         rw [mul_pow]
         congr -- ⊢ C ((algebraMap 𝔽q L) c) ^ q = C ((algebraMap 𝔽q L) (c ^ q))
         rw [←C_pow]
         simp_rw [algebraMap.coe_pow c q]
-      _ = C (algebraMap 𝔽q L (c^q)) * ((W L 𝔽q β i).comp f)^q
-        - C v ^ (q - 1) * (C (algebraMap 𝔽q L c) * (W L 𝔽q β i).comp f) := by
+      _ = C (algebraMap 𝔽q L (c^q)) * ((W 𝔽q β i).comp f)^q
+        - C v ^ (q - 1) * (C (algebraMap 𝔽q L c) * (W 𝔽q β i).comp f) := by
         -- use Fermat's Little Theorem (X^q = X)
         simp only [map_pow]
-      _ = C (algebraMap 𝔽q L (c)) * ((W L 𝔽q β i).comp f)^q
-        - C v ^ (q - 1) * (C (algebraMap 𝔽q L c) * (W L 𝔽q β i).comp f) := by
+      _ = C (algebraMap 𝔽q L (c)) * ((W 𝔽q β i).comp f)^q
+        - C v ^ (q - 1) * (C (algebraMap 𝔽q L c) * (W 𝔽q β i).comp f) := by
         rw [FiniteField.pow_card]
-      _ = C (algebraMap 𝔽q L c) * (((W L 𝔽q β i).comp f)^q
-        - C v ^ (q - 1) * (W L 𝔽q β i).comp f) := by
+      _ = C (algebraMap 𝔽q L c) * (((W 𝔽q β i).comp f)^q
+        - C v ^ (q - 1) * (W 𝔽q β i).comp f) := by
         rw [←mul_assoc]
         conv_lhs => rw [mul_comm (a := C v ^ (q - 1)) (b := C (algebraMap 𝔽q L c))]; rw [mul_assoc]
         exact
           Eq.symm
-            (mul_sub_left_distrib (C ((algebraMap 𝔽q L) c)) ((W L 𝔽q β i).comp f ^ q)
-              (C v ^ (q - 1) * (W L 𝔽q β i).comp f))
-      _ = C (algebraMap 𝔽q L c) * (W L 𝔽q β (i + 1)).comp f := by
+            (mul_sub_left_distrib (C ((algebraMap 𝔽q L) c)) ((W 𝔽q β i).comp f ^ q)
+              (C v ^ (q - 1) * (W 𝔽q β i).comp f))
+      _ = C (algebraMap 𝔽q L c) * (W 𝔽q β (i + 1)).comp f := by
         rw [h_rec_form h_i_add_1 f]
       _ = _ := by
         rw [h_c_smul_to_C_algebraMap_mul]
@@ -1061,13 +1060,13 @@ theorem W_linearity
     (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
     (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
     (i : Fin r)
-      : IsLinearMap 𝔽q (f := fun inner_p ↦ (W L 𝔽q β i).comp inner_p) := by
+      : IsLinearMap 𝔽q (f := fun inner_p ↦ (W 𝔽q β i).comp inner_p) := by
   induction i using Fin.succRecOnSameFinType with
   | zero =>
     -- Base Case: i = 0 => Prove W₀ is linear.
     unfold W
-    have h_U0 : (univ : Finset (U L 𝔽q β 0)) = {0} := by
-      ext u -- u : ↥(U L 𝔽q β 0)
+    have h_U0 : (univ : Finset (U 𝔽q β 0)) = {0} := by
+      ext u -- u : ↥(U 𝔽q β 0)
       simp only [mem_univ, true_iff, mem_singleton]
       -- ⊢ u = 0
       by_contra h
@@ -1087,8 +1086,8 @@ theorem W_linearity
     }
   | succ j jh p =>
     -- Inductive Step: Assume properties hold for `j`, prove for `j+1`.
-    have h_linear_map: (IsLinearMap 𝔽q (f := fun inner_p ↦ (W L 𝔽q β (j + 1)).comp inner_p)) := by
-      exact inductive_linear_map_W L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep (i := j)
+    have h_linear_map: (IsLinearMap 𝔽q (f := fun inner_p ↦ (W 𝔽q β (j + 1)).comp inner_p)) := by
+      exact inductive_linear_map_W 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep (i := j)
         (h_i_add_1 := by omega) (h_prev_linear_map := p)
 
     exact h_linear_map
@@ -1106,11 +1105,11 @@ theorem W_linear_comp_decomposition (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
     (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
     (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
     (i : Fin r) (h_i_add_1 : i + 1 < r):
-    ∀ p: L[X], (W L 𝔽q β (i + 1)).comp p =
-      ((W L 𝔽q β i).comp p) ^ Fintype.card 𝔽q -
-        C (eval (β i) (W L 𝔽q β i)) ^ (Fintype.card 𝔽q - 1) * ((W L 𝔽q β i).comp p) := by
-  have h_linear := W_linearity L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep (i :=i)
-  exact inductive_rec_form_W_comp L 𝔽q β h_Fq_card_gt_1 hβ_lin_indep h_i_add_1 (i :=i) h_linear
+    ∀ p: L[X], (W 𝔽q β (i + 1)).comp p =
+      ((W 𝔽q β i).comp p) ^ Fintype.card 𝔽q -
+        C (eval (β i) (W 𝔽q β i)) ^ (Fintype.card 𝔽q - 1) * ((W 𝔽q β i).comp p) := by
+  have h_linear := W_linearity 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep (i :=i)
+  exact inductive_rec_form_W_comp 𝔽q β h_Fq_card_gt_1 hβ_lin_indep h_i_add_1 (i :=i) h_linear
 
 /-- The additive property of `Wᵢ`: `Wᵢ(x + y) = Wᵢ(x) + Wᵢ(y)`. -/
 lemma W_is_additive
@@ -1118,17 +1117,17 @@ lemma W_is_additive
   (h_Fq_char_prime: Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
   (i : Fin r):
-  IsLinearMap (R := 𝔽q) (M := L) (M₂ := L) (f := fun x ↦ (W L 𝔽q β i).eval x) := by
-  exact AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval (f := (W L 𝔽q β i))
-    (h_f_linear := W_linearity L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep (i :=i))
+  IsLinearMap (R := 𝔽q) (M := L) (M₂ := L) (f := fun x ↦ (W 𝔽q β i).eval x) := by
+  exact AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval (f := (W 𝔽q β i))
+    (h_f_linear := W_linearity 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep (i :=i))
 
 theorem kernel_W_eq_U
   (h_Fq_card_gt_1 : Fintype.card 𝔽q > 1)
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
   (i : Fin r):
-  LinearMap.ker (poly_eval_linear_map (W L 𝔽q β i)
-    (W_is_additive L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)) = U L 𝔽q β i := by
+  LinearMap.ker (poly_eval_linear_map (W 𝔽q β i)
+    (W_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i)) = U 𝔽q β i := by
   ext x
   -- Unfold the definition of kernel membership and polynomial evaluation.
   simp_rw [LinearMap.mem_ker, poly_eval_linear_map]
@@ -1141,16 +1140,16 @@ lemma W_add_U_invariant
   (h_Fq_char_prime: Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
   (i : Fin r):
-  ∀ x : L, ∀ y ∈ U L 𝔽q β i, (W L 𝔽q β i).eval (x + y) = (W L 𝔽q β i).eval x := by
+  ∀ x : L, ∀ y ∈ U 𝔽q β i, (W 𝔽q β i).eval (x + y) = (W 𝔽q β i).eval x := by
   intro x y hy
-  rw [(W_is_additive L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep (i :=i)).map_add]
-  rw [Wᵢ_vanishing L 𝔽q β i y hy, add_zero]
+  rw [(W_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep (i :=i)).map_add]
+  rw [Wᵢ_vanishing 𝔽q β i y hy, add_zero]
 
 /-! # Normalized Subspace Vanishing Polynomials `Ŵᵢ(X) := Wᵢ(X) / Wᵢ(βᵢ), ∀ i ∈ {0, ..., r-1}` -/
 noncomputable def normalizedW (i : Fin r) : L[X] :=
-  C (1 / (W L 𝔽q β i).eval (β i)) * W L 𝔽q β i
+  C (1 / (W 𝔽q β i).eval (β i)) * W 𝔽q β i
 
-omit [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [DecidableEq L] [Fintype 𝔽q]  in
 /-- The evaluation of the normalized polynomial `Ŵᵢ(X)` at `βᵢ` is 1. -/
 lemma normalizedWᵢ_eval_βᵢ {i : Fin r}
   (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β)):
@@ -1165,18 +1164,18 @@ lemma normalizedWᵢ_eval_βᵢ {i : Fin r}
   -- ⊢ u ≠ 0
   exact Wᵢ_eval_βᵢ_neq_zero (𝔽q := 𝔽q) (β := β) (i :=i) (hβ_lin_indep := hβ_lin_indep)
 
-omit [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [DecidableEq L] [Fintype 𝔽q]  in
 lemma normalizedW₀_eq_1_div_β₀ : normalizedW (𝔽q := 𝔽q) (β := β) (i :=0) = X * C (1 / (β 0)) := by
   -- By definition, U ... 0 = {0}, so the vanishing polynomial is X
   rw [normalizedW]
   rw [W₀_eq_X, eval_X]
   rw [mul_comm]
 
-omit [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [Fintype 𝔽q]  in
 /-- The evaluation `Ŵᵢ₊₁(βᵢ)` is 0. This is because `Ŵᵢ₊₁ = q⁽ⁱ⁾ ∘ Ŵᵢ` and `q⁽ⁱ⁾(1) = 0`. -/
 lemma eval_normalizedW_succ_at_beta_prev (i : Fin r) (h_i_add_1 : i + 1 < r):
-  (normalizedW L 𝔽q β (i + 1)).eval (β i) = 0 := by
-  have h_W_eval: (W L 𝔽q β (i+1)).eval (β i) = 0 := by
+  (normalizedW 𝔽q β (i + 1)).eval (β i) = 0 := by
+  have h_W_eval: (W 𝔽q β (i+1)).eval (β i) = 0 := by
     rw [eval_W_eq_zero_iff_in_U]
     unfold U
     have h_β_i_in_U: β i ∈ β '' Set.Ico 0 (i + 1) := by
@@ -1186,15 +1185,14 @@ lemma eval_normalizedW_succ_at_beta_prev (i : Fin r) (h_i_add_1 : i + 1 < r):
   rw [eval_mul]
   rw [h_W_eval, mul_zero]
 
-omit [DecidableEq 𝔽q] in
 /-- The degree of `Ŵᵢ(X)` remains `|𝔽q|ⁱ`. -/
 lemma degree_normalizedW
   (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
   (i : Fin r):
-    (normalizedW L 𝔽q β i).degree = (Fintype.card 𝔽q)^(i.val) := by
+    (normalizedW 𝔽q β i).degree = (Fintype.card 𝔽q)^(i.val) := by
    -- Multiplication by a non-zero constant does not change the degree of a polynomial.
-  let c := (1 / (W L 𝔽q β i).eval (β i))
-  have c_eq: c = (eval (β i) (W L 𝔽q β i))⁻¹ := by
+  let c := (1 / (W 𝔽q β i).eval (β i))
+  have c_eq: c = (eval (β i) (W 𝔽q β i))⁻¹ := by
     rw [←one_div]
   have hc : c ≠ 0 := by
     have eval_ne_0 := Wᵢ_eval_βᵢ_neq_zero (𝔽q := 𝔽q) (β := β) (i :=i) (hβ_lin_indep := hβ_lin_indep)
@@ -1204,14 +1202,14 @@ lemma degree_normalizedW
   rw [normalizedW, degree_C_mul hc]
   exact degree_W (𝔽q := 𝔽q) (β := β) (i :=i) (hβ_lin_indep := hβ_lin_indep)
 
-omit [DecidableEq L] [Fintype 𝔽q] [DecidableEq 𝔽q] in
+omit [DecidableEq L] [Fintype 𝔽q]  in
 /-- The normalized polynomial `Ŵᵢ(X)` vanishes on `Uᵢ`. -/
 lemma normalizedWᵢ_vanishing (i : Fin r) :
-  ∀ u ∈ U L 𝔽q β i, (normalizedW L 𝔽q β i).eval u = 0 := by
+  ∀ u ∈ U 𝔽q β i, (normalizedW 𝔽q β i).eval u = 0 := by
   -- The roots of `Ŵᵢ(X)` are precisely the elements of `Uᵢ`.
   -- `Ŵᵢ` is just a constant multiple of `Wᵢ`, so they share the same roots.
   intro u hu
-  rw [normalizedW, eval_mul, eval_C, Wᵢ_vanishing L 𝔽q β i u hu, mul_zero]
+  rw [normalizedW, eval_mul, eval_C, Wᵢ_vanishing 𝔽q β i u hu, mul_zero]
 
 /-- The normalized subspace vanishing polynomial `Ŵᵢ(X)` is `𝔽q`-linear. -/
 theorem normalizedW_is_linear_map
@@ -1219,13 +1217,13 @@ theorem normalizedW_is_linear_map
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
   (i : Fin r):
-  IsLinearMap 𝔽q (f := fun inner_p ↦ (normalizedW L 𝔽q β i).comp inner_p) := by
-  let c := 1 / (W L 𝔽q β i).eval (β i)
-  have hW_lin : IsLinearMap 𝔽q (f := fun inner_p ↦ (W L 𝔽q β i).comp inner_p) :=
-    W_linearity L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep (i :=i)
+  IsLinearMap 𝔽q (f := fun inner_p ↦ (normalizedW 𝔽q β i).comp inner_p) := by
+  let c := 1 / (W 𝔽q β i).eval (β i)
+  have hW_lin : IsLinearMap 𝔽q (f := fun inner_p ↦ (W 𝔽q β i).comp inner_p) :=
+    W_linearity 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep (i :=i)
   have h_comp_add := hW_lin.map_add
   have h_comp_smul := hW_lin.map_smul
-  -- ⊢ IsLinearMap 𝔽q fun inner_p ↦ (normalizedW L 𝔽q β i).comp inner_p
+  -- ⊢ IsLinearMap 𝔽q fun inner_p ↦ (normalizedW 𝔽q β i).comp inner_p
   -- We are given that the composition map for W_i is 𝔽q-linear.
   have h_comp_add := hW_lin.map_add
   have h_comp_smul := hW_lin.map_smul
@@ -1262,13 +1260,13 @@ theorem normalizedW_is_linear_map
       -- The rest is showing that scalar multiplication by `k` and polynomial
       -- multiplication by `C c` commute, which follows from ring axioms.
       -- `C c * (k • W_i.comp p)` should equal `k • (C c * W_i.comp p)`.
-      -- ⊢ C c * k • (W L 𝔽q β i).comp p = k • (C c * (W L 𝔽q β i).comp p)
+      -- ⊢ C c * k • (W 𝔽q β i).comp p = k • (C c * (W 𝔽q β i).comp p)
       rw [Algebra.smul_def, Algebra.smul_def]
-      -- ⊢ C c * ((algebraMap 𝔽q L[X]) k * (W L 𝔽q β i).comp p)
-      -- = (algebraMap 𝔽q L[X]) k * (C c * (W L 𝔽q β i).comp p)
+      -- ⊢ C c * ((algebraMap 𝔽q L[X]) k * (W 𝔽q β i).comp p)
+      -- = (algebraMap 𝔽q L[X]) k * (C c * (W 𝔽q β i).comp p)
       -- The `algebraMap` converts the scalar k from 𝔽q into a constant polynomial.
       rw [Algebra.algebraMap_eq_smul_one]
-      -- ⊢ C c * (k • 1 * (W L 𝔽q β i).comp p) = k • 1 * (C c * (W L 𝔽q β i).comp p)
+      -- ⊢ C c * (k • 1 * (W 𝔽q β i).comp p) = k • 1 * (C c * (W 𝔽q β i).comp p)
       ac_rfl
     }
   }
@@ -1278,9 +1276,9 @@ theorem normalizedW_is_additive
   (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
   (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
   (i : Fin r):
-  IsLinearMap 𝔽q (f := fun x ↦ (normalizedW L 𝔽q β i).eval x) := by
-  exact AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval (f := (normalizedW L 𝔽q β i))
-    (h_f_linear := normalizedW_is_linear_map L 𝔽q β h_Fq_card_gt_1
+  IsLinearMap 𝔽q (f := fun x ↦ (normalizedW 𝔽q β i).eval x) := by
+  exact AdditiveNTT.linear_map_of_comp_to_linear_map_of_eval (f := (normalizedW 𝔽q β i))
+    (h_f_linear := normalizedW_is_linear_map 𝔽q β h_Fq_card_gt_1
       h_Fq_char_prime hβ_lin_indep (i :=i))
 
 theorem kernel_normalizedW_eq_U
@@ -1288,16 +1286,16 @@ theorem kernel_normalizedW_eq_U
     (h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q)))
     (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
     (i : Fin r):
-    LinearMap.ker (poly_eval_linear_map (normalizedW L 𝔽q β i)
-    (normalizedW_is_additive L 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i))
-    = U L 𝔽q β i := by
+    LinearMap.ker (poly_eval_linear_map (normalizedW 𝔽q β i)
+    (normalizedW_is_additive 𝔽q β h_Fq_card_gt_1 h_Fq_char_prime hβ_lin_indep i))
+    = U 𝔽q β i := by
   ext x
   -- Unfold the definition of kernel membership and polynomial evaluation.
   simp_rw [LinearMap.mem_ker, poly_eval_linear_map]
   simp_rw [normalizedW, Polynomial.eval_mul, Polynomial.eval_C]
   simp only [one_div, LinearMap.coe_mk, AddHom.coe_mk, mul_eq_zero, inv_eq_zero] -- simp?
-  simp only [AdditiveNTT.Wᵢ_eval_βᵢ_neq_zero L 𝔽q β hβ_lin_indep i, false_or]
-  -- ⊢ eval x (W L 𝔽q β i) = 0 ↔ x ∈ U L 𝔽q β i
+  simp only [AdditiveNTT.Wᵢ_eval_βᵢ_neq_zero 𝔽q β hβ_lin_indep i, false_or]
+  -- ⊢ eval x (W 𝔽q β i) = 0 ↔ x ∈ U 𝔽q β i
   simp only [eval_W_eq_zero_iff_in_U]
 
 end LinearityOfSubspaceVanishingPolynomials
@@ -1309,22 +1307,21 @@ section NovelPolynomialBasisProof
 -- Definition of Novel Polynomial Basis: `Xⱼ(X) := Π_{i=0}^{ℓ-1} (Ŵᵢ(X))^{jᵢ}`
 noncomputable def Xⱼ (ℓ : ℕ) (h_ℓ : ℓ ≤ r) (j : Fin (2 ^ ℓ)) : L[X] :=
   (Finset.univ : Finset (Fin ℓ)).prod
-    (fun i => (normalizedW L 𝔽q β (Fin.castLE h_ℓ i))^(bit (k := i) (n := j)))
+    (fun i => (normalizedW 𝔽q β (Fin.castLE h_ℓ i))^(bit (k := i) (n := j)))
 
-omit [DecidableEq 𝔽q] in
 /-- The degree of `Xⱼ(X)` is `j`:
   `deg(Xⱼ(X)) = Σ_{i=0}^{ℓ-1} jᵢ * deg(Ŵᵢ(X)) = Σ_{i=0}^{ℓ-1} jᵢ * 2ⁱ = j` -/
 lemma degree_Xⱼ
-  (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
+  (hβ_lin_indep : LinearIndependent 𝔽q β)
   (hF₂ : Fintype.card 𝔽q = 2)
   (ℓ : ℕ) (h_ℓ : ℓ ≤ r) (j : Fin (2 ^ ℓ)) :
-  (Xⱼ L 𝔽q β ℓ h_ℓ j).degree = j := by
+  (Xⱼ 𝔽q β ℓ h_ℓ j).degree = j := by
   rw [Xⱼ, degree_prod]
   set rangeL := Fin ℓ
-  -- ⊢ ∑ i ∈ rangeL, (normalizedW L 𝔽q β i ^ bit (↑i) j).degree = ↑j
+  -- ⊢ ∑ i ∈ rangeL, (normalizedW 𝔽q β i ^ bit (↑i) j).degree = ↑j
   by_cases h_ℓ_0: ℓ = 0
   · simp only [degree_pow, nsmul_eq_mul];
-    -- ⊢ ∑ x, ↑(bit (↑x) j) * (normalizedW L 𝔽q β (Fin.castLE h_ℓ✝ x)).degree = ↑j
+    -- ⊢ ∑ x, ↑(bit (↑x) j) * (normalizedW 𝔽q β (Fin.castLE h_ℓ✝ x)).degree = ↑j
     simp only [h_ℓ_0, Fin.isEmpty', univ_eq_empty, sum_empty, WithBot.zero_eq_coe,
       Fin.val_eq_zero_iff]
     have h_j := j.isLt
@@ -1332,11 +1329,11 @@ lemma degree_Xⱼ
     exact h_j
   · push_neg at h_ℓ_0
     have deg_each: ∀ i ∈ (Finset.univ : Finset (Fin ℓ)),
-      ((normalizedW L 𝔽q β (Fin.castLE h_ℓ i))^(bit (k := i) (n := j))).degree
+      ((normalizedW 𝔽q β (Fin.castLE h_ℓ i))^(bit (k := i) (n := j))).degree
       = if bit (k := i) (n := j) = 1 then (2:ℕ)^i.val else 0 := by
       intro i _
       rw [degree_pow]
-      rw [degree_normalizedW L 𝔽q β (i :=Fin.castLE h_ℓ i) (hβ_lin_indep := hβ_lin_indep)]
+      rw [degree_normalizedW 𝔽q β (i :=Fin.castLE h_ℓ i) (hβ_lin_indep := hβ_lin_indep)]
       simp only [bit, Nat.and_one_is_mod, Fin.coe_castLE, nsmul_eq_mul, Nat.cast_ite, Nat.cast_pow,
         Nat.cast_ofNat, CharP.cast_eq_zero, hF₂]
       -- simp? [Nat.and_one_is_mod, nsmul_eq_mul]
@@ -1382,12 +1379,12 @@ lemma degree_Xⱼ
     rw [←h_bit_repr_j]
 
 /-- The basis vectors `{Xⱼ(X), j ∈ Fin 2^ℓ}` forms a basis for `L⦃<2^ℓ⦄[X]` -/
-noncomputable def basis_vectors (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ : ℓ ≤ r):
+noncomputable def basisVectors (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ : ℓ ≤ r):
   Fin (2 ^ ℓ) → L⦃<2^ℓ⦄[X] :=
-  fun j => ⟨Xⱼ L 𝔽q β ℓ h_ℓ j, by
+  fun j => ⟨Xⱼ 𝔽q β ℓ h_ℓ j, by
     -- proof of coercion of `Xⱼ(X)` to `L⦃<2^ℓ⦄[X]`, i.e. `degree < 2^ℓ`
     apply Polynomial.mem_degreeLT.mpr
-    rw [degree_Xⱼ L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ j]
+    rw [degree_Xⱼ 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ j]
     change (j.val: WithBot ℕ) < ((2: WithBot ℕ) ^ ℓ)
     norm_cast -- somehow `change` helps `norm_cast` to work better here
     omega
@@ -1428,9 +1425,8 @@ noncomputable def change_of_basis_matrix (hF₂ : Fintype.card 𝔽q = 2)
   (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
   (ℓ : Nat) (h_ℓ : ℓ ≤ r) : Matrix (Fin (2^ℓ)) (Fin (2^ℓ)) L :=
     fun j i => (to_coeffs_vec (L := L) (ℓ := ℓ) (
-      basis_vectors L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ j)) i
+      basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ j)) i
 
-omit [DecidableEq 𝔽q] in
 /--
 The coefficient vectors of the novel basis polynomials are linearly independent.
 This is proven by showing that the change-of-basis matrix to the monomial basis
@@ -1440,53 +1436,51 @@ lemma coeff_vectors_linear_independent (hF₂ : Fintype.card 𝔽q = 2)
   (hβ_lin_indep : LinearIndependent (R := 𝔽q) (M := L) (v := β))
   (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
   LinearIndependent L (to_coeffs_vec (L := L) (ℓ := ℓ) ∘
-    (basis_vectors L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ)) := by
+    (basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ)) := by
   -- Let `A` be the `2^ℓ x 2^ℓ` change-of-basis matrix.
-  set A := change_of_basis_matrix L 𝔽q β hF₂ hβ_lin_indep ℓ h_ℓ
+  set A := change_of_basis_matrix 𝔽q β hF₂ hβ_lin_indep ℓ h_ℓ
   -- The `i`-th row of `A` is the coefficient vector of `Xᵢ` in the novel basis.
   -- Apply the lemma about triangular matrices.
   apply linearIndependent_rows_of_lower_triangular_ne_zero_diag A
   · -- ⊢ A.BlockTriangular ⇑OrderDual.toDual => Prove the matrix A is lower-triangular.
     intro i j hij
-    dsimp only [to_coeffs_vec, basis_vectors, LinearMap.coe_mk, AddHom.coe_mk, A]
+    dsimp only [to_coeffs_vec, basisVectors, LinearMap.coe_mk, AddHom.coe_mk, A]
     -- ⊢ (Xⱼ β ℓ ↑i).coeff ↑j = 0
-    have deg_X : (Xⱼ L 𝔽q β ℓ h_ℓ i).degree = i :=
-      degree_Xⱼ L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ i
+    have deg_X : (Xⱼ 𝔽q β ℓ h_ℓ i).degree = i :=
+      degree_Xⱼ 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ i
     have h_i_lt_j : i < j := by
       simp only [OrderDual.toDual_lt_toDual] at hij
       exact hij
-    have h_res: (Xⱼ L 𝔽q β ℓ h_ℓ i).coeff j = 0 := by
+    have h_res: (Xⱼ 𝔽q β ℓ h_ℓ i).coeff j = 0 := by
       apply coeff_eq_zero_of_natDegree_lt -- we don't use coeff_eq_zero_of_degree_lt
       -- because p.natDegree returns a value of type ℕ instead of WithBot ℕ as in p.degree
-      rw [natDegree_eq_of_degree_eq_some (degree_Xⱼ L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ i)]
+      rw [natDegree_eq_of_degree_eq_some (degree_Xⱼ 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ i)]
       norm_cast -- auto resolve via h_i_lt_j
     exact h_res
   · -- ⊢ ∀ (i : Fin (2 ^ ℓ)), A i i ≠ 0 => All diagonal entries are non-zero.
     intro i
-    dsimp [A, to_coeffs_vec, basis_vectors]
+    dsimp [A, to_coeffs_vec, basisVectors]
     -- `A i i` is the `i`-th (also the leading) coefficient of `Xⱼ`, which is non-zero.
-    have h_deg : (Xⱼ L 𝔽q β ℓ h_ℓ i).degree = i := degree_Xⱼ L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ i
-    have h_natDegree : (Xⱼ L 𝔽q β ℓ h_ℓ i).natDegree = i := natDegree_eq_of_degree_eq_some h_deg
-    have deg_X : (Xⱼ L 𝔽q β ℓ h_ℓ i).degree = i := degree_Xⱼ L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ i
+    have h_deg : (Xⱼ 𝔽q β ℓ h_ℓ i).degree = i := degree_Xⱼ 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ i
+    have h_natDegree : (Xⱼ 𝔽q β ℓ h_ℓ i).natDegree = i := natDegree_eq_of_degree_eq_some h_deg
+    have deg_X : (Xⱼ 𝔽q β ℓ h_ℓ i).degree = i := degree_Xⱼ 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ i
     apply coeff_ne_zero_of_eq_degree -- (hn : degree p = n) : coeff p n ≠ 0
     norm_cast
 
-omit [DecidableEq 𝔽q] in
 /-- The basis vectors are linearly independent over `L`. -/
-theorem basis_vectors_linear_independent (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
-  LinearIndependent L (basis_vectors L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ) := by
+theorem basisVectors_linear_independent (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
+  LinearIndependent L (basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ) := by
   -- We have proved that the image of our basis vectors under the linear map
   -- `to_coeffs_vec` is a linearly independent family.
-  have h_comp_li := coeff_vectors_linear_independent L 𝔽q β hF₂ hβ_lin_indep ℓ h_ℓ
+  have h_comp_li := coeff_vectors_linear_independent 𝔽q β hF₂ hβ_lin_indep ℓ h_ℓ
   -- `LinearIndependent.of_comp` states that if the image of a family of vectors under
   -- a linear map is linearly independent, then so is the original family.
   exact LinearIndependent.of_comp (to_coeffs_vec (L := L) (ℓ := ℓ)) h_comp_li
 
-omit [DecidableEq 𝔽q] in
 /-- The basis vectors span the space of polynomials with degree less than `2^ℓ`. -/
-theorem basis_vectors_span (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
-  Submodule.span L (Set.range (basis_vectors L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ)) = ⊤ := by
-  have h_li := basis_vectors_linear_independent L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ
+theorem basisVectors_span (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
+  Submodule.span L (Set.range (basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ)) = ⊤ := by
+  have h_li := basisVectors_linear_independent 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ
   let n := 2 ^ ℓ
   have h_n: n = 2 ^ ℓ := by omega
   have h_n_pos: 0 < n := by
@@ -1496,7 +1490,7 @@ theorem basis_vectors_span (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ :
   -- We have `n` linearly independent vectors in an `n`-dimensional space.
   -- The dimension of their span is `n`.
   have h_span_finrank : Module.finrank L (Submodule.span L (Set.range (
-    basis_vectors L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ))) = n := by
+    basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ))) = n := by
     rw [finrank_span_eq_card h_li, Fintype.card_fin]
   -- A subspace with the same dimension as the ambient space must be the whole space.
   rw [←h_finrank_eq_n] at h_span_finrank
@@ -1506,26 +1500,25 @@ theorem basis_vectors_span (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ :
   exact h_span_finrank
 
 /-- The novel polynomial basis for `L⦃<2^ℓ⦄[X]` -/
-noncomputable def novel_polynomial_basis (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
+noncomputable def novelPolynomialBasis (hF₂ : Fintype.card 𝔽q = 2) (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
   Basis (Fin (2^ℓ)) (R := L) (M := L⦃<2^ℓ⦄[X]) := by
-  have hli := basis_vectors_linear_independent L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ
-  have hspan := basis_vectors_span L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ
+  have hli := basisVectors_linear_independent 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ
+  have hspan := basisVectors_span 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ
   exact Basis.mk hli (le_of_eq hspan.symm)
 
 end NovelPolynomialBasisProof
 
 /-- The polynomial `P(X)` derived from coefficients `a` in the novel polynomial basis `(Xⱼ)`,
 `P(X) := ∑_{j=0}^{2^ℓ-1} aⱼ ⋅ Xⱼ(X)` -/
-noncomputable def polynomial_from_novel_coeffs (ℓ : Nat) (h_ℓ : ℓ ≤ r)
-  (a : Fin (2 ^ ℓ) → L) : L[X] :=
-  ∑ j, C (a j) * (Xⱼ L 𝔽q β ℓ h_ℓ j)
+noncomputable def polynomial_from_novel_coeffs (ℓ : ℕ) (h_ℓ : ℓ ≤ r)
+    (a : Fin (2 ^ ℓ) → L) : L[X] :=
+  ∑ j, C (a j) * (Xⱼ 𝔽q β ℓ h_ℓ j)
 
-omit [DecidableEq 𝔽q] in
 /-- Proof that the novel polynomial basis is indeed the indicated basis vectors -/
-theorem novel_polynomial_basis_is_basis_vectors (hF₂ : Fintype.card 𝔽q = 2)
+theorem novelPolynomialBasis_is_basisVectors (hF₂ : Fintype.card 𝔽q = 2)
   (ℓ : Nat) (h_ℓ : ℓ ≤ r) :
-  (novel_polynomial_basis L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ)
-  = basis_vectors L 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ := by
-  simp only [novel_polynomial_basis, Basis.coe_mk]
+  (novelPolynomialBasis 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ)
+  = basisVectors 𝔽q β hβ_lin_indep hF₂ ℓ h_ℓ := by
+  simp only [novelPolynomialBasis, Basis.coe_mk]
 
 end AdditiveNTT

--- a/ArkLib/Data/FieldTheory/AdditiveNTT/NovelPolynomialBasis.lean
+++ b/ArkLib/Data/FieldTheory/AdditiveNTT/NovelPolynomialBasis.lean
@@ -36,6 +36,8 @@ algebra over its prime-characteristic subfield `𝔽q`, and an `𝔽q`-basis `β
   Computation, Zurich, Switzerland, 1996, pp. 1–9.
 -/
 
+set_option linter.style.longFile 1600
+
 open AdditiveNTT Polynomial FiniteDimensional Finset
 namespace AdditiveNTT
 
@@ -1510,7 +1512,7 @@ end NovelPolynomialBasisProof
 
 /-- The polynomial `P(X)` derived from coefficients `a` in the novel polynomial basis `(Xⱼ)`,
 `P(X) := ∑_{j=0}^{2^ℓ-1} aⱼ ⋅ Xⱼ(X)` -/
-noncomputable def polynomial_from_novel_coeffs (ℓ : ℕ) (h_ℓ : ℓ ≤ r)
+noncomputable def polynomialFromNovelCoeffs (ℓ : ℕ) (h_ℓ : ℓ ≤ r)
     (a : Fin (2 ^ ℓ) → L) : L[X] :=
   ∑ j, C (a j) * (Xⱼ 𝔽q β ℓ h_ℓ j)
 


### PR DESCRIPTION
Clean up of the additive ntt & novel polynomial basis files, including renaming definitions from snake case to camel case (per mathlib's convention), moving variable `L` from explicit to implicit (it is determined by `\beta`), and removing `DecidableEq` instances whenever possible