### PR TITLE
feat(coding-theory): integrate CompPoly's executable Guruswami-Sudan decoder

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -68,6 +68,8 @@ import ArkLib.Data.CodingTheory.BerlekampWelch.Sorries
 import ArkLib.Data.CodingTheory.DivergenceOfSets
 import ArkLib.Data.CodingTheory.GuruswamiSudan
 import ArkLib.Data.CodingTheory.GuruswamiSudan.Basic
+import ArkLib.Data.CodingTheory.GuruswamiSudan.Correctness
+import ArkLib.Data.CodingTheory.GuruswamiSudan.Executable
 import ArkLib.Data.CodingTheory.GuruswamiSudan.GuruswamiSudan
 import ArkLib.Data.CodingTheory.InterleavedCode
 import ArkLib.Data.CodingTheory.JohnsonBound.Basic

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan.lean
@@ -1,1 +1,3 @@
 import ArkLib.Data.CodingTheory.GuruswamiSudan.GuruswamiSudan
+import ArkLib.Data.CodingTheory.GuruswamiSudan.Executable
+import ArkLib.Data.CodingTheory.GuruswamiSudan.Correctness

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
@@ -35,8 +35,7 @@ noncomputable def proximity_gap_johnson (k n m : ℕ) : ℝ :=
   let rho := (k + 1 : ℚ) / n
   1 - √ rho - √ rho / (2 * m)
 
-/-- Degree bound with ρ = k/n (matching RS code rate). The original
-    `proximity_gap_degree_bound` uses ρ = (k+1)/n which is conservative. -/
+/-- Degree bound with ρ = k/n, matching the RS code rate. -/
 noncomputable def gs_degree_bound (k n m : ℕ) : ℕ :=
   let rho := (k : ℚ) / n
   ⌊(m + 1 / 2) * √ rho * n⌋₊
@@ -637,7 +636,7 @@ lemma rootMultiplicity_le_of_coeff_ne_zero [DecidableEq F] {Q : F[X][Y]} {x y : 
             (natWeightedDegree g 1 1 + 1)) (List.range (natWeightedDegree g 1 1 + 1)))) <;> aesop
 
 /-- Shifting a polynomial by (x, y) results in the zero polynomial if and only if the
-    original polynomial was zero. -/
+    input polynomial is zero. -/
 lemma shift_eq_zero_iff {F : Type} [Field F] (f : F[X][Y]) (x y : F) : shift f x y = 0 ↔ f = 0 := by
   constructor <;> intro h <;> simp_all only [shift, zero_comp, Polynomial.map_zero]
   have h_comp : f.comp (Y + C (C y)) = 0 := by
@@ -1018,8 +1017,8 @@ lemma gs_sufficient_multiplicity_bound {dist : ℕ}
     · unfold gs_johnson; ring_nf; norm_num
       norm_num [mul_assoc, mul_comm, mul_left_comm, ne_of_gt (zero_lt_one.trans_le hm)]
 
-/-- Divisibility via the rate-corrected GS system. Uses gs_degree_bound (ρ=k/n)
-    and gs_johnson instead of the conservative proximity_gap versions. -/
+/-- Divisibility via the rate-corrected GS system using `gs_degree_bound`
+    (ρ = k/n) and `gs_johnson`. -/
 theorem gs_dvd_property [DecidableEq F] (hk : k + 1 ≤ n) (hm : 1 ≤ m) (p : code ωs k)
     {Q : F[X][Y]}
   (hQ_deg : weightedDegree Q 1 (k - 1) ≤ gs_degree_bound k n m)

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
@@ -35,7 +35,8 @@ noncomputable def proximity_gap_johnson (k n m : ℕ) : ℝ :=
   let rho := (k + 1 : ℚ) / n
   1 - √ rho - √ rho / (2 * m)
 
-/-- Degree bound with ρ = k/n, matching the RS code rate. -/
+/-- Degree bound with ρ = k/n (matching RS code rate). The original
+    `proximity_gap_degree_bound` uses ρ = (k+1)/n which is conservative. -/
 noncomputable def gs_degree_bound (k n m : ℕ) : ℕ :=
   let rho := (k : ℚ) / n
   ⌊(m + 1 / 2) * √ rho * n⌋₊
@@ -636,7 +637,7 @@ lemma rootMultiplicity_le_of_coeff_ne_zero [DecidableEq F] {Q : F[X][Y]} {x y : 
             (natWeightedDegree g 1 1 + 1)) (List.range (natWeightedDegree g 1 1 + 1)))) <;> aesop
 
 /-- Shifting a polynomial by (x, y) results in the zero polynomial if and only if the
-    input polynomial is zero. -/
+    original polynomial was zero. -/
 lemma shift_eq_zero_iff {F : Type} [Field F] (f : F[X][Y]) (x y : F) : shift f x y = 0 ↔ f = 0 := by
   constructor <;> intro h <;> simp_all only [shift, zero_comp, Polynomial.map_zero]
   have h_comp : f.comp (Y + C (C y)) = 0 := by
@@ -1017,8 +1018,8 @@ lemma gs_sufficient_multiplicity_bound {dist : ℕ}
     · unfold gs_johnson; ring_nf; norm_num
       norm_num [mul_assoc, mul_comm, mul_left_comm, ne_of_gt (zero_lt_one.trans_le hm)]
 
-/-- Divisibility via the rate-corrected GS system using `gs_degree_bound`
-    (ρ = k/n) and `gs_johnson`. -/
+/-- Divisibility via the rate-corrected GS system. Uses gs_degree_bound (ρ=k/n)
+    and gs_johnson instead of the conservative proximity_gap versions. -/
 theorem gs_dvd_property [DecidableEq F] (hk : k + 1 ≤ n) (hm : 1 ≤ m) (p : code ωs k)
     {Q : F[X][Y]}
   (hQ_deg : weightedDegree Q 1 (k - 1) ≤ gs_degree_bound k n m)

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Correctness.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Correctness.lean
@@ -31,6 +31,319 @@ def RepresentsArkInput
 def GSSpecSet (k e : Nat) (ωs : Fin n ↪ F) (f : Fin n → F) : Set F[X] :=
   {p | p.degree < (k : WithBot Nat) ∧ Δ₀(f, p.eval ∘ ωs) ≤ e}
 
