### PR TITLE
feat(Append): construct the challenge-oracle SubSpec embeddings

### DIFF
--- a/ArkLib/OracleReduction/Composition/Sequential/Append.lean
+++ b/ArkLib/OracleReduction/Composition/Sequential/Append.lean
@@ -331,8 +331,35 @@ variable {P₁ : Prover oSpec Stmt₁ Wit₁ Stmt₂ Wit₂ pSpec₁}
 
 -- theorem append_runToRound
 
-instance : [(pSpec₁).Challenge]ₒ ⊂ₒ [(pSpec₁ ++ₚ pSpec₂).Challenge]ₒ := sorry
-instance : [(pSpec₂).Challenge]ₒ ⊂ₒ [(pSpec₁ ++ₚ pSpec₂).Challenge]ₒ := sorry
+/-- The challenge type at a left-embedded index of the appended protocol is the
+left protocol's challenge type. -/
+theorem _root_.ProtocolSpec.Challenge_inl (i : pSpec₁.ChallengeIdx) :
+    (pSpec₁ ++ₚ pSpec₂).Challenge (ChallengeIdx.inl i) = pSpec₁.Challenge i := by
+  simp only [ProtocolSpec.append, Challenge, ChallengeIdx.inl, Fin.vappend_eq_append,
+    Fin.append_left]
+
+/-- The challenge type at a right-embedded index of the appended protocol is the
+right protocol's challenge type. -/
+theorem _root_.ProtocolSpec.Challenge_inr (i : pSpec₂.ChallengeIdx) :
+    (pSpec₁ ++ₚ pSpec₂).Challenge (ChallengeIdx.inr i) = pSpec₂.Challenge i := by
+  simp only [ProtocolSpec.append, Challenge, ChallengeIdx.inr, Fin.vappend_eq_append,
+    Fin.append_right]
+
+/-- The left component's challenge oracles embed into the appended protocol's:
+`ChallengeIdx.inl` on indices, transport along `Challenge_inl` on responses. -/
+instance : [(pSpec₁).Challenge]ₒ ⊂ₒ [(pSpec₁ ++ₚ pSpec₂).Challenge]ₒ where
+  monadLift q := ⟨⟨ChallengeIdx.inl q.input.1, q.input.2⟩,
+    q.cont ∘ fun r => cast (ProtocolSpec.Challenge_inl q.input.1) r⟩
+  onQuery t := ⟨ChallengeIdx.inl t.1, t.2⟩
+  onResponse t r := cast (ProtocolSpec.Challenge_inl t.1) r
+
+/-- The right component's challenge oracles embed into the appended protocol's:
+`ChallengeIdx.inr` on indices, transport along `Challenge_inr` on responses. -/
+instance : [(pSpec₂).Challenge]ₒ ⊂ₒ [(pSpec₁ ++ₚ pSpec₂).Challenge]ₒ where
+  monadLift q := ⟨⟨ChallengeIdx.inr q.input.1, q.input.2⟩,
+    q.cont ∘ fun r => cast (ProtocolSpec.Challenge_inr q.input.1) r⟩
+  onQuery t := ⟨ChallengeIdx.inr t.1, t.2⟩
+  onResponse t r := cast (ProtocolSpec.Challenge_inr t.1) r
 
 /--
 States that running an appended prover `P₁.append P₂` with an initial statement `stmt₁` and


### PR DESCRIPTION
Fills the two `sorry`'d instances in `Composition/Sequential/Append.lean`:

```lean
instance : [(pSpec₁).Challenge]ₒ ⊂ₒ [(pSpec₁ ++ₚ pSpec₂).Challenge]ₒ
instance : [(pSpec₂).Challenge]ₒ ⊂ₒ [(pSpec₁ ++ₚ pSpec₂).Challenge]ₒ
```

**Construction.** A `SubSpec` instance is a lens plus a coherent `monadLift`. Here the lens is:
- `onQuery`: `ChallengeIdx.inl`/`.inr` on the oracle index (the embeddings already in `SeqCompose.lean`), identity on the trivial `Unit` query;
- `onResponse`: transport along the challenge-type equalities `Challenge_inl` / `Challenge_inr` — two new lemmas proved by `Fin.append_left`/`Fin.append_right` (these are the equalities sketched in the commented-out `challengeOracleInterface_append_*` lemmas in `SeqCompose.lean`).

`monadLift` is spelled directly in lens form, so the coherence field `liftM_eq_lift` holds by `rfl` — per the design note in `VCVio/OracleComp/Coercions/SubSpec.lean` this keeps lifted queries transparent to `isDefEq`, which matters for the downstream `append_run` factorization work.

**Motivation.** These instances are prerequisites for stating/proving `Prover.append_run` and the append security theorems (they let a component prover's challenge queries be replayed inside the appended protocol). Part of the sequential-composition thread discussed on #627; smallest complete unit, nothing else touched.

**Checks.** `lake build` of the module and all importers (`Sequential.General`, `Security/CoordinateWiseSpecialSoundness/Composition`, `RingSwitching/*`) passes; sorry delta −2; no new axioms.

From The Institute for Ontological Mathematics (IAOM) / Equation Capital dba Apoth3osis