### PR TITLE
feat(fri): define FRI per-round relations and error accounting

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -171,6 +171,7 @@ import ArkLib.ProofSystem.ConstraintSystem.R1CS
 import ArkLib.ProofSystem.Fri.RoundConsistency
 import ArkLib.ProofSystem.Fri.Spec.General
 import ArkLib.ProofSystem.Fri.Spec.SingleRound
+import ArkLib.ProofSystem.Fri.Spec.Soundness
 import ArkLib.ProofSystem.Plonk.Basic
 import ArkLib.ProofSystem.Spartan.Basic
 import ArkLib.ProofSystem.Stir.Combine

--- a/ArkLib/ProofSystem/Fri/Spec/SingleRound.lean
+++ b/ArkLib/ProofSystem/Fri/Spec/SingleRound.lean
@@ -6,6 +6,8 @@ Authors: Quang Dao, František Silváši, Julian Sutherland, Ilia Vlasov
 
 
 import ArkLib.Data.CodingTheory.ReedSolomon.FftDomain
+import ArkLib.Data.CodingTheory.ReedSolomon
+import ArkLib.Data.CodingTheory.Basic.RelativeDistance
 import ArkLib.OracleReduction.Basic
 import CompPoly.Univariate.Basic
 import CompPoly.Univariate.Linear
@@ -260,23 +262,69 @@ namespace FoldPhase
 --     let x₀  := stmt j;
 --     roundConsistent cond f f' x₀
 
-/- The FRI non-final folding round input relation, with proximity parameter `δ`, f
-   for the `i`th round. -/
-def inputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
+/-- The FRI non-final folding round input relation, with proximity parameter `0 < δ`,
+    for the `i`-th round. The latest oracle codeword (the round-`i` evaluation
+    commitment, indexed at `Fin.last i.castSucc.val`) is δ-close to the Reed-Solomon
+    code on the round-`i` evaluation domain at the witness's degree bound. -/
+def inputRelation (_cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
     Set
       (
         (Statement F i.castSucc × (∀ j, OracleStatement s ω i.castSucc j)) ×
         Witness F s d i.castSucc.castSucc
-      ) := sorry
+      ) :=
+  fun ⟨⟨_, ostmt⟩, _⟩ =>
+    let N := ∑ j' ∈ finRangeTo (k + 1) (Fin.last i.castSucc.val).val, (s j').1
+    let dom := ω.subdomainNatReversed N
+    let f : Fin (2 ^ (n - N)) → F :=
+      fun idx => ostmt (Fin.last i.castSucc.val)
+        ⟨dom idx, Finset.mem_image.mpr ⟨idx, Finset.mem_univ _, rfl⟩⟩
+    0 < δ ∧
+      δᵣ(f, (ReedSolomon.code (↑dom : Fin (2 ^ (n - N)) ↪ F)
+        (2 ^ ((∑ j', (s j').1) - N) * d.1) : Set _)) ≤ ↑δ
 