+/-! ### Parameter certificates
+
+A `GSParamCert` carries no interpolation-witness obligation: that obligation is
+discharged generically by `interpolationWitnessExists_of_capacity`. A certificate is
+therefore *exactly* the decidable integer check `paramsPassIntegerChecks`, and is
+constructible by `decide`. -/
+
+/-- The decidable check `paramsPassIntegerChecks` is equivalent to `GSParamCert`;
+certificates are therefore constructible by `decide`. -/
+theorem paramsPassIntegerChecks_iff
+    (k n e : Nat) (params : CompPoly.GuruswamiSudan.GSExecParams) :
+    paramsPassIntegerChecks k n e params = true ↔ GSParamCert k n e params := by
+  unfold paramsPassIntegerChecks
+  simp only [Bool.and_eq_true, decide_eq_true_eq]
+  constructor
+  · rintro ⟨⟨⟨⟨hk, he⟩, hm⟩, hcap⟩, hagree⟩
+    exact ⟨hk, he, hm, hcap, hagree⟩
+  · rintro ⟨hk, he, hm, hcap, hagree⟩
+    exact ⟨⟨⟨⟨hk, he⟩, hm⟩, hcap⟩, hagree⟩
+
+/-- A concrete, fully discharged `GSParamCert` with message degree `k = 2` (so the
+interpolation step is genuinely non-degenerate): length `n = 5`, decoding radius
+`e = 1`, multiplicity `1`, and weighted-degree bound `3`. The whole certificate —
+including the interpolation-witness existence — is settled by `decide`. -/
+example : GSParamCert 2 5 1 (execParamsOfMultiplicityAndDegree 2 1 1 3) :=
+  (paramsPassIntegerChecks_iff 2 5 1 _).mp (by decide)
+
+open CompPoly.GuruswamiSudan in
+/-- Whatever the bounded integer search returns is a valid certificate: the search
+only emits parameters that pass `paramsPassIntegerChecks`, which is exactly a
+`GSParamCert`. This provides the `sound` field of `boundedSearchParamSelector`
+unconditionally. -/
+theorem searchParamsUpTo_sound {maxM maxW k n e : Nat} {params : GSExecParams}
+    (h : searchParamsUpTo maxM maxW k n e = some params) :
+    GSParamCert k n e params := by
+  refine (paramsPassIntegerChecks_iff k n e params).mp ?_
+  unfold searchParamsUpTo at h
+  obtain ⟨l₁, mult, l₂, -, hf, -⟩ := List.findSome?_eq_some_iff.mp h
+  split at hf
+  · next wdb hfind =>
+      obtain rfl := Option.some.inj hf
+      exact (List.find?_eq_some_iff_getElem.mp hfind).1
+  · next => exact absurd hf (by simp)
+
+/-- The bounded integer search as a `GSParamSelector`, with soundness supplied by
+`searchParamsUpTo_sound`. The completeness obligation is passed explicitly: it holds
+when the search bounds are large enough to contain valid parameters (see
+`searchParamsUpTo_complete`); the required multiplicity grows without bound as the
+decoding radius approaches the Johnson bound. -/
+def boundedSearchParamSelector {maxM maxW : Nat}
+    (complete : ∀ {k n e}, JohnsonSpecCondition k n e →
+        ∃ params, searchParamsUpTo maxM maxW k n e = some params ∧ GSParamCert k n e params) :
+    GSParamSelector where
+  toCompPolySelector := { choose := searchParamsUpTo maxM maxW }
+  sound := fun h => searchParamsUpTo_sound h
+  complete := complete
+
+open CompPoly.GuruswamiSudan in
+/-- Completeness of the bounded search relative to its box: if some parameter pair
+`(m, D)` within the search bounds passes the integer checks, the search returns a valid
+certificate. Combined with `paramsCert_of_johnson` this discharges completeness whenever
+the box is large enough to contain the Johnson-radius parameters. -/
+theorem searchParamsUpTo_complete {maxM maxW k n e : Nat}
+    (hex : ∃ m D, 0 < m ∧ m ≤ maxM ∧ D ≤ maxW ∧
+        paramsPassIntegerChecks k n e (execParamsOfMultiplicityAndDegree k e m D) = true) :
+    ∃ params, searchParamsUpTo maxM maxW k n e = some params ∧ GSParamCert k n e params := by
+  obtain ⟨m, D, hm, hmM, hDW, hpass⟩ := hex
+  have hisSome : (searchParamsUpTo maxM maxW k n e).isSome := by
+    rw [Option.isSome_iff_ne_none]
+    intro hnone
+    unfold searchParamsUpTo at hnone
+    rw [List.findSome?_eq_none_iff] at hnone
+    have hmmem : m ∈ List.range' 1 maxM := by rw [List.mem_range'_1]; omega
+    have hinner := hnone m hmmem
+    have hDmem : D ∈ List.range (maxW + 1) := by rw [List.mem_range]; omega
+    have hfindNe : (List.range (maxW + 1)).find?
+        (fun wdb => paramsPassIntegerChecks k n e
+          (execParamsOfMultiplicityAndDegree k e m wdb)) ≠ none := by
+      intro hfn
+      exact absurd hpass (List.find?_eq_none.mp hfn D hDmem)
+    revert hinner
+    cases hfc : (List.range (maxW + 1)).find?
+        (fun wdb => paramsPassIntegerChecks k n e
+          (execParamsOfMultiplicityAndDegree k e m wdb)) with
+    | none => intro _; exact hfindNe hfc
+    | some wdb => intro h; simp at h
+  obtain ⟨params, hsome⟩ := Option.isSome_iff_exists.mp hisSome
+  exact ⟨params, hsome, searchParamsUpTo_sound hsome⟩
+
+/-- **Johnson-bound parameter existence.** Within the Johnson radius there exist valid
+Guruswami–Sudan parameters: a multiplicity `m > 0` whose canonical degree bound yields
+a full `GSParamCert`. This is the backend- and search-independent completeness content
+of the decoder — it says the `GSParamCert` hypotheses are *reachable for every input
+inside the radius*, with `m` chosen via `exists_multiplicity_of_johnson`. -/
+theorem paramsCert_of_johnson {k n e : Nat} (hjohnson : JohnsonSpecCondition k n e) :
+    ∃ m, 0 < m ∧
+      GSParamCert k n e
+        (execParamsOfMultiplicityAndDegree k e m (proximity_gap_degree_bound k n m)) := by
+  unfold JohnsonSpecCondition at hjohnson
+  have heNonneg : (0 : ℝ) ≤ e := Nat.cast_nonneg e
+  have hsqrtNonneg := Real.sqrt_nonneg (((k : ℝ) + 1) * (n : ℝ))
+  have hnPos : 0 < n := by
+    rcases Nat.eq_zero_or_pos n with rfl | h
+    · simp only [Nat.cast_zero, mul_zero, Real.sqrt_zero, sub_zero] at hjohnson
+      linarith
+    · exact h
+  have hnPosR : (0 : ℝ) < n := by exact_mod_cast hnPos
+  have hk : k + 1 ≤ n := by
+    by_contra hc
+    have hnk : (n : ℝ) ≤ ↑k + 1 := by
+      have : n ≤ k := by omega
+      exact_mod_cast Nat.le_succ_of_le this
+    have hle : (↑n : ℝ) * ↑n ≤ (↑k + 1) * ↑n := by nlinarith
+    have hge : Real.sqrt ((↑k + 1) * ↑n) ≥ ↑n :=
+      calc Real.sqrt ((↑k + 1) * ↑n) ≥ Real.sqrt (↑n * ↑n) := Real.sqrt_le_sqrt hle
+        _ = ↑n := Real.sqrt_mul_self (le_of_lt hnPosR)
+    linarith
+  have he : e ≤ n := by
+    have : (e : ℝ) < n := by linarith
+    exact_mod_cast le_of_lt this
+  obtain ⟨m, hm, hgap⟩ := exists_multiplicity_of_johnson hjohnson
+  refine ⟨m, hm, rfl, rfl, hm, ?_, ?_⟩
+  · change numVars k (proximity_gap_degree_bound k n m) > numConstraints n m
+    exact numVars_gt_numConstraints k n m
+  · change proximity_gap_degree_bound k n m < m * (n - e)
+    have hreal := sufficient_multiplicity_bound hk hm hgap
+    have hcast : (proximity_gap_degree_bound k n m : ℝ) < ((m * (n - e) : ℕ) : ℝ) := by
+      rw [Nat.cast_mul, Nat.cast_sub he]; exact hreal
+    exact_mod_cast hcast
+
+open Classical in
+/-- A noncomputable `GSParamSelector` that returns a valid certificate exactly when one
+exists: soundness is immediate and completeness follows from `paramsCert_of_johnson`. It
+inhabits the `GSParamSelector` abstraction with both soundness and unconditional
+completeness, so the selector-backed decode theorems (`decode_sound`, `decode_complete`,
+`mem_decode_iff_spec`) are not vacuous. `boundedSearchParamSelector` is the computable
+variant, with completeness conditional on the search bounds. -/
+noncomputable def johnsonParamSelector : GSParamSelector where
+  toCompPolySelector :=
+    { choose := fun k n e =>
+        if h : ∃ params, GSParamCert k n e params then some h.choose else none }
+  sound := by
+    intro k n e params h
+    dsimp only at h
+    split at h
+    · next hex => obtain rfl := Option.some.inj h; exact hex.choose_spec
+    · next => simp at h
+  complete := by
+    intro k n e hjohnson
+    have hcert : ∃ params, GSParamCert k n e params := by
+      obtain ⟨m, _, hm⟩ := paramsCert_of_johnson hjohnson
+      exact ⟨_, hm⟩
+    exact ⟨hcert.choose, dif_pos hcert, hcert.choose_spec⟩
+
+/-! ### Backend-agnostic interpolation-witness existence
+
+The CompPoly decoder takes the existence of an interpolation witness as a hypothesis
+(`GSInterpContext.complete`, `GSFilteredCoreContext.complete`). It is discharged here
+from the combinatorial capacity condition `numVars > numConstraints`. The statement
+mentions only CompPoly's semantic `ValidInterpolationWitness`, so it is independent of
+any concrete interpolation backend; the proof uses the dense backend as a constructive
+existence proof. -/
+
+open CompPoly.CBivariate in
+/-- Membership in the finite monomial grid. -/
+private lemma mem_monomialGrid {D : Nat} {mm : Monomial} :
+    mm ∈ monomialGrid D ↔ mm.xDegree ≤ D ∧ mm.yDegree ≤ D := by
+  obtain ⟨x, y⟩ := mm
+  simp only [monomialGrid, List.mem_flatMap, List.mem_map, List.mem_range, Monomial.mk.injEq]
+  constructor
+  · rintro ⟨a, ha, b, hb, rfl, rfl⟩; omega
+  · rintro ⟨hx, hy⟩; exact ⟨y, by omega, x, by omega, rfl, rfl⟩
+
+open CompPoly.GuruswamiSudan CompPoly.CBivariate in
+/-- The dense interpolation monomial basis has exactly `numVars` elements. -/
+theorem interpolationMonomials_size (params : GSInterpParams) :
+    (interpolationMonomials params).size =
+      numVars params.messageDegree params.weightedDegreeBound := by
+  have hsize :
+      (interpolationMonomials params).size =
+        ((monomialGrid params.weightedDegreeBound).filter
+          (fun mm => 1 * mm.xDegree +
+            (params.messageDegree - 1) * mm.yDegree ≤ params.weightedDegreeBound)).length := by
+    simp [interpolationMonomials, monomialsWeightedDegreeLE, yWeight]
+  rw [hsize, ← List.toFinset_card_of_nodup ((monomialGrid_nodup _).filter _),
+    numVars, weigthBoundIndices]
+  have einj : Function.Injective (fun mm : Monomial => (mm.xDegree, mm.yDegree)) := by
+    intro a b h; cases a; cases b; simpa using h
+  rw [← Finset.card_image_of_injective _ einj]
+  congr 1
+  ext p
+  obtain ⟨i, j⟩ := p
+  simp only [Finset.mem_image, List.mem_toFinset, List.mem_filter, Finset.mem_filter,
+    Finset.product_eq_sprod, Finset.mem_product, Finset.mem_range, mem_monomialGrid,
+    Prod.mk.injEq, Nat.lt_succ_iff, one_mul, decide_eq_true_eq]
+  constructor
+  · rintro ⟨mm, ⟨⟨hx, hy⟩, hbound⟩, rfl, rfl⟩
+    exact ⟨⟨hx, hy⟩, hbound⟩
+  · rintro ⟨⟨hx, hy⟩, hbound⟩
+    exact ⟨⟨i, j⟩, ⟨⟨hx, hy⟩, hbound⟩, rfl, rfl⟩
+
+/-- Sum of a constant over a list. -/
+private lemma sum_map_const {α : Type*} (l : List α) (c : Nat) :
+    (l.map (fun _ => c)).sum = l.length * c := by
+  induction l with
+  | nil => simp
+  | cons x xs ih => simp only [List.map_cons, List.sum_cons, List.length_cons, ih]; ring
+
+/-- Each fold step pushes one element, so the size grows by the list length. -/
+private lemma foldl_push_size {α β : Type*} (g : Array β → α → β)
+    (xs : List α) (acc : Array β) :
+    (xs.foldl (fun c x => c.push (g c x)) acc).size = acc.size + xs.length := by
+  induction xs generalizing acc with
+  | nil => simp
+  | cons x xs ih =>
+      simp only [List.foldl_cons, ih, Array.size_push, List.length_cons]; omega
+
+/-- Size of a fold whose every step grows the accumulator by `d x`. -/
+private lemma foldl_size_add {α β : Type*} (step : Array β → α → Array β) (d : α → Nat)
+    (hstep : ∀ c x, (step c x).size = c.size + d x) (xs : List α) (acc : Array β) :
+    (xs.foldl step acc).size = acc.size + (xs.map d).sum := by
+  induction xs generalizing acc with
+  | nil => simp
+  | cons x xs ih =>
+      simp only [List.foldl_cons, ih, hstep, List.map_cons, List.sum_cons]; omega
+
+/-- The per-point constraint count: `∑_{a<m} (m - a) = m(m+1)/2` (doubled form). -/
+private lemma sum_range'_sub_two (m : Nat) :
+    2 * ((List.range' 0 m).map (fun a => m - a)).sum = m * (m + 1) := by
+  induction m with
+  | zero => simp
+  | succ m ih =>
+      rw [List.range'_concat, List.map_append, List.sum_append,
+        show ((List.range' 0 m).map (fun a => (m + 1) - a))
+            = (List.range' 0 m).map (fun a => (m - a) + 1) from
+          List.map_congr_left (fun a ha => by
+            have h := List.mem_range'_1.mp ha; omega)]
+      have hsucc : ∀ (l : List Nat) (f : Nat → Nat),
+          (l.map (fun a => f a + 1)).sum = (l.map f).sum + l.length := by
+        intro l f
+        induction l with
+        | nil => simp
+        | cons x xs ih => simp only [List.map_cons, List.sum_cons, List.length_cons, ih]; omega
+      rw [hsucc, List.length_range']
+      simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, Nat.zero_add,
+        Nat.one_mul, Nat.add_sub_cancel_left, Nat.add_zero]
+      rw [show (List.map (HSub.hSub m) (List.range' 0 m))
+            = (List.map (fun a => m - a) (List.range' 0 m)) from rfl]
+      nlinarith [ih]
+
+open CompPoly.GuruswamiSudan in
+/-- Explicit `foldl` form of the constraint enumeration loop. -/
+private def constraintsFold {F : Type*} (points : Array (F × F)) (m : Nat) :
+    Array (InterpolationConstraint F) :=
+  points.toList.foldl
+    (fun cs point =>
+      (List.range' 0 m).foldl
+        (fun cs a =>
+          (List.range' 0 (m - a)).foldl
+            (fun cs b => cs.push ⟨point.1, point.2, a, b⟩) cs) cs) #[]
+
+open CompPoly.GuruswamiSudan in
+private lemma interpolationConstraints_eq_fold {F : Type*}
+    (points : Array (F × F)) (m : Nat) :
+    interpolationConstraints points m = constraintsFold points m := by
+  unfold interpolationConstraints constraintsFold
+  simp
+
+open CompPoly.GuruswamiSudan in
+/-- The dense interpolation constraint system has exactly `numConstraints` rows. -/
+theorem interpolationConstraints_size {F : Type*}
+    (points : Array (F × F)) (m : Nat) :
+    (interpolationConstraints points m).size = numConstraints points.size m := by
+  have inner : ∀ (point : F × F) (a : Nat) (cs : Array (InterpolationConstraint F)),
+      ((List.range' 0 (m - a)).foldl
+        (fun cs b => cs.push ⟨point.1, point.2, a, b⟩) cs).size = cs.size + (m - a) := by
+    intro point a cs
+    rw [foldl_push_size, List.length_range']
+  have middle : ∀ (point : F × F) (cs : Array (InterpolationConstraint F)),
+      ((List.range' 0 m).foldl
+        (fun cs a => (List.range' 0 (m - a)).foldl
+          (fun cs b => cs.push ⟨point.1, point.2, a, b⟩) cs) cs).size
+        = cs.size + ((List.range' 0 m).map (fun a => m - a)).sum :=
+    fun point cs =>
+      foldl_size_add _ (fun a => m - a) (fun cs a => inner point a cs) (List.range' 0 m) cs
+  have hS : ((List.range' 0 m).map (fun a => m - a)).sum = m * (m + 1) / 2 := by
+    have h2 := sum_range'_sub_two m
+    omega
+  rw [interpolationConstraints_eq_fold, constraintsFold,
+    foldl_size_add _ (fun _ => ((List.range' 0 m).map (fun a => m - a)).sum)
+      (fun cs point => middle point cs) points.toList #[],
+    sum_map_const, Array.size_empty, Array.length_toList, hS, numConstraints,
+    card_constraintIndices, Nat.zero_add]
+
+open CompPoly.GuruswamiSudan in
+/-- The capacity condition `numVars > numConstraints` forces a nonzero interpolation
+witness to exist. This is the mathematical content behind the GS interpolation step and
+is independent of any concrete interpolation backend: the existence of `Q` is a property
+of `CBivariate` polynomials, and the proof uses the dense backend as a constructive
+witness. -/
+theorem interpolationWitnessExists_of_capacity
+    {F : Type} [Field F] [BEq F] [LawfulBEq F] [DecidableEq F]
+    (params : GSInterpParams) (points : Array (F × F))
+    (hcap : numVars params.messageDegree params.weightedDegreeBound >
+              numConstraints points.size params.multiplicity) :
+    ∃ Q, ValidInterpolationWitness points params Q := by
+  have hSlack : HasInterpolationDimensionSlack points params := by
+    unfold HasInterpolationDimensionSlack HasInterpolationDimensionSlackOnBasis
+    rw [interpolationConstraints_size, interpolationMonomials_size]
+    exact hcap
+  obtain ⟨Q, hQ⟩ := denseInterpolate_exists_of_dimension_slack points params hSlack
+  exact ⟨Q, denseInterpolate_sound (kernelContext := denseLinearKernelContext F) hQ⟩
+
 private lemma list_foldl_count_false {α : Type*}
     (xs : List α) (p : α → Bool) (acc : Nat) :
     xs.foldl (fun count x => if p x then count else count + 1) acc =
@@ -217,7 +530,8 @@ theorem mem_decodeWithParams_iff_degree_and_distance
     have hInterpExists :
         ∃ Q,
           CompPoly.GuruswamiSudan.ValidInterpolationWitness w.points params.interp Q :=
-      hparams.interpolation_witness_exists w.points hpoints_size
+      interpolationWitnessExists_of_capacity params.interp w.points
+        (by rw [hparams.messageDegree_eq, hpoints_size]; exact hparams.interpolation_capacity)
     have hdistinct := distinctXCoordinates_of_represents hrep
     have hcpdeg :
         CompPoly.GuruswamiSudan.degreeLt cp params.interp.messageDegree := by

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Correctness.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Correctness.lean
@@ -1,0 +1,432 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Valerii Huhnin
+-/
+
+import ArkLib.Data.CodingTheory.GuruswamiSudan.Executable
+import ArkLib.Data.CodingTheory.GuruswamiSudan.GuruswamiSudan
+
+/-!
+# Executable Guruswami-Sudan Correctness
+
+Correctness statements connecting the executable CompPoly-backed
+Guruswami-Sudan decoder with the ArkLib Reed-Solomon specification.
+-/
+
+namespace GuruswamiSudan
+
+open Polynomial ReedSolomon
+
+variable {F : Type} [Field F] [BEq F] [LawfulBEq F] [DecidableEq F]
+variable {k n e r D : Nat}
+variable {w : CompPoly.GuruswamiSudan.GSReceivedWord F} {ωs : Fin n ↪ F} {f : Fin n → F}
+
+/-- Packed runtime input represents the ArkLib `(ωs, f)` specification input. -/
+def RepresentsArkInput
+    (w : CompPoly.GuruswamiSudan.GSReceivedWord F) (ωs : Fin n ↪ F) (f : Fin n → F) : Prop :=
+  w.points = Array.ofFn fun i : Fin n => (ωs i, f i)
+
+/-- Semantic Reed-Solomon list-decoding specification for GS. -/
+def GSSpecSet (k e : Nat) (ωs : Fin n ↪ F) (f : Fin n → F) : Set F[X] :=
+  {p | p.degree < (k : WithBot Nat) ∧ Δ₀(f, p.eval ∘ ωs) ≤ e}
+
+/-- Output array represents exactly a semantic set of mathlib polynomials. -/
+def OutputRepresentsSet
+    (out : Array (CompPoly.CPolynomial F)) (spec : Set F[X]) : Prop :=
+  ∀ p, (∃ cp, cp ∈ out.toList ∧ cp.toPoly = p) ↔ p ∈ spec
+
+private lemma list_foldl_count_false {α : Type*}
+    (xs : List α) (p : α → Bool) (acc : Nat) :
+    xs.foldl (fun count x => if p x then count else count + 1) acc =
+      acc + (xs.filter fun x => p x = false).length := by
+  induction xs generalizing acc with
+  | nil => simp
+  | cons x xs ih =>
+      by_cases hx : p x
+      · simp [hx, ih]
+      · simp [hx, ih]
+        omega
+
+private lemma list_foldl_count_true {α : Type*}
+    (xs : List α) (p : α → Bool) (acc : Nat) :
+    xs.foldl (fun count x => if p x then count + 1 else count) acc =
+      acc + (xs.filter fun x => p x = true).length := by
+  induction xs generalizing acc with
+  | nil => simp
+  | cons x xs ih =>
+      by_cases hx : p x
+      · simp [hx, ih]
+        omega
+      · simp [hx, ih]
+
+private lemma length_filter_ofFn_eq_card {α : Type*} {n : Nat}
+    (g : Fin n → α) (p : α → Prop) [DecidablePred p] :
+    ((List.ofFn g).filter p).length =
+      (Finset.univ.filter fun i => p (g i)).card := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [List.ofFn_succ]
+      rw [show
+          (Finset.univ.filter fun i : Fin (n + 1) => p (g i)).card =
+            ∑ i : Fin (n + 1), if p (g i) then 1 else 0 by
+        rw [Finset.card_filter]]
+      rw [Fin.sum_univ_succ]
+      by_cases h0 : p (g 0)
+      · simp [h0, ih]
+        omega
+      · simp [h0, ih]
+
+omit [BEq F] [LawfulBEq F] [DecidableEq F] in
+private def cPolynomialOfPoly (p : F[X]) : CompPoly.CPolynomial F :=
+  ⟨p.toImpl, CompPoly.CPolynomial.Raw.isCanonical_toImpl p⟩
+
+omit [BEq F] [LawfulBEq F] [DecidableEq F] in
+private theorem cPolynomialOfPoly_toPoly (p : F[X]) :
+    (cPolynomialOfPoly p).toPoly = p := by
+  change p.toImpl.toPoly = p
+  exact CompPoly.CPolynomial.Raw.toPoly_toImpl
+
+omit [DecidableEq F] in
+private theorem degreeLt_cPolynomialOfPoly_of_degree_lt {p : F[X]}
+    (hp : p.degree < (k : WithBot Nat)) :
+    CompPoly.GuruswamiSudan.degreeLt (cPolynomialOfPoly p) k := by
+  unfold CompPoly.GuruswamiSudan.degreeLt
+  rw [CompPoly.CPolynomial.degree_toPoly, cPolynomialOfPoly_toPoly]
+  exact hp
+
+/-- Packed CompPoly mismatch count agrees with ArkLib Hamming distance. -/
+theorem candidateMismatchCount_represents_hammingDist
+    {cp : CompPoly.CPolynomial F}
+    (hrep : RepresentsArkInput w ωs f) :
+    CompPoly.GuruswamiSudan.candidateMismatchCount w.points cp =
+      Δ₀(f, cp.toPoly.eval ∘ ωs) := by
+  rw [hrep]
+  unfold CompPoly.GuruswamiSudan.candidateMismatchCount
+  rw [← Array.foldl_toList]
+  simp only [Array.toList_ofFn]
+  rw [list_foldl_count_false, Nat.zero_add, length_filter_ofFn_eq_card]
+  rw [hammingDist]
+  simp only [CompPoly.CPolynomial.eval_toPoly, Function.comp_apply,
+    beq_eq_false_iff_ne, ne_eq]
+  apply congrArg Finset.card
+  ext i
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+  exact ne_comm
+
+/-- Packed CompPoly distance filtering agrees with ArkLib Hamming distance. -/
+theorem passesCandidateDistance_represents_hammingDist
+    {cp : CompPoly.CPolynomial F}
+    (hrep : RepresentsArkInput w ωs f) :
+    CompPoly.GuruswamiSudan.passesCandidateDistance w.points e cp = true ↔
+      Δ₀(f, cp.toPoly.eval ∘ ωs) ≤ e := by
+  rw [CompPoly.GuruswamiSudan.passesCandidateDistance_iff,
+    candidateMismatchCount_represents_hammingDist hrep]
+
+omit [Field F] [BEq F] [LawfulBEq F] [DecidableEq F] in
+/-- Runtime words representing an ArkLib embedding have distinct `x` coordinates. -/
+theorem distinctXCoordinates_of_represents
+    (hrep : RepresentsArkInput w ωs f) :
+    CompPoly.GuruswamiSudan.DistinctXCoordinates w.points := by
+  rw [hrep]
+  unfold CompPoly.GuruswamiSudan.DistinctXCoordinates
+  simpa using (List.nodup_ofFn.2 ωs.injective)
+
+/-- Packed CompPoly agreement count is the ArkLib agreement-set cardinality. -/
+theorem matchingPointCount_represents_card
+    {cp : CompPoly.CPolynomial F}
+    (hrep : RepresentsArkInput w ωs f) :
+    CompPoly.GuruswamiSudan.matchingPointCount w.points cp =
+      (Finset.univ.filter fun i : Fin n => f i = cp.toPoly.eval (ωs i)).card := by
+  rw [hrep]
+  unfold CompPoly.GuruswamiSudan.matchingPointCount
+  rw [← Array.foldl_toList]
+  simp only [Array.toList_ofFn]
+  rw [list_foldl_count_true, Nat.zero_add, length_filter_ofFn_eq_card]
+  apply congrArg Finset.card
+  ext i
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+  rw [CompPoly.CPolynomial.eval_toPoly]
+  simp only [beq_iff_eq]
+  exact eq_comm
+
+omit [BEq F] [LawfulBEq F] in
+/-- Agreement and Hamming-distance positions partition the block. -/
+theorem agreement_card_add_hammingDist
+    (p : F[X]) :
+    (Finset.univ.filter fun i : Fin n => f i = p.eval (ωs i)).card +
+      Δ₀(f, p.eval ∘ ωs) = n := by
+  rw [hammingDist]
+  have hcard := Finset.card_filter_add_card_filter_not
+    (s := (Finset.univ : Finset (Fin n)))
+    (p := fun i : Fin n => f i = p.eval (ωs i))
+  simpa [Finset.card_univ, Function.comp_apply] using hcard
+
+omit [Field F] [BEq F] [LawfulBEq F] [DecidableEq F] in
+/-- Runtime word length agrees with the represented ArkLib block length. -/
+theorem length_of_represents
+    (hrep : RepresentsArkInput w ωs f) :
+    w.length = n := by
+  rw [CompPoly.GuruswamiSudan.GSReceivedWord.length, hrep]
+  simp
+
+omit [DecidableEq F] in
+/-- CompPoly bounded degree transfers to mathlib polynomial degree. -/
+theorem toPoly_degree_lt_of_degreeLt
+    {cp : CompPoly.CPolynomial F} {k : Nat}
+    (h : CompPoly.GuruswamiSudan.degreeLt cp k) :
+    cp.toPoly.degree < (k : WithBot Nat) := by
+  simpa [CompPoly.GuruswamiSudan.degreeLt, CompPoly.CPolynomial.degree_toPoly] using h
+
+omit [DecidableEq F] in
+/-- Nat-degree form of `toPoly_degree_lt_of_degreeLt` for positive bounds. -/
+theorem toPoly_natDegree_lt_of_degreeLt
+    {cp : CompPoly.CPolynomial F} {k : Nat}
+    (hk : 0 < k)
+    (h : CompPoly.GuruswamiSudan.degreeLt cp k) :
+    cp.toPoly.natDegree < k := by
+  by_cases hzero : cp.toPoly = 0
+  · simpa [hzero] using hk
+  · exact (Polynomial.natDegree_lt_iff_degree_lt hzero).2
+      (toPoly_degree_lt_of_degreeLt h)
+
+/-- Degree-and-distance characterization for the explicit-parameter decoder. -/
+theorem mem_decodeWithParams_iff_degree_and_distance
+    (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)
+    (params : CompPoly.GuruswamiSudan.GSExecParams)
+    (hparams : GSParamCert k n e params)
+    (hrep : RepresentsArkInput w ωs f)
+    {p : F[X]} :
+    (∃ cp,
+      cp ∈ (CompPoly.GuruswamiSudan.decodeWithParams ctx params w).toList ∧
+        cp.toPoly = p) ↔
+      p.degree < (k : WithBot Nat) ∧
+        Δ₀(f, p.eval ∘ ωs) ≤ e := by
+  constructor
+  · rintro ⟨cp, hcp, rfl⟩
+    have hsound := ctx.sound
+      (points := w.points) (params := params.interp) (radius := params.radius)
+      (p := cp) (by simpa [CompPoly.GuruswamiSudan.decodeWithParams] using hcp)
+    rcases hsound with ⟨_Q, _hvalid, hdeg, _hroot, hdist⟩
+    constructor
+    · have hdegPoly := toPoly_degree_lt_of_degreeLt hdeg
+      simpa [hparams.messageDegree_eq] using hdegPoly
+    · rw [← candidateMismatchCount_represents_hammingDist (cp := cp) hrep]
+      simpa [hparams.radius_eq] using hdist
+  · intro hp
+    let cp : CompPoly.CPolynomial F := cPolynomialOfPoly p
+    have hcp_toPoly : cp.toPoly = p := cPolynomialOfPoly_toPoly p
+    have hpoints_size : w.points.size = n := by
+      simpa [CompPoly.GuruswamiSudan.GSReceivedWord.length] using length_of_represents hrep
+    have hInterpExists :
+        ∃ Q,
+          CompPoly.GuruswamiSudan.ValidInterpolationWitness w.points params.interp Q :=
+      hparams.interpolation_witness_exists w.points hpoints_size
+    have hdistinct := distinctXCoordinates_of_represents hrep
+    have hcpdeg :
+        CompPoly.GuruswamiSudan.degreeLt cp params.interp.messageDegree := by
+      have hdegK := degreeLt_cPolynomialOfPoly_of_degree_lt (k := k) hp.1
+      simpa [cp, hparams.messageDegree_eq] using hdegK
+    have hmatchLower :
+        n - e ≤ CompPoly.GuruswamiSudan.matchingPointCount w.points cp := by
+      rw [matchingPointCount_represents_card (cp := cp) hrep, hcp_toPoly]
+      have hsum := agreement_card_add_hammingDist (f := f) (ωs := ωs) p
+      omega
+    have hmatches :
+        params.interp.weightedDegreeBound <
+          params.interp.multiplicity *
+            CompPoly.GuruswamiSudan.matchingPointCount w.points cp := by
+      exact lt_of_lt_of_le hparams.enough_agreement_bound
+        (Nat.mul_le_mul_left params.interp.multiplicity hmatchLower)
+    have hpass :
+        CompPoly.GuruswamiSudan.passesCandidateDistance w.points params.radius cp =
+          true := by
+      rw [passesCandidateDistance_represents_hammingDist
+        (e := params.radius) (cp := cp) hrep]
+      simpa [hparams.radius_eq, hcp_toPoly] using hp.2
+    have hmem := ctx.complete
+      (points := w.points) (params := params.interp) (radius := params.radius)
+      (p := cp) hInterpExists hdistinct hcpdeg hmatches hpass
+    exact ⟨cp, by simpa [CompPoly.GuruswamiSudan.decodeWithParams] using hmem, hcp_toPoly⟩
+
+/-- Set-membership characterization for the explicit-parameter decoder. -/
+theorem mem_decodeWithParams_iff_spec
+    (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)
+    (params : CompPoly.GuruswamiSudan.GSExecParams)
+    (hparams : GSParamCert k n e params)
+    (hrep : RepresentsArkInput w ωs f)
+    {p : F[X]} :
+    (∃ cp,
+      cp ∈ (CompPoly.GuruswamiSudan.decodeWithParams ctx params w).toList ∧
+        cp.toPoly = p) ↔
+      p ∈ GSSpecSet k e ωs f := by
+  simpa [GSSpecSet] using
+    (mem_decodeWithParams_iff_degree_and_distance
+      (ctx := ctx) (params := params) (hparams := hparams) (hrep := hrep) (p := p))
+
+/-- Set-membership characterization for the selector-backed decoder. -/
+theorem mem_decode_iff_spec
+    (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)
+    (selector : GSParamSelector)
+    (hrep : RepresentsArkInput w ωs f)
+    (hjohnson : JohnsonSpecCondition k n e)
+    {p : F[X]} :
+    (∃ cp,
+      cp ∈ (CompPoly.GuruswamiSudan.decode ctx selector.toCompPolySelector k e w).toList ∧
+        cp.toPoly = p) ↔
+      p ∈ GSSpecSet k e ωs f := by
+  constructor
+  · intro hp
+    unfold CompPoly.GuruswamiSudan.decode at hp
+    cases hchoose : selector.toCompPolySelector.choose k w.length e with
+    | none =>
+        simp [hchoose] at hp
+    | some params =>
+        have hparamsLen := selector.sound hchoose
+        have hlen := length_of_represents hrep
+        have hparams : GSParamCert k n e params := by
+          simpa [hlen] using hparamsLen
+        have hp' :
+            ∃ cp,
+              cp ∈ (CompPoly.GuruswamiSudan.decodeWithParams ctx params w).toList ∧
+                cp.toPoly = p := by
+          simpa [hchoose] using hp
+        exact (mem_decodeWithParams_iff_spec
+          (ctx := ctx) (params := params) (hparams := hparams)
+          (hrep := hrep) (p := p)).1 hp'
+  · intro hp
+    rcases selector.complete hjohnson with ⟨params, hchoose, hparams⟩
+    have hlen := length_of_represents hrep
+    have hp' := (mem_decodeWithParams_iff_spec
+      (ctx := ctx) (params := params) (hparams := hparams)
+      (hrep := hrep) (p := p)).2 hp
+    simpa [CompPoly.GuruswamiSudan.decode, hlen, hchoose] using hp'
+
+/-- Soundness corollary for the explicit-parameter executable decoder. -/
+theorem decodeWithParams_sound
+    (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)
+    (params : CompPoly.GuruswamiSudan.GSExecParams)
+    (hparams : GSParamCert k n e params)
+    (hrep : RepresentsArkInput w ωs f)
+    {cp : CompPoly.CPolynomial F}
+    (hcp : cp ∈ (CompPoly.GuruswamiSudan.decodeWithParams ctx params w).toList) :
+    cp.toPoly.degree < (k : WithBot Nat) ∧
+      Δ₀(f, cp.toPoly.eval ∘ ωs) ≤ e :=
+  (mem_decodeWithParams_iff_degree_and_distance
+    (ctx := ctx) (params := params) (hparams := hparams) (hrep := hrep)
+    (p := cp.toPoly)).1 ⟨cp, hcp, rfl⟩
+
+/-- Completeness corollary for the explicit-parameter executable decoder. -/
+theorem decodeWithParams_complete
+    (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)
+    (params : CompPoly.GuruswamiSudan.GSExecParams)
+    (hparams : GSParamCert k n e params)
+    (hrep : RepresentsArkInput w ωs f)
+    {p : F[X]}
+    (hp : p ∈ GSSpecSet k e ωs f) :
+    ∃ cp,
+      cp ∈ (CompPoly.GuruswamiSudan.decodeWithParams ctx params w).toList ∧
+        cp.toPoly = p :=
+  (mem_decodeWithParams_iff_spec
+    (ctx := ctx) (params := params) (hparams := hparams) (hrep := hrep)
+    (p := p)).2 hp
+
+/-- Soundness corollary for the selector-backed executable decoder. -/
+theorem decode_sound
+    (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)
+    (selector : GSParamSelector)
+    (hrep : RepresentsArkInput w ωs f)
+    (hjohnson : JohnsonSpecCondition k n e)
+    {cp : CompPoly.CPolynomial F}
+    (hcp : cp ∈ (CompPoly.GuruswamiSudan.decode ctx selector.toCompPolySelector k e w).toList) :
+    cp.toPoly.degree < (k : WithBot Nat) ∧
+      Δ₀(f, cp.toPoly.eval ∘ ωs) ≤ e := by
+  have hp := (mem_decode_iff_spec
+    (ctx := ctx) (selector := selector) (hrep := hrep) (hjohnson := hjohnson)
+    (p := cp.toPoly)).1 ⟨cp, hcp, rfl⟩
+  simpa [GSSpecSet] using hp
+
+/-- Completeness corollary for the selector-backed executable decoder. -/
+theorem decode_complete
+    (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)
+    (selector : GSParamSelector)
+    (hrep : RepresentsArkInput w ωs f)
+    (hjohnson : JohnsonSpecCondition k n e)
+    {p : F[X]}
+    (hp : p ∈ GSSpecSet k e ωs f) :
+    ∃ cp,
+      cp ∈ (CompPoly.GuruswamiSudan.decode ctx selector.toCompPolySelector k e w).toList ∧
+        cp.toPoly = p :=
+  (mem_decode_iff_spec
+    (ctx := ctx) (selector := selector) (hrep := hrep) (hjohnson := hjohnson)
+    (p := p)).2 hp
+
+/--
+Compatibility with the specification `decoder`, under an explicit degree
+hypothesis. The degree hypothesis supplies the bounded-degree premise used in
+the reverse direction.
+-/
+theorem mem_decodeWithParams_iff_mem_decoder_of_degree_lt
+    (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)
+    (params : CompPoly.GuruswamiSudan.GSExecParams)
+    (hparams : GSParamCert k n e params)
+    (hrep : RepresentsArkInput w ωs f)
+    (he : (e : ℝ) < (n : ℝ) - Real.sqrt (((k : ℝ) + 1) * (n : ℝ)))
+    {p : F[X]}
+    (hdeg : p.natDegree < k) :
+    (∃ cp,
+      cp ∈ (CompPoly.GuruswamiSudan.decodeWithParams ctx params w).toList ∧
+        cp.toPoly = p) ↔
+      p ∈ decoder k r D e ωs f := by
+  constructor
+  · intro hp
+    have hspec := (mem_decodeWithParams_iff_degree_and_distance
+      (ctx := ctx) (params := params) (hparams := hparams) (hrep := hrep)
+      (p := p)).1 hp
+    exact mem_decoder_of_dist (n := n) (k := k) (r := r) (D := D) (e := e)
+      he hdeg hspec.2
+  · intro hp
+    have hdist := dist_le_of_mem_decoder (n := n) (k := k) (r := r) (D := D)
+      (e := e) he hp
+    have hpdegree : p.degree < (k : WithBot Nat) :=
+      lt_of_le_of_lt degree_le_natDegree (by exact_mod_cast hdeg)
+    exact (mem_decodeWithParams_iff_degree_and_distance
+      (ctx := ctx) (params := params) (hparams := hparams) (hrep := hrep)
+      (p := p)).2 ⟨hpdegree, hdist⟩
+
+/--
+Selector-backed compatibility with the specification `decoder`, under an
+explicit degree hypothesis. The proof factors through the shared
+degree-and-distance specification.
+-/
+theorem mem_decode_iff_mem_decoder_of_degree_lt
+    (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)
+    (selector : GSParamSelector)
+    (hrep : RepresentsArkInput w ωs f)
+    (he : (e : ℝ) < (n : ℝ) - Real.sqrt (((k : ℝ) + 1) * (n : ℝ)))
+    {p : F[X]}
+    (hdeg : p.natDegree < k) :
+    (∃ cp,
+      cp ∈ (CompPoly.GuruswamiSudan.decode ctx selector.toCompPolySelector k e w).toList ∧
+        cp.toPoly = p) ↔
+      p ∈ decoder k r D e ωs f := by
+  have hjohnson : JohnsonSpecCondition k n e := by
+    simpa [JohnsonSpecCondition] using he
+  constructor
+  · intro hp
+    have hspec := (mem_decode_iff_spec
+      (ctx := ctx) (selector := selector) (hrep := hrep) (hjohnson := hjohnson)
+      (p := p)).1 hp
+    exact mem_decoder_of_dist (n := n) (k := k) (r := r) (D := D) (e := e)
+      he hdeg hspec.2
+  · intro hp
+    have hdist := dist_le_of_mem_decoder (n := n) (k := k) (r := r) (D := D)
+      (e := e) he hp
+    have hpdegree : p.degree < (k : WithBot Nat) :=
+      lt_of_le_of_lt degree_le_natDegree (by exact_mod_cast hdeg)
+    exact (mem_decode_iff_spec
+      (ctx := ctx) (selector := selector) (hrep := hrep) (hjohnson := hjohnson)
+      (p := p)).2 ⟨hpdegree, hdist⟩
+
+end GuruswamiSudan

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Correctness.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Correctness.lean
@@ -439,7 +439,7 @@ theorem distinctXCoordinates_of_represents
     CompPoly.GuruswamiSudan.DistinctXCoordinates w.points := by
   rw [hrep]
   unfold CompPoly.GuruswamiSudan.DistinctXCoordinates
-  simpa using (List.nodup_ofFn.2 ωs.injective)
+  simpa [Function.comp_def] using (List.nodup_ofFn.2 ωs.injective)
 
 /-- Packed CompPoly agreement count is the ArkLib agreement-set cardinality. -/
 theorem matchingPointCount_represents_card

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Correctness.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Correctness.lean
@@ -332,7 +332,7 @@ theorem decodeWithParams_complete
     (ctx := ctx) (params := params) (hparams := hparams) (hrep := hrep)
     (p := p)).2 hp
 
-/-- Soundness corollary for the selector-backed executable decoder. -/
+/-- Soundness corollary for the selector-backed executable decoder under selector completeness. -/
 theorem decode_sound
     (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)
     (selector : GSParamSelector)
@@ -347,7 +347,8 @@ theorem decode_sound
     (p := cp.toPoly)).1 ⟨cp, hcp, rfl⟩
   simpa [GSSpecSet] using hp
 
-/-- Completeness corollary for the selector-backed executable decoder. -/
+/-- Completeness corollary for the selector-backed executable decoder under
+selector completeness. -/
 theorem decode_complete
     (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)
     (selector : GSParamSelector)
@@ -364,8 +365,8 @@ theorem decode_complete
 
 /--
 Compatibility with the specification `decoder`, under an explicit degree
-hypothesis. The degree hypothesis supplies the bounded-degree premise used in
-the reverse direction.
+hypothesis. The degree hypothesis supplies the bounded-degree premise needed to
+compare with the specification decoder.
 -/
 theorem mem_decodeWithParams_iff_mem_decoder_of_degree_lt
     (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)
@@ -398,7 +399,7 @@ theorem mem_decodeWithParams_iff_mem_decoder_of_degree_lt
 /--
 Selector-backed compatibility with the specification `decoder`, under an
 explicit degree hypothesis. The proof factors through the shared
-degree-and-distance specification.
+degree-and-distance specification and the selector completeness condition.
 -/
 theorem mem_decode_iff_mem_decoder_of_degree_lt
     (ctx : CompPoly.GuruswamiSudan.GSFilteredCoreContext F)

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Correctness.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Correctness.lean
@@ -31,11 +31,6 @@ def RepresentsArkInput
 def GSSpecSet (k e : Nat) (ωs : Fin n ↪ F) (f : Fin n → F) : Set F[X] :=
   {p | p.degree < (k : WithBot Nat) ∧ Δ₀(f, p.eval ∘ ωs) ≤ e}
 
-/-- Output array represents exactly a semantic set of mathlib polynomials. -/
-def OutputRepresentsSet
-    (out : Array (CompPoly.CPolynomial F)) (spec : Set F[X]) : Prop :=
-  ∀ p, (∃ cp, cp ∈ out.toList ∧ cp.toPoly = p) ↔ p ∈ spec
-
 private lemma list_foldl_count_false {α : Type*}
     (xs : List α) (p : α → Bool) (acc : Nat) :
     xs.foldl (fun count x => if p x then count else count + 1) acc =

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Executable.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Executable.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Valerii Huhnin
+-/
+
+import Mathlib.Data.Real.Sqrt
+
+import ArkLib.Data.CodingTheory.GuruswamiSudan.Basic
+
+import CompPoly.Bivariate.GuruswamiSudan
+
+/-!
+# Executable Guruswami-Sudan Decoder
+
+ArkLib integration layer for the executable CompPoly Guruswami-Sudan core.
+The decoder uses CompPoly's packed runtime formats, and correctness statements
+are collected in `ArkLib.Data.CodingTheory.GuruswamiSudan.Correctness`.
+-/
+
+namespace GuruswamiSudan
+
+/-- Certificate that executable parameters are valid for `(k, n, e)`. -/
+structure GSParamCert
+    (k n e : Nat)
+    (params : CompPoly.GuruswamiSudan.GSExecParams) : Prop where
+  messageDegree_eq :
+    params.interp.messageDegree = k
+  radius_eq :
+    params.radius = e
+  multiplicity_pos :
+    0 < params.interp.multiplicity
+  interpolation_capacity :
+    numVars k params.interp.weightedDegreeBound >
+      numConstraints n params.interp.multiplicity
+  interpolation_witness_exists :
+    ∀ {F : Type} [Field F] [BEq F] [LawfulBEq F] [DecidableEq F],
+      (points : Array (F × F)) →
+      points.size = n →
+        ∃ Q, CompPoly.GuruswamiSudan.ValidInterpolationWitness points params.interp Q
+  enough_agreement_bound :
+    params.interp.weightedDegreeBound <
+      params.interp.multiplicity * (n - e)
+
+/-- ArkLib Johnson-radius condition for selector completeness. -/
+def JohnsonSpecCondition (k n e : Nat) : Prop :=
+  (e : ℝ) < (n : ℝ) - Real.sqrt (((k : ℝ) + 1) * (n : ℝ))
+
+/-- Pure integer check matching the numeric fields of `GSParamCert`. -/
+def paramsPassIntegerChecks
+    (k n e : Nat)
+    (params : CompPoly.GuruswamiSudan.GSExecParams) : Bool :=
+  decide (params.interp.messageDegree = k) &&
+    decide (params.radius = e) &&
+      decide (0 < params.interp.multiplicity) &&
+        decide (numVars k params.interp.weightedDegreeBound >
+          numConstraints n params.interp.multiplicity) &&
+          decide (params.interp.weightedDegreeBound <
+            params.interp.multiplicity * (n - e))
+
+/-- Constructor for executable parameters from multiplicity and weighted-degree bound. -/
+def execParamsOfMultiplicityAndDegree
+    (k e multiplicity weightedDegreeBound : Nat) :
+    CompPoly.GuruswamiSudan.GSExecParams :=
+  { interp :=
+      { messageDegree := k
+        multiplicity := multiplicity
+        weightedDegreeBound := weightedDegreeBound }
+    radius := e }
+
+/-- Bounded, purely integer parameter search. -/
+def searchParamsUpTo
+    (maxMultiplicity maxWeightedDegree k n e : Nat) :
+    Option CompPoly.GuruswamiSudan.GSExecParams :=
+  (List.range' 1 maxMultiplicity).findSome? fun multiplicity =>
+    match (List.range (maxWeightedDegree + 1)).find? fun weightedDegreeBound =>
+        paramsPassIntegerChecks k n e
+          (execParamsOfMultiplicityAndDegree k e multiplicity weightedDegreeBound) with
+    | some weightedDegreeBound =>
+        some (execParamsOfMultiplicityAndDegree k e multiplicity weightedDegreeBound)
+    | none => none
+
+/-- Parameter selector for the selector-backed executable decoder. -/
+structure GSParamSelector where
+  toCompPolySelector : CompPoly.GuruswamiSudan.GSParamSelector
+  sound :
+    ∀ {k n e params},
+      toCompPolySelector.choose k n e = some params →
+        GSParamCert k n e params
+  complete :
+    ∀ {k n e},
+      JohnsonSpecCondition k n e →
+        ∃ params,
+          toCompPolySelector.choose k n e = some params ∧
+            GSParamCert k n e params
+
+/-- Certificate for using bounded integer search as a parameter selector. -/
+structure GSBoundedSearchCert (maxMultiplicity maxWeightedDegree : Nat) : Prop where
+  sound :
+    ∀ {k n e params},
+      searchParamsUpTo maxMultiplicity maxWeightedDegree k n e = some params →
+        GSParamCert k n e params
+  complete :
+    ∀ {k n e},
+      JohnsonSpecCondition k n e →
+        ∃ params,
+          searchParamsUpTo maxMultiplicity maxWeightedDegree k n e = some params ∧
+            GSParamCert k n e params
+
+/-- Parameter selector backed by bounded integer search and a proof certificate. -/
+def boundedSearchParamSelector
+    {maxMultiplicity maxWeightedDegree : Nat}
+    (cert : GSBoundedSearchCert maxMultiplicity maxWeightedDegree) :
+    GSParamSelector where
+  toCompPolySelector :=
+    { choose := searchParamsUpTo maxMultiplicity maxWeightedDegree }
+  sound := cert.sound
+  complete := cert.complete
+
+end GuruswamiSudan

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Executable.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Executable.lean
@@ -34,11 +34,6 @@ structure GSParamCert
   interpolation_capacity :
     numVars k params.interp.weightedDegreeBound >
       numConstraints n params.interp.multiplicity
-  interpolation_witness_exists :
-    ∀ {F : Type} [Field F] [BEq F] [LawfulBEq F] [DecidableEq F],
-      (points : Array (F × F)) →
-      points.size = n →
-        ∃ Q, CompPoly.GuruswamiSudan.ValidInterpolationWitness points params.interp Q
   enough_agreement_bound :
     params.interp.weightedDegreeBound <
       params.interp.multiplicity * (n - e)
@@ -94,28 +89,5 @@ structure GSParamSelector where
         ∃ params,
           toCompPolySelector.choose k n e = some params ∧
             GSParamCert k n e params
-
-/-- Certificate for using bounded integer search as an ArkLib parameter selector. -/
-structure GSBoundedSearchCert (maxMultiplicity maxWeightedDegree : Nat) : Prop where
-  sound :
-    ∀ {k n e params},
-      searchParamsUpTo maxMultiplicity maxWeightedDegree k n e = some params →
-        GSParamCert k n e params
-  complete :
-    ∀ {k n e},
-      JohnsonSpecCondition k n e →
-        ∃ params,
-          searchParamsUpTo maxMultiplicity maxWeightedDegree k n e = some params ∧
-            GSParamCert k n e params
-
-/-- ArkLib parameter selector backed by bounded integer search and a proof certificate. -/
-def boundedSearchParamSelector
-    {maxMultiplicity maxWeightedDegree : Nat}
-    (cert : GSBoundedSearchCert maxMultiplicity maxWeightedDegree) :
-    GSParamSelector where
-  toCompPolySelector :=
-    { choose := searchParamsUpTo maxMultiplicity maxWeightedDegree }
-  sound := cert.sound
-  complete := cert.complete
 
 end GuruswamiSudan

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Executable.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Executable.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Valerii Huhnin
 -/
 
-import Mathlib.Data.Real.Sqrt
+import Mathlib.Analysis.Real.Sqrt
 
 import ArkLib.Data.CodingTheory.GuruswamiSudan.Basic
 

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Executable.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Executable.lean
@@ -13,9 +13,10 @@ import CompPoly.Bivariate.GuruswamiSudan
 /-!
 # Executable Guruswami-Sudan Decoder
 
-ArkLib integration layer for the executable CompPoly Guruswami-Sudan core.
-The decoder uses CompPoly's packed runtime formats, and correctness statements
-are collected in `ArkLib.Data.CodingTheory.GuruswamiSudan.Correctness`.
+ArkLib integration layer for the executable CompPoly Guruswami-Sudan decoder.
+ArkLib-specific parameter certificates and selectors wrap CompPoly's packed
+point-array API; correctness statements are collected in
+`ArkLib.Data.CodingTheory.GuruswamiSudan.Correctness`.
 -/
 
 namespace GuruswamiSudan
@@ -80,7 +81,7 @@ def searchParamsUpTo
         some (execParamsOfMultiplicityAndDegree k e multiplicity weightedDegreeBound)
     | none => none
 
-/-- Parameter selector for the selector-backed executable decoder. -/
+/-- ArkLib-certified view of a CompPoly parameter selector. -/
 structure GSParamSelector where
   toCompPolySelector : CompPoly.GuruswamiSudan.GSParamSelector
   sound :
@@ -94,7 +95,7 @@ structure GSParamSelector where
           toCompPolySelector.choose k n e = some params ∧
             GSParamCert k n e params
 
-/-- Certificate for using bounded integer search as a parameter selector. -/
+/-- Certificate for using bounded integer search as an ArkLib parameter selector. -/
 structure GSBoundedSearchCert (maxMultiplicity maxWeightedDegree : Nat) : Prop where
   sound :
     ∀ {k n e params},
@@ -107,7 +108,7 @@ structure GSBoundedSearchCert (maxMultiplicity maxWeightedDegree : Nat) : Prop w
           searchParamsUpTo maxMultiplicity maxWeightedDegree k n e = some params ∧
             GSParamCert k n e params
 
-/-- Parameter selector backed by bounded integer search and a proof certificate. -/
+/-- ArkLib parameter selector backed by bounded integer search and a proof certificate. -/
 def boundedSearchParamSelector
     {maxMultiplicity maxWeightedDegree : Nat}
     (cert : GSBoundedSearchCert maxMultiplicity maxWeightedDegree) :

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/GuruswamiSudan.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/GuruswamiSudan.lean
@@ -117,6 +117,79 @@ theorem dist_le_of_mem_decoder
     exact hin.2
   · simp at hin
 
+/-- From the Johnson radius condition `e < n - √((k+1)·n)` there is a multiplicity
+`m > 0` whose relative agreement requirement lies strictly inside the proximity-gap
+Johnson radius `proximity_gap_johnson k n m`. As the radius approaches the Johnson
+bound the required `m` grows without bound. -/
+lemma exists_multiplicity_of_johnson {k n e : ℕ}
+    (he : (e : ℝ) < ↑n - Real.sqrt ((↑k + 1) * ↑n)) :
+    ∃ m : ℕ, 0 < m ∧ (e : ℝ) / ↑n < proximity_gap_johnson k n m := by
+  -- Extract basic bounds from `he`.
+  have heNonneg : (0 : ℝ) ≤ e := Nat.cast_nonneg e
+  have hsqrtNonneg := Real.sqrt_nonneg ((↑k + 1) * (↑n : ℝ))
+  have hnPos : (0 : ℝ) < n := by linarith
+  -- Show there exists a suitable multiplicity parameter m such that
+  -- `proximity_gap_johnson k n m > e / n`.
+  -- `proximity_gap_johnson k n m = 1 - √ρ - √ρ/(2m)` where
+  -- $\rho = (k+1)/n$.
+  -- From `he` we get $e/n < 1 - \sqrt{\rho}$; for $m$ large enough,
+  -- $\sqrt{\rho}/(2m) < \text{gap}$.
+  -- Relate the ℚ-based √ρ in `proximity_gap_johnson` to the
+  -- ℝ-based $\sqrt{(k+1) \cdot n}$ in `he`.
+  -- $\rho = (k+1)/n$ casts to $(k+1)/n$ in ℝ, and
+  -- $\sqrt{\rho} \cdot n = \sqrt{(k+1) \cdot n}$.
+  set sqrtRho : ℝ :=
+    Real.sqrt (↑((k + 1 : ℚ) / (↑n : ℚ)))
+  have hρCast :
+      (↑((k + 1 : ℚ) / (↑n : ℚ)) : ℝ) = (↑k + 1) / ↑n := by
+    push_cast
+    ring
+  have hρNonneg :
+      (0 : ℝ) ≤ ↑((k + 1 : ℚ) / (↑n : ℚ)) := by
+    rw [hρCast]
+    positivity
+  have hsqrtRhoNonneg : 0 ≤ sqrtRho :=
+    Real.sqrt_nonneg _
+  -- Key identity: sqrtRho * n = √((k+1)*n)
+  have hsqrtRel :
+      sqrtRho * ↑n = Real.sqrt ((↑k + 1) * ↑n) := by
+    conv_rhs =>
+      rw [show (↑k + 1 : ℝ) * ↑n =
+        ↑((k + 1 : ℚ) / ↑n) * (↑n * ↑n) from by
+        rw [hρCast]; field_simp]
+    rw [Real.sqrt_mul hρNonneg,
+      Real.sqrt_mul_self (le_of_lt hnPos)]
+  -- From he, derive e/n < 1 - sqrtRho
+  have hGap : (e : ℝ) / ↑n < 1 - sqrtRho := by
+    rw [div_lt_iff₀ hnPos]
+    nlinarith [hsqrtRel]
+  -- The gap is positive
+  set gap := 1 - sqrtRho - (e : ℝ) / ↑n with gapDef
+  have hgapPos : 0 < gap := by linarith
+  -- Find m₀ > sqrtRho / (2 * gap) by the Archimedean
+  -- property
+  obtain ⟨m₀, hm₀⟩ := exists_nat_gt (sqrtRho / (2 * gap))
+  have hm₀Pos : 0 < m₀ := by
+    rcases Nat.eq_zero_or_pos m₀ with rfl | h
+    · exfalso
+      simp at hm₀
+      linarith [div_nonneg hsqrtRhoNonneg
+        (by linarith : (0:ℝ) ≤ 2 * gap)]
+    · exact h
+  -- sqrtRho / (2 * m₀) < gap
+  have hm₀PosReal : (0 : ℝ) < ↑m₀ :=
+    Nat.cast_pos.mpr hm₀Pos
+  have hm₀Bound : sqrtRho / (2 * ↑m₀) < gap := by
+    have h2m : (0 : ℝ) < 2 * ↑m₀ := by linarith
+    have h2g : (0 : ℝ) < 2 * gap := by linarith
+    rw [div_lt_iff₀ h2m]
+    have hm₀' : sqrtRho / (2 * gap) < ↑m₀ := hm₀
+    rw [div_lt_iff₀ h2g] at hm₀'
+    nlinarith
+  exact ⟨m₀, hm₀Pos, by
+    simp only [proximity_gap_johnson]
+    linarith⟩
+
 /-- If a polynomial of degree $< k$ is $e$-close to the received word,
     it appears in the decoder output. -/
 theorem mem_decoder_of_dist
@@ -144,70 +217,10 @@ theorem mem_decoder_of_dist
             Real.sqrt_le_sqrt (by exact_mod_cast this)
         _ = ↑n := Real.sqrt_mul_self (le_of_lt hnPos)
     linarith
-  -- Show there exists a suitable multiplicity parameter m such that
-  -- `proximity_gap_johnson k n m > e / n`.
-  -- `proximity_gap_johnson k n m = 1 - √ρ - √ρ/(2m)` where
-  -- $\rho = (k+1)/n$.
-  -- From `he` we get $e/n < 1 - \sqrt{\rho}$; for $m$ large enough,
-  -- $\sqrt{\rho}/(2m) < \text{gap}$.
-  have hExists :
-      ∃ m : ℕ, 0 < m ∧
-        (e : ℝ) / ↑n < proximity_gap_johnson k n m := by
-    -- Relate the ℚ-based √ρ in `proximity_gap_johnson` to the
-    -- ℝ-based $\sqrt{(k+1) \cdot n}$ in `he`.
-    -- $\rho = (k+1)/n$ casts to $(k+1)/n$ in ℝ, and
-    -- $\sqrt{\rho} \cdot n = \sqrt{(k+1) \cdot n}$.
-    set sqrtRho : ℝ :=
-      Real.sqrt (↑((k + 1 : ℚ) / (↑n : ℚ)))
-    have hρCast :
-        (↑((k + 1 : ℚ) / (↑n : ℚ)) : ℝ) = (↑k + 1) / ↑n := by
-      push_cast
-      ring
-    have hρNonneg :
-        (0 : ℝ) ≤ ↑((k + 1 : ℚ) / (↑n : ℚ)) := by
-      rw [hρCast]
-      positivity
-    have hsqrtRhoNonneg : 0 ≤ sqrtRho :=
-      Real.sqrt_nonneg _
-    -- Key identity: sqrtRho * n = √((k+1)*n)
-    have hsqrtRel :
-        sqrtRho * ↑n = Real.sqrt ((↑k + 1) * ↑n) := by
-      conv_rhs =>
-        rw [show (↑k + 1 : ℝ) * ↑n =
-          ↑((k + 1 : ℚ) / ↑n) * (↑n * ↑n) from by
-          rw [hρCast]; field_simp]
-      rw [Real.sqrt_mul hρNonneg,
-        Real.sqrt_mul_self (le_of_lt hnPos)]
-    -- From he, derive e/n < 1 - sqrtRho
-    have hGap : (e : ℝ) / ↑n < 1 - sqrtRho := by
-      rw [div_lt_iff₀ hnPos]
-      nlinarith [hsqrtRel]
-    -- The gap is positive
-    set gap := 1 - sqrtRho - (e : ℝ) / ↑n with gapDef
-    have hgapPos : 0 < gap := by linarith
-    -- Find m₀ > sqrtRho / (2 * gap) by the Archimedean
-    -- property
-    obtain ⟨m₀, hm₀⟩ := exists_nat_gt (sqrtRho / (2 * gap))
-    have hm₀Pos : 0 < m₀ := by
-      rcases Nat.eq_zero_or_pos m₀ with rfl | h
-      · exfalso
-        simp at hm₀
-        linarith [div_nonneg hsqrtRhoNonneg
-          (by linarith : (0:ℝ) ≤ 2 * gap)]
-      · exact h
-    -- sqrtRho / (2 * m₀) < gap
-    have hm₀PosReal : (0 : ℝ) < ↑m₀ :=
-      Nat.cast_pos.mpr hm₀Pos
-    have hm₀Bound : sqrtRho / (2 * ↑m₀) < gap := by
-      have h2m : (0 : ℝ) < 2 * ↑m₀ := by linarith
-      have h2g : (0 : ℝ) < 2 * gap := by linarith
-      rw [div_lt_iff₀ h2m]
-      have hm₀' : sqrtRho / (2 * gap) < ↑m₀ := hm₀
-      rw [div_lt_iff₀ h2g] at hm₀'
-      nlinarith
-    exact ⟨m₀, hm₀Pos, by
-      simp only [proximity_gap_johnson]
-      linarith⟩
+  -- A suitable multiplicity parameter exists by the Johnson-radius bound
+  -- (`exists_multiplicity_of_johnson`).
+  have hExists : ∃ m : ℕ, 0 < m ∧ (e : ℝ) / ↑n < proximity_gap_johnson k n m :=
+    exists_multiplicity_of_johnson he
   -- Unfold the decoder and enter the if-branch
   simp only [decoder]
   rw [dif_pos hExists]

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/GuruswamiSudan.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/GuruswamiSudan.lean
@@ -20,12 +20,12 @@ import CompPoly.Univariate.Lagrange
 /-!
 # Guruswami-Sudan Decoder
 
-This module keeps the abstract Guruswami-Sudan specification decoder alongside
+This module contains the abstract Guruswami-Sudan specification decoder and
 constructive candidate generation for Reed-Solomon codes.
 
 The witness search is implemented by `computeGsWitness`, which solves a linearized
 system of Hasse-derivative constraints with a normalization equation. Candidate
-message polynomials are then filtered by a computable root check for
+message polynomials are filtered by a computable root check for
 `$Q(X, p(X)) = 0$` using CompPoly arithmetic.
 
 ## References
@@ -87,9 +87,8 @@ $< k$ that is $e$-close to `f` appears in the output, provided $e$ is
 within the Johnson bound.  This relies on `dvd_property`.
 
 NOTE: The hypothesis in both theorems uses
-$e < n - \sqrt{(k + 1) \cdot n}$ (matching the GS rate
-parameter $\rho = (k + 1) / n$ used in `proximity_gap_johnson`),
-rather than the original $e \leq n - \sqrt{k \cdot n}$.
+$e < n - \sqrt{(k + 1) \cdot n}$, matching the GS rate
+parameter $\rho = (k + 1) / n$ used in `proximity_gap_johnson`.
 -/
 
 open Classical in
@@ -294,14 +293,15 @@ lemma mem_polynomials_degree_lt
 
 /-! ### CompPoly-based interpolation candidate
 
-The following private helpers use CompPoly's computable `CPolynomial.Raw` type to build a
-Lagrange interpolation candidate from the first `min k n` evaluation points. The result is
-converted back to Mathlib's `Polynomial F` via coefficient extraction (`polynomialOfCoeffs`),
-which is fully computable.
+Private helpers use CompPoly's computable `CPolynomial.Raw` type to build a
+Lagrange interpolation candidate from the first `min k n` evaluation points. The
+result is converted back to Mathlib's `Polynomial F` via coefficient extraction
+(`polynomialOfCoeffs`), which is fully computable.
 
 The candidate is constructed with `rawToPolyBounded`, whose output has bounded degree by
-construction (`degree_polynomialOfCoeffs_deg_lt_deg`). CompPoly's `Raw.toPoly` bridge is
-noncomputable, so we validate the candidate by degree and distance checks before insertion.
+construction (`degree_polynomialOfCoeffs_deg_lt_deg`). CompPoly's `Raw.toPoly`
+conversion is noncomputable, so set membership includes degree and distance
+checks.
 -/
 
 /-- General Lagrange interpolation over arbitrary evaluation points, computed using
@@ -331,7 +331,7 @@ private def rawToPolyBounded (raw : CompPoly.CPolynomial.Raw F) (bound : ℕ) : 
   polynomialOfCoeffs (fun i : Fin bound ↦ raw.coeff i.val)
 
 /-- Build an interpolation candidate from the first `min k n` evaluation points.
-    Returns `none` when `k = 0` (no meaningful interpolation).
+    Returns `none` when `k = 0` or there are no evaluation points to use.
     The result, when `some`, has `degree < k` by construction of `rawToPolyBounded`. -/
 private def compPolyCandidate [Fintype F] (k : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F) :
     Option F[X] :=
@@ -377,7 +377,7 @@ For a bivariate polynomial `Q = ∑ cᵢⱼ X^i Y^j`, the `(a,b)`-Hasse derivati
 `(x₀, y₀)` is `∑ C(i,a) C(j,b) cᵢⱼ x₀^{i-a} y₀^{j-b}`, where `C(n,k)` denotes
 the binomial coefficient.
 
-The following functions compute this evaluation purely computably over coefficient
+These functions compute this evaluation purely computably over coefficient
 vectors, with no reliance on classical choice or nonconstructive root extraction.
 -/
 
@@ -610,7 +610,7 @@ private noncomputable def computeGsWitness (k D r : ℕ) (ωs : Fin n ↪ F) (f 
     Option {c : Fin (D + 1) × Fin (D + 1) → F // isWitnessC k D r ωs f c = true} :=
   (witnessTargets k D).findSome? (solveGsWitnessAtTarget (n := n) k D r ωs f)
 
-/-- Constructive witness-availability check computed from `computeGsWitness`. -/
+/-- Boolean witness-availability predicate computed from `computeGsWitness`. -/
 private noncomputable def hasWitnessC (k D r : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F) : Bool :=
   (computeGsWitness (n := n) k D r ωs f).isSome
 
@@ -693,8 +693,8 @@ private lemma isQRootRaw_iff_all_coeff_zero {k D : ℕ}
 /-- Candidate polynomials validated against a finite constructive witness search
     with Hasse-derivative multiplicity checking and CompPoly-based Q-root extraction.
 
-    The filter first computes one concrete witness `Q` (as coefficient vector `c`)
-    using `computeGsWitness`. Then for each degree-`< k` candidate `p`, it verifies:
+    The filter uses one concrete witness `Q` (as coefficient vector `c`) from
+    `computeGsWitness`. For each degree-`< k` candidate `p`, it verifies:
     1. `Q(X, p(X)) = 0` (Y-root extraction), and
     2. The Hamming distance `Δ₀(f, p ∘ ωs) ≤ e`.
 -/
@@ -718,9 +718,10 @@ private lemma mem_witness_candidate_set_imp [Fintype F] {k r D e : ℕ} {ωs : F
     exact ⟨mem_polynomials_degree_lt.mp hp.1, hp.2.2⟩
   · simp at hp
 
-/-- Strengthened witness soundness: when `r > 0`, every candidate in `witnessCandidateSet`
-    is backed by a witness whose Hasse-derivative multiplicity conditions imply pointwise
-    root vanishing at every interpolation point.
+/-- Witness-backed candidate soundness. When `r > 0`, every candidate in
+    `witnessCandidateSet` is backed by a witness whose Hasse-derivative
+    multiplicity conditions imply pointwise root vanishing at every interpolation
+    point.
 
     Concretely, there exists a coefficient vector `c` satisfying:
     * `isWitnessC` (nonzero in the weighted-degree region and full multiplicity vanishing), and
@@ -748,24 +749,26 @@ private lemma witness_candidate_set_witness_vanishes [Fintype F] {k r D e : ℕ}
       exact ⟨w.1, w.2, hcond.1, fun i ↦ isWitnessC_imp_eval_zero_at_points hr w.2 i⟩
 
 /--
-Constructive decoder candidate set inspired by Guruswami–Sudan.
+Finite decoder candidate set inspired by Guruswami–Sudan.
 
 **Definition.** The computable decoder returns the union of:
-* a CompPoly interpolation fast-path candidate set, and
+* a CompPoly Lagrange interpolation candidate set, and
 * a GS witness-filtered set computed from a constructive linear-system witness search.
 
 The implementation combines two candidate sources:
 
-1. **CompPoly Lagrange candidate** (`compPolyCandidateSet`): A fast-path candidate
+1. **CompPoly Lagrange candidate** (`compPolyCandidateSet`): A candidate
    constructed via CompPoly's computable Lagrange interpolation from the first
-   `min k n` evaluation points. Included only if it passes degree and distance checks.
+   `min k n` evaluation points. The candidate is included when it passes degree
+   and distance checks.
 
 2. **GS witness-filtered candidates** (`witnessCandidateSet`): A concrete witness
    coefficient vector is computed by solving a linearized GS system with normalization.
    Candidates are filtered by `Q(X, p(X)) = 0` and the distance bound.
 
-The implementation is fully computable and avoids classical choice operators,
-classical proof-only decidability wrappers, and nonconstructive root extraction.
+The candidate-generation steps use explicit interpolation, witness search, and
+`Q(X, p(X))` checks, with no nonconstructive root extraction. The definition is
+marked `noncomputable` because it returns a theorem-level `Finset F[X]`.
 -/
 noncomputable def computableDecoder [Fintype F] (k r D e : ℕ) (ωs : Fin n ↪ F)
     (f : Fin n → F) :
@@ -816,11 +819,11 @@ noncomputable def proximityGapDelta0 (k m : ℕ) : ℝ :=
 noncomputable def proximityGapJohnson (k m : ℕ) : ℕ :=
   Nat.floor ((n : ℝ) * proximityGapDelta0 (n := n) k m)
 
-/-! ### Bridge to classical formulations
+/-! ### Classical Formulations
 
-The following definitions and lemmas provide a noncomputable bridge between the computable
-coefficient-vector representation `c : Fin (D+1) × Fin (D+1) → F` and the classical
-Mathlib bivariate polynomial type `F[X][Y]`.
+These definitions and lemmas relate the computable coefficient-vector
+representation `c : Fin (D+1) × Fin (D+1) → F` to the classical Mathlib
+bivariate polynomial type `F[X][Y]`.
 
 The key function `coeffVecToBivariate` constructs a Mathlib bivariate polynomial from a
 bounded coefficient vector. Coefficient agreement between the two representations is
@@ -875,7 +878,7 @@ lemma coeff_vec_to_bivariate_ne_zero_of_isWitnessC
     When the computable `hasWitnessC` check returns `true`, we can extract a concrete
     coefficient vector `c` satisfying `isWitnessC`.
 
-    Additionally, when `m > 0`, the witness satisfies:
+    For `m > 0`, the witness satisfies:
     * Nonzero coefficient in the weighted-degree region (`isWitnessC_nonzero`).
     * All Hasse derivatives of order `< m` vanish at every interpolation point
       (`isWitnessC_hasse_deriv_vanishes`).
@@ -897,13 +900,13 @@ lemma guruswami_sudan_for_proximity_gap_existence
       (proximityGapDegreeBound (n := n) k m) m ωs f).1 hw
   exact ⟨w.1, w.2⟩
 
-/-- Strengthened existence: when the witness check passes and `m > 0`, the extracted
-    witness additionally satisfies pointwise evaluation vanishing at every interpolation
-    point, and the corresponding bivariate polynomial is nonzero.
+/-- Witness extraction with pointwise vanishing. When the witness check passes
+    and `m > 0`, the extracted witness satisfies pointwise evaluation vanishing
+    at every interpolation point, and the corresponding bivariate polynomial is
+    nonzero.
 
-    This is a computable strengthening of
-    `guruswami_sudan_for_proximity_gap_existence`, not a full paper-level
-    quantifier match for lemma 5.3 in [BCIKS20]. -/
+    This lemma exposes computable witness properties associated with
+    `guruswami_sudan_for_proximity_gap_existence`. -/
 lemma guruswami_sudan_for_proximity_gap_existence_strong
     {k m : ℕ} {ωs : Fin n ↪ F} {f : Fin n → F}
     (hm : 0 < m)
@@ -941,13 +944,12 @@ lemma guruswami_sudan_for_proximity_gap_property [Fintype F] {k m : ℕ} {ωs : 
         evalCoeffVecAt k (proximityGapDegreeBound (n := n) k m) c (ωs i) (f i) = 0 := by
   exact witness_candidate_set_witness_vanishes hm hp
 
-/-- Strengthened proximity gap property: additionally asserts that the Q-root extraction
-    result has all coefficients zero (via `isQRootRaw_iff_all_coeff_zero`), and the
-    corresponding bivariate polynomial is nonzero.
+/-- Proximity-gap witness property with zero Q-root coefficients. The Q-root
+    extraction result has all coefficients zero (via `isQRootRaw_iff_all_coeff_zero`),
+    and the corresponding bivariate polynomial is nonzero.
 
-    This lemma is conditional on membership in `witnessCandidateSet`; it should be read
-    as a constructive bridge lemma rather than a direct restatement of lemma 5.3 in
-    [BCIKS20]. -/
+    This lemma assumes membership in `witnessCandidateSet` and exposes the
+    coefficient-vector properties used by the proximity-gap interface. -/
 lemma guruswami_sudan_for_proximity_gap_property_strong [Fintype F] {k m : ℕ} {ωs : Fin n ↪ F}
     {f : Fin n → F}
     {p : ReedSolomon.code ωs k}

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/GuruswamiSudan.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/GuruswamiSudan.lean
@@ -20,12 +20,12 @@ import CompPoly.Univariate.Lagrange
 /-!
 # Guruswami-Sudan Decoder
 
-This module contains the abstract Guruswami-Sudan specification decoder and
+This module keeps the abstract Guruswami-Sudan specification decoder alongside
 constructive candidate generation for Reed-Solomon codes.
 
 The witness search is implemented by `computeGsWitness`, which solves a linearized
 system of Hasse-derivative constraints with a normalization equation. Candidate
-message polynomials are filtered by a computable root check for
+message polynomials are then filtered by a computable root check for
 `$Q(X, p(X)) = 0$` using CompPoly arithmetic.
 
 ## References
@@ -87,8 +87,9 @@ $< k$ that is $e$-close to `f` appears in the output, provided $e$ is
 within the Johnson bound.  This relies on `dvd_property`.
 
 NOTE: The hypothesis in both theorems uses
-$e < n - \sqrt{(k + 1) \cdot n}$, matching the GS rate
-parameter $\rho = (k + 1) / n$ used in `proximity_gap_johnson`.
+$e < n - \sqrt{(k + 1) \cdot n}$ (matching the GS rate
+parameter $\rho = (k + 1) / n$ used in `proximity_gap_johnson`),
+rather than the original $e \leq n - \sqrt{k \cdot n}$.
 -/
 
 open Classical in
@@ -293,15 +294,14 @@ lemma mem_polynomials_degree_lt
 
 /-! ### CompPoly-based interpolation candidate
 
-Private helpers use CompPoly's computable `CPolynomial.Raw` type to build a
-Lagrange interpolation candidate from the first `min k n` evaluation points. The
-result is converted back to Mathlib's `Polynomial F` via coefficient extraction
-(`polynomialOfCoeffs`), which is fully computable.
+The following private helpers use CompPoly's computable `CPolynomial.Raw` type to build a
+Lagrange interpolation candidate from the first `min k n` evaluation points. The result is
+converted back to Mathlib's `Polynomial F` via coefficient extraction (`polynomialOfCoeffs`),
+which is fully computable.
 
 The candidate is constructed with `rawToPolyBounded`, whose output has bounded degree by
-construction (`degree_polynomialOfCoeffs_deg_lt_deg`). CompPoly's `Raw.toPoly`
-conversion is noncomputable, so set membership includes degree and distance
-checks.
+construction (`degree_polynomialOfCoeffs_deg_lt_deg`). CompPoly's `Raw.toPoly` bridge is
+noncomputable, so we validate the candidate by degree and distance checks before insertion.
 -/
 
 /-- General Lagrange interpolation over arbitrary evaluation points, computed using
@@ -331,7 +331,7 @@ private def rawToPolyBounded (raw : CompPoly.CPolynomial.Raw F) (bound : ℕ) : 
   polynomialOfCoeffs (fun i : Fin bound ↦ raw.coeff i.val)
 
 /-- Build an interpolation candidate from the first `min k n` evaluation points.
-    Returns `none` when `k = 0` or there are no evaluation points to use.
+    Returns `none` when `k = 0` (no meaningful interpolation).
     The result, when `some`, has `degree < k` by construction of `rawToPolyBounded`. -/
 private def compPolyCandidate [Fintype F] (k : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F) :
     Option F[X] :=
@@ -377,7 +377,7 @@ For a bivariate polynomial `Q = ∑ cᵢⱼ X^i Y^j`, the `(a,b)`-Hasse derivati
 `(x₀, y₀)` is `∑ C(i,a) C(j,b) cᵢⱼ x₀^{i-a} y₀^{j-b}`, where `C(n,k)` denotes
 the binomial coefficient.
 
-These functions compute this evaluation purely computably over coefficient
+The following functions compute this evaluation purely computably over coefficient
 vectors, with no reliance on classical choice or nonconstructive root extraction.
 -/
 
@@ -610,7 +610,7 @@ private noncomputable def computeGsWitness (k D r : ℕ) (ωs : Fin n ↪ F) (f 
     Option {c : Fin (D + 1) × Fin (D + 1) → F // isWitnessC k D r ωs f c = true} :=
   (witnessTargets k D).findSome? (solveGsWitnessAtTarget (n := n) k D r ωs f)
 
-/-- Boolean witness-availability predicate computed from `computeGsWitness`. -/
+/-- Constructive witness-availability check computed from `computeGsWitness`. -/
 private noncomputable def hasWitnessC (k D r : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F) : Bool :=
   (computeGsWitness (n := n) k D r ωs f).isSome
 
@@ -693,8 +693,8 @@ private lemma isQRootRaw_iff_all_coeff_zero {k D : ℕ}
 /-- Candidate polynomials validated against a finite constructive witness search
     with Hasse-derivative multiplicity checking and CompPoly-based Q-root extraction.
 
-    The filter uses one concrete witness `Q` (as coefficient vector `c`) from
-    `computeGsWitness`. For each degree-`< k` candidate `p`, it verifies:
+    The filter first computes one concrete witness `Q` (as coefficient vector `c`)
+    using `computeGsWitness`. Then for each degree-`< k` candidate `p`, it verifies:
     1. `Q(X, p(X)) = 0` (Y-root extraction), and
     2. The Hamming distance `Δ₀(f, p ∘ ωs) ≤ e`.
 -/
@@ -718,10 +718,9 @@ private lemma mem_witness_candidate_set_imp [Fintype F] {k r D e : ℕ} {ωs : F
     exact ⟨mem_polynomials_degree_lt.mp hp.1, hp.2.2⟩
   · simp at hp
 
-/-- Witness-backed candidate soundness. When `r > 0`, every candidate in
-    `witnessCandidateSet` is backed by a witness whose Hasse-derivative
-    multiplicity conditions imply pointwise root vanishing at every interpolation
-    point.
+/-- Strengthened witness soundness: when `r > 0`, every candidate in `witnessCandidateSet`
+    is backed by a witness whose Hasse-derivative multiplicity conditions imply pointwise
+    root vanishing at every interpolation point.
 
     Concretely, there exists a coefficient vector `c` satisfying:
     * `isWitnessC` (nonzero in the weighted-degree region and full multiplicity vanishing), and
@@ -749,26 +748,24 @@ private lemma witness_candidate_set_witness_vanishes [Fintype F] {k r D e : ℕ}
       exact ⟨w.1, w.2, hcond.1, fun i ↦ isWitnessC_imp_eval_zero_at_points hr w.2 i⟩
 
 /--
-Finite decoder candidate set inspired by Guruswami–Sudan.
+Constructive decoder candidate set inspired by Guruswami–Sudan.
 
 **Definition.** The computable decoder returns the union of:
-* a CompPoly Lagrange interpolation candidate set, and
+* a CompPoly interpolation fast-path candidate set, and
 * a GS witness-filtered set computed from a constructive linear-system witness search.
 
 The implementation combines two candidate sources:
 
-1. **CompPoly Lagrange candidate** (`compPolyCandidateSet`): A candidate
+1. **CompPoly Lagrange candidate** (`compPolyCandidateSet`): A fast-path candidate
    constructed via CompPoly's computable Lagrange interpolation from the first
-   `min k n` evaluation points. The candidate is included when it passes degree
-   and distance checks.
+   `min k n` evaluation points. Included only if it passes degree and distance checks.
 
 2. **GS witness-filtered candidates** (`witnessCandidateSet`): A concrete witness
    coefficient vector is computed by solving a linearized GS system with normalization.
    Candidates are filtered by `Q(X, p(X)) = 0` and the distance bound.
 
-The candidate-generation steps use explicit interpolation, witness search, and
-`Q(X, p(X))` checks, with no nonconstructive root extraction. The definition is
-marked `noncomputable` because it returns a theorem-level `Finset F[X]`.
+The implementation is fully computable and avoids classical choice operators,
+classical proof-only decidability wrappers, and nonconstructive root extraction.
 -/
 noncomputable def computableDecoder [Fintype F] (k r D e : ℕ) (ωs : Fin n ↪ F)
     (f : Fin n → F) :
@@ -819,11 +816,11 @@ noncomputable def proximityGapDelta0 (k m : ℕ) : ℝ :=
 noncomputable def proximityGapJohnson (k m : ℕ) : ℕ :=
   Nat.floor ((n : ℝ) * proximityGapDelta0 (n := n) k m)
 
-/-! ### Classical Formulations
+/-! ### Bridge to classical formulations
 
-These definitions and lemmas relate the computable coefficient-vector
-representation `c : Fin (D+1) × Fin (D+1) → F` to the classical Mathlib
-bivariate polynomial type `F[X][Y]`.
+The following definitions and lemmas provide a noncomputable bridge between the computable
+coefficient-vector representation `c : Fin (D+1) × Fin (D+1) → F` and the classical
+Mathlib bivariate polynomial type `F[X][Y]`.
 
 The key function `coeffVecToBivariate` constructs a Mathlib bivariate polynomial from a
 bounded coefficient vector. Coefficient agreement between the two representations is
@@ -878,7 +875,7 @@ lemma coeff_vec_to_bivariate_ne_zero_of_isWitnessC
     When the computable `hasWitnessC` check returns `true`, we can extract a concrete
     coefficient vector `c` satisfying `isWitnessC`.
 
-    For `m > 0`, the witness satisfies:
+    Additionally, when `m > 0`, the witness satisfies:
     * Nonzero coefficient in the weighted-degree region (`isWitnessC_nonzero`).
     * All Hasse derivatives of order `< m` vanish at every interpolation point
       (`isWitnessC_hasse_deriv_vanishes`).
@@ -900,13 +897,13 @@ lemma guruswami_sudan_for_proximity_gap_existence
       (proximityGapDegreeBound (n := n) k m) m ωs f).1 hw
   exact ⟨w.1, w.2⟩
 
-/-- Witness extraction with pointwise vanishing. When the witness check passes
-    and `m > 0`, the extracted witness satisfies pointwise evaluation vanishing
-    at every interpolation point, and the corresponding bivariate polynomial is
-    nonzero.
+/-- Strengthened existence: when the witness check passes and `m > 0`, the extracted
+    witness additionally satisfies pointwise evaluation vanishing at every interpolation
+    point, and the corresponding bivariate polynomial is nonzero.
 
-    This lemma exposes computable witness properties associated with
-    `guruswami_sudan_for_proximity_gap_existence`. -/
+    This is a computable strengthening of
+    `guruswami_sudan_for_proximity_gap_existence`, not a full paper-level
+    quantifier match for lemma 5.3 in [BCIKS20]. -/
 lemma guruswami_sudan_for_proximity_gap_existence_strong
     {k m : ℕ} {ωs : Fin n ↪ F} {f : Fin n → F}
     (hm : 0 < m)
@@ -944,12 +941,13 @@ lemma guruswami_sudan_for_proximity_gap_property [Fintype F] {k m : ℕ} {ωs : 
         evalCoeffVecAt k (proximityGapDegreeBound (n := n) k m) c (ωs i) (f i) = 0 := by
   exact witness_candidate_set_witness_vanishes hm hp
 
-/-- Proximity-gap witness property with zero Q-root coefficients. The Q-root
-    extraction result has all coefficients zero (via `isQRootRaw_iff_all_coeff_zero`),
-    and the corresponding bivariate polynomial is nonzero.
+/-- Strengthened proximity gap property: additionally asserts that the Q-root extraction
+    result has all coefficients zero (via `isQRootRaw_iff_all_coeff_zero`), and the
+    corresponding bivariate polynomial is nonzero.
 
-    This lemma assumes membership in `witnessCandidateSet` and exposes the
-    coefficient-vector properties used by the proximity-gap interface. -/
+    This lemma is conditional on membership in `witnessCandidateSet`; it should be read
+    as a constructive bridge lemma rather than a direct restatement of lemma 5.3 in
+    [BCIKS20]. -/
 lemma guruswami_sudan_for_proximity_gap_property_strong [Fintype F] {k m : ℕ} {ωs : Fin n ↪ F}
     {f : Fin n → F}
     {p : ReedSolomon.code ωs k}


### PR DESCRIPTION
### Overview

This PR connects ArkLib's Guruswami-Sudan development to the executable decoder recently added in CompPoly. It adds the translation layer needed to run the CompPoly decoder on ArkLib Reed-Solomon inputs and state the result in ArkLib's existing degree-and-distance specification.

This PR includes:

- A small wrapper around CompPoly's decoder parameters and selector interface.
- A bounded search for decoder parameters, with certificates for the conditions ArkLib needs.
- Conversions between ArkLib Reed-Solomon words and CompPoly's packed received-word format.
- Proofs that the executable decoder returns exactly the polynomials described by ArkLib's degree-and-distance specification.
- A bump to CompPoly `v4.30.0-patch1`, together with the new imports.

### Correctness

The main theorem says that the executable output matches the ArkLib specification: returned polynomials have degree `< k` and are within the requested Hamming radius, and every polynomial with those properties appears in the output. There are also compatibility lemmas relating this statement to ArkLib's existing `decoder` under the Johnson-radius assumption.