-/- The FRI non-final folding round output relation, with proximity parameter `δ`,
-   for the `i`th round. -/
-def outputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
+/-- The FRI non-final folding round output relation, with proximity parameter `0 < δ`,
+    for the `i`-th round. After folding, the round-`(i+1)` codeword must satisfy:
+    1. **Proximity:** δ-close to the Reed-Solomon code on the round-`(i+1)` domain.
+    2. **Folding consistency:** the witness polynomial is derived from a polynomial
+       matching the round-`i` oracle via `polyFold` at the round-`i` verifier challenge.
+       The round-`(i+1)` oracle equals the witness evaluation on its domain.
+
+    Condition (2) is required by BCIKS20 §7.2: the proximity gap argument assumes
+    `f^{i+1}` is constructed from `f^i` via challenge-dependent folding. Without it,
+    a malicious prover could send an unrelated δ-close codeword, invalidating the
+    per-round proximity gap bound. The query phase checks (2) at `l` sampled points;
+    here we state the full (all-points) version as the ideal relation. -/
+def outputRelation (_cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
     Set
       (
         (Statement F i.succ × (∀ j, OracleStatement s ω i.succ j)) ×
         Witness F s d i.succ.castSucc
-      ) := sorry
+      ) :=
+  fun ⟨⟨stmt, ostmt⟩, w⟩ =>
+    let N := ∑ j' ∈ finRangeTo (k + 1) (Fin.last i.succ.val).val, (s j').1
+    let dom := ω.subdomainNatReversed N
+    let f_next : Fin (2 ^ (n - N)) → F :=
+      fun idx => ostmt (Fin.last i.succ.val)
+        ⟨dom idx, Finset.mem_image.mpr ⟨idx, Finset.mem_univ _, rfl⟩⟩
+    let N_prev := ∑ j' ∈ finRangeTo (k + 1) (Fin.last i.castSucc.val).val, (s j').1
+    let dom_prev := ω.subdomainNatReversed N_prev
+    let f_prev : Fin (2 ^ (n - N_prev)) → F :=
+      fun idx => ostmt ⟨Fin.last i.castSucc.val, by simp [Fin.val_succ]⟩
+        ⟨dom_prev idx, Finset.mem_image.mpr ⟨idx, Finset.mem_univ _, rfl⟩⟩
+    let α : F := stmt ⟨i.val, by simp [Fin.val_succ]⟩
+    -- (1) Proximity: f^{i+1} is δ-close to RS code on round-(i+1) domain
+    (0 < δ ∧
+      δᵣ(f_next, (ReedSolomon.code (↑dom : Fin (2 ^ (n - N)) ↪ F)
+        (2 ^ ((∑ j', (s j').1) - N) * d.1) : Set _)) ≤ ↑δ) ∧
+    -- (2) Folding consistency: witness is polyFold of a polynomial matching the
+    -- round-i oracle, at the round-i challenge α
+    (∃ (p_prev : Witness F s d i.castSucc.castSucc),
+      (∀ (idx : Fin (2 ^ (n - N_prev))),
+        p_prev.1.eval (dom_prev idx : F) = f_prev idx) ∧
+      w.1 = CompPoly.CPolynomial.FoldingPolynomial.cpolyFold p_prev.1 (2 ^ (s i.castSucc).1) α) ∧
+    -- (3) Oracle consistency: f^{i+1} equals the witness evaluation
+    (∀ (idx : Fin (2 ^ (n - N))),
+      f_next idx = w.1.eval (dom idx : F))
 
 /-- Each round of the FRI protocol begins with the verifier sending a random field element as the
   challenge to the prover, and ends with the prover sending an oracle to
@@ -370,9 +418,11 @@ def foldProver :
         chals,
         fun j ↦
           if h : j.1 < i.1
-          then o ⟨j.1, by
-            rw [Fin.val_castSucc]
-            exact Nat.lt_add_right 1 h⟩
+          then by
+            simpa [OracleStatement] using o ⟨j.1, by
+              rw [Fin.val_castSucc]
+              exact Nat.lt_add_right 1 h
+            ⟩
           else fun x ↦ p.1.eval x.1
       ⟩,
       p
@@ -460,9 +510,11 @@ namespace FinalFoldPhase
 --       let β := f'.eval (s₀.1.1 ^ (2 ^ s));
 --         RoundConsistency.roundConsistencyCheck x₀ pts β
 
-/- Input relation for the final folding round. This is currently sorried out, to be filled in later.
--/
-def inputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
+/-- Input relation for the final folding round, with proximity parameter `0 < δ`. The
+    round-`k` codeword (the last folding round's commit, indexed at `Fin.last k`) is
+    δ-close to the Reed-Solomon code on the round-`k` evaluation domain at the
+    pre-final-fold witness's degree bound. -/
+def inputRelation (_cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
     Set
       (
         (
@@ -470,16 +522,54 @@ def inputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
           (∀ j, OracleStatement s ω (Fin.last k) j)
         ) ×
         Witness F s d (Fin.last k).castSucc
-      ) := sorry
+      ) :=
+  fun ⟨⟨_, ostmt⟩, _⟩ =>
+    let N := ∑ j' ∈ finRangeTo (k + 1) (Fin.last (Fin.last k).val).val, (s j').1
+    let dom := ω.subdomainNatReversed N
+    let f : Fin (2 ^ (n - N)) → F :=
+      fun idx => ostmt (Fin.last (Fin.last k).val)
+        ⟨dom idx, Finset.mem_image.mpr ⟨idx, Finset.mem_univ _, rfl⟩⟩
+    0 < δ ∧
+      δᵣ(f, (ReedSolomon.code (↑dom : Fin (2 ^ (n - N)) ↪ F)
+        (2 ^ ((∑ j', (s j').1) - N) * d.1) : Set _)) ≤ ↑δ
 
-/- Output relation for the final folding round. This is currently sorried out, to be filled in
-later. -/
-def outputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
+/-- Output relation for the final folding round. After the final round the prover
+    sends a polynomial in the clear (the final oracle entry at index
+    `Fin.last (k + 1)` carries `F[X]`, not an evaluation function). The relation
+    asserts:
+    1. **Plaintext match:** the final oracle polynomial equals the witness.
+    2. **Folding consistency:** the witness is derived from a polynomial matching
+       the round-`k` oracle via `polyFold` at the final verifier challenge.
+
+    This mirrors `FoldPhase.outputRelation`'s folding consistency clause, extended
+    to the final round where the output is a polynomial rather than an oracle. -/
+def outputRelation (_cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
     Set
       (
         (FinalStatement F k × ∀ j, FinalOracleStatement s ω j) ×
         Witness F s d (Fin.last (k + 1))
-      ) := sorry
+      ) :=
+  fun ⟨⟨stmt, ostmt⟩, w⟩ =>
+    let α : F := stmt ⟨k, by omega⟩
+    let N_prev := ∑ j' ∈ finRangeTo (k + 1) k, (s j').1
+    let dom_prev := ω.subdomainNatReversed N_prev
+    let f_prev : Fin (2 ^ (n - N_prev)) → F :=
+      fun idx =>
+        (cast (by unfold FinalOracleStatement; simp; rfl)
+          (ostmt ⟨k, by omega⟩) :
+          (ω.subdomainNatReversed N_prev).toFinset → F)
+        ⟨dom_prev idx, Finset.mem_image.mpr ⟨idx, Finset.mem_univ _, rfl⟩⟩
+    -- (1) Plaintext match: final oracle polynomial = witness
+    (0 < δ ∧
+      (cast (by simp [FinalOracleStatement])
+        (ostmt (Fin.last (k + 1))) : CompPoly.CPolynomial F) = w.1) ∧
+    -- (2) Folding consistency: witness = polyFold of a round-k polynomial
+    --     matching the round-k oracle, at the final challenge α
+    (∃ (p_prev : Witness F s d (Fin.last k).castSucc),
+      (∀ (idx : Fin (2 ^ (n - N_prev))),
+        p_prev.1.eval (dom_prev idx : F) = f_prev idx) ∧
+      w.1 = CompPoly.CPolynomial.FoldingPolynomial.cpolyFold p_prev.1
+        (2 ^ (s (Fin.last k)).1) α)
 
 /-- The final folding round of the FRI protocol begins with the verifier sending a random field
   element as the challenge to the prover, then in contrast to the previous folding rounds simply
@@ -505,7 +595,7 @@ instance : ∀ j, Inhabited ((pSpec F).Challenge j) := by
     | zero => rfl
     | succ j1 =>
         cases j1 using Fin.cases with
-        | zero => simp [pSpec] at hj
+        | zero => simp at hj
         | succ j2 => exact j2.elim0
   subst h_j_eq_0
   simpa [pSpec, Challenge] using (inferInstance : Inhabited F)
@@ -681,8 +771,7 @@ noncomputable instance : ∀ j, Inhabited ((pSpec (ω := ω) l).Challenge j) := 
     | zero => rfl
     | succ j1 => exact j1.elim0
   subst h_j_eq_0
-  simp only [Challenge, Nat.sub_zero,
-   Fin.isValue, Fin.vcons_zero]
+  simp only [Challenge, Nat.sub_zero, Fin.isValue, Fin.vcons_zero]
   exact ⟨fun _ ↦ Inhabited.default⟩
 
 noncomputable instance : ∀ j, Fintype ((pSpec (ω := ω) l).Challenge j) := by

--- a/ArkLib/ProofSystem/Fri/Spec/Soundness.lean
+++ b/ArkLib/ProofSystem/Fri/Spec/Soundness.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2024-2025 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao, František Silváši, Julian Sutherland, Ilia Vlasov
+-/
+
+import ArkLib.ProofSystem.Fri.Spec.General
+import ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.ReedSolomonGap
+import ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.ErrorBound
+import ArkLib.OracleReduction.Security.Basic
+
+/-!
+# FRI error accounting definitions
+
+Candidate per-round and total error definitions for the FRI protocol soundness
+analysis. These definitions follow the structure of the BCIKS20 proximity gap
+bounds and Schwartz-Zippel query consistency bounds, but are not yet tied to a
+soundness theorem — they are accounting placeholders pending the sequential
+composition infrastructure needed for the full soundness proof.
+
+## References
+
+* [Ben-Sasson, I., Chiesa, A., Goldberg, L., Gur, T., Riabzev, M., Spooner, N.,
+  *Proximity Gaps for Reed-Solomon Codes*, FOCS 2020][BCIKS20]
+-/
+
+namespace Fri
+
+open Polynomial OracleSpec OracleComp ProtocolSpec Finset NNReal ProximityGap
+
+namespace Spec
+
+variable {F : Type} [NonBinaryField F] [Fintype F] [DecidableEq F]
+variable {n : ℕ}
+variable (k : ℕ) (s : Fin (k + 1) → ℕ+) (d : ℕ+)
+variable (dom_size_cond : (2 ^ (∑ i, (s i).1)) * d ≤ 2 ^ n)
+variable (l : ℕ) [NeZero l]
+variable {ω : ReedSolomon.SmoothCosetFftDomain n F}
+
+/-- Candidate per-round proximity-gap error for the `i`-th FRI folding round,
+    following the BCIKS20 error bound for the round-`i` Reed-Solomon code.
+    Pending a soundness proof linking this to actual failure probability. -/
+noncomputable def roundError (δ : ℝ≥0) (i : Fin k) : ℝ≥0 :=
+  let N := ∑ j' ∈ finRangeTo (k + 1) (Fin.last i.castSucc.val).val, (s j').1
+  let dom : ReedSolomon.SmoothCosetFftDomain (n - N) F := ω.subdomainNatReversed N
+  let degBound := 2 ^ ((∑ j', (s j').1) - N) * d.1
+  errorBound δ degBound (↑dom : Fin (2 ^ (n - N)) ↪ F)
+
+/-- Candidate per-round query consistency error: `(D / N)^l` where `D` is the
+    degree bound and `N` the domain size for round `i`. This follows the
+    Schwartz-Zippel argument structure but is not yet formally tied to the
+    query verifier's failure probability via a proven lemma. -/
+noncomputable def queryRoundError (i : Fin (k + 1)) : ℝ≥0 :=
+  let N := ∑ j' ∈ finRangeTo (k + 1) i.val, (s j').1
+  let _dom : ReedSolomon.SmoothCosetFftDomain (n - N) F := ω.subdomainNatReversed N
+  let domSize : ℕ := Fintype.card (Fin (2 ^ (n - N)))
+  let degBound := 2 ^ ((∑ j', (s j').1) - N) * d.1
+  ((degBound : ℝ≥0) / (domSize : ℝ≥0)) ^ l
+
+/-- Candidate total query consistency error, summing per-round query error
+    over all `k + 1` rounds (including the final-polynomial check). -/
+noncomputable def queryError : ℝ≥0 :=
+  ∑ i : Fin (k + 1), queryRoundError k s d l (ω := ω) i
+
+/-- Candidate total soundness error: sum of per-round proximity-gap errors
+    (fold phase) plus query consistency errors (query phase). These are
+    accounting definitions; a formal soundness theorem using them is deferred
+    pending sequential composition infrastructure. -/
+noncomputable def totalError (δ : ℝ≥0) : ℝ≥0 :=
+  (∑ i : Fin k, roundError k s d (ω := ω) δ i) + queryError k s d l (ω := ω)
+
+end Spec
+
+end Fri

--- a/docs/kb/_generated/lean-citations.json
+++ b/docs/kb/_generated/lean-citations.json
@@ -1,8 +1,8 @@
 {
   "counts": {
-    "files_with_citations": 58,
+    "files_with_citations": 59,
     "keys_cited": 20,
-    "total_citation_edges": 68
+    "total_citation_edges": 69
   },
   "files": {
     "ArkLib/AGM/Basic.lean": [
@@ -153,6 +153,9 @@
     "ArkLib/ProofSystem/Fri/Spec/SingleRound.lean": [
       "FRI1216"
     ],
+    "ArkLib/ProofSystem/Fri/Spec/Soundness.lean": [
+      "BCIKS20"
+    ],
     "ArkLib/ProofSystem/Plonk/Basic.lean": [
       "GWZC19"
     ],
@@ -242,6 +245,7 @@
       "ArkLib/Data/Polynomial/RationalFunctions.lean",
       "ArkLib/Data/Polynomial/Trivariate.lean",
       "ArkLib/ProofSystem/BatchedFri/Security.lean",
+      "ArkLib/ProofSystem/Fri/Spec/Soundness.lean",
       "ArkLib/ProofSystem/Stir/ProximityGap.lean",
       "ArkLib/ProofSystem/Whir/ProximityGen.lean"
     ],


### PR DESCRIPTION
## Summary

- Define `FoldPhase.inputRelation`, `FoldPhase.outputRelation`, `FinalFoldPhase.inputRelation`, `FinalFoldPhase.outputRelation` with δ-proximity to RS code on per-round evaluation domains
- Folding consistency in `FoldPhase.outputRelation` (BCIKS20 §7.2): witness derived via `polyFold` from a polynomial matching the round-i oracle at the round-i challenge
- Folding consistency in `FinalFoldPhase.outputRelation`: witness derived via `polyFold` from a polynomial matching the round-k oracle at the final challenge (mirrors `FoldPhase.outputRelation` pattern)
- Define candidate error accounting: `roundError`, `queryRoundError`, `queryError`, `totalError` (proximity gap + query consistency over k+1 rounds with ℝ≥0 division). These are accounting definitions pending a soundness theorem.