### PR TITLE
docs: add oracle reduction design plan

### DIFF
--- a/docs/design/00-end-state.md
+++ b/docs/design/00-end-state.md
@@ -1,0 +1,208 @@
+# 00 — End State: A Verified Architecture for SNARKs
+
+## 0. Status and scope
+
+This document is a **north star and coverage contract**, not a claim that every proof system has
+already been reduced to one carrier. The near-term scope is classical hash-, algebraic-, and
+lattice-based proof systems under explicitly stated oracle and adversary models. Quantum access,
+relativized relations that query the model's own random oracle, and other execution models require
+new semantics; the architecture must leave seams for them without pretending that the classical
+core already covers them.
+
+The design is being developed on `design/oracle-reduction-v2`, but that branch is documentation and
+prototype provenance, **not an implementation base**. At the 2026-07-13 audit it forked from ArkLib
+at `9f6e989`, while current ArkLib `main` was `e2c3710`; it also carried the older core-rebuild tree.
+Every implementation PR described in [`01a-foundation-pr-plan.md`](01a-foundation-pr-plan.md) starts
+from the then-current default branch. Prototype declarations may be transplanted only as reviewed
+source material.
+
+There is already a separate Lean 4.31 migration candidate, `quang/bump-v4.31.0` at `55a9ccc` after
+merging current `main`. It pins VCVio `cbd4144b` and VCVio's tested PolyFun revision `04a12b6`.
+AR-0 should review, rebase, validate, and land that work (or its successor), not recreate the
+migration from scratch; candidate-branch existence is not itself an acceptance result.
+
+## 1. The ambition
+
+ArkLib should become the integration library in which a broad range of SNARK constructions can be
+stated, composed, compiled, and connected to executable implementations:
+
+- hash-based protocols such as FRI, STIR, WHIR, BaseFold, Binius, and BCS/Micali compilers;
+- algebraic systems such as KZG/PLONK, IPA/Bulletproofs, Nova/ProtoStar folding, pairing-based
+  systems, and protocols proved in the AGM;
+- lattice-based commitments and arguments, including Ajtai-style commitments and structured
+  lattice reductions;
+- recursion, IVC, PCD, aggregation, preprocessing, and executable refinement.
+
+This is a **coverage hypothesis** tested by conformance cases, not an axiom. The first cases are
+sumcheck, FRI, and Nova; a polynomial-commitment protocol, a preprocessing protocol, and one
+lattice-backed protocol must follow before the common carrier is treated as mature. A construction
+that does not naturally pass through ideal oracle reduction may enter at the committed-relation or
+argument-system layer. The architecture must accommodate that route rather than force a false
+encoding.
+
+## 2. Architecture: pipeline plus two cross-cutting planes
+
+The former “layer cake” was useful intuition but misleading as a dependency stack: security games
+quantify over objects at several layers, and ideal reductions do not depend on adversarial worlds.
+The end state has one object/compilation pipeline and two cross-cutting planes.
+
+### 2.1 Object and compilation pipeline
+
+```text
+generic interaction syntax
+        ↓ specialize to oracle protocols
+ideal claims and oracle reductions (Δ)
+        ↓ represent / lower / transport
+committed relations and backend capabilities
+        ↓ Fiat–Shamir / argument compiler
+interactive or noninteractive argument systems
+        ↓ executable refinement
+production representations and implementations
+```
+
+- **PolyFun** supplies domain-agnostic interaction semantics: polynomial functors, `FreeM` and
+  `ITree`, displayed data, handlers/responders, dynamical systems, finite and infinite runs,
+  structural traces, generic sequential/multiparty/concurrent wiring, and refinement.
+- **VCVio** specializes that substrate to oracle computation and probabilistic semantics:
+  `OracleSpec`, `OracleComp`, `QueryImpl`, stateful simulation, evaluation distributions, random
+  oracles, query resources, and cryptographic games.
+- **ArkLib** supplies protocol meaning: prover/verifier roles, public and oracle messages, claims,
+  relations, reductions, extractors, commitment-backend adapters, compilers, and concrete proof
+  systems.
+
+### 2.2 Adversarial-execution plane (Γ)
+
+Worlds, persistent state, query-event traces, replay/reprogramming, probability, and resource
+accounting interpret the pipeline's objects. PolyFun owns their effect-polymorphic structural
+algebra; VCVio owns oracle/probability specializations; ArkLib owns the protocol games and security
+notions that consume them. This plane is the subject of `03`, not a prerequisite for defining the
+ideal carrier in `02`.
+
+### 2.3 Mathematical and representation plane
+
+`ArkLib/Data`, CompPoly, coding theory, finite fields, curves, modules, lattices, encodings, and
+serialization cross several semantic layers. They are not “below” protocol syntax in a useful
+sense. Each backend states exactly which mathematical structures and representation theorems it
+uses.
+
+## 3. The commonality claim, stated precisely
+
+The target is **one capability-parametric language of ideal resources and claims**, not literal
+identity of every hash-, curve-, and lattice-based construction.
+
+- A FRI fold, a Nova fold, and a polynomial-evaluation reduction may all expose virtual output
+  oracles, but their interfaces and guarantees differ.
+- A backend advertises operations it can realize: random access, batch opening, evaluation,
+  linear action on commitments, proximity enforcement, or a link argument.
+- `GuaranteeTransport` says how an ideal slot guarantee becomes a commit/open/link obligation. It
+  does not assert that every backend can realize every guarantee.
+- A conformance theorem embeds a concrete construction into the common carrier and discharges its
+  capability obligations. Failed conformance is evidence that the carrier needs a principled
+  extension, not permission to add a scheme-local parallel framework.
+
+Nova and FRI remain the canonical contrast. Pedersen linearity realizes a virtual linear action on
+committed witnesses without a fresh prover message; Merkle commitments do not, so FRI requires a
+fresh committed word plus consistency and proximity obligations. The shared abstraction is the
+ideal transformation plus an explicit backend action—not a claim that the concrete protocols are
+the same.
+
+## 4. Security assumptions are complete game data
+
+An assumption family is not merely “world + adversary class.” A usable computational game records:
+
+1. the security parameter and public parameter/setup distribution;
+2. the world and representation semantics in which the experiment runs;
+3. the adversary interface and admissible class (including uniformity/advice choices);
+4. the event or advantage functional;
+5. the cost/resource model and reduction loss.
+
+ROM, AGM, DLOG, SIS, and pairing assumptions instantiate different parts of this record. AGM, for
+example, combines an instrumented algebraic-representation semantics with an adversary restriction;
+it is not only a trace flag. VCVio owns generic game/reduction carriers and standalone primitive or
+hardness games (for example Merkle, DLOG, or SIS); ArkLib owns protocol-security experiments that
+consume them. AGM may therefore split into a VCVio algebraic world/representation adapter and an
+ArkLib protocol adversary restriction.
+
+## 5. Real objects and virtual views
+
+The design deliberately tracks both layers.
+
+- The **real layer** contains setup/input resources, prover messages, concrete data, world state,
+  commitments, and openings.
+- The **virtual layer** contains source-scoped query programs describing the oracle behavior a
+  claim exposes.
+- A runner-produced artifact relates them: the security-game API consumes the paired output of one
+  execution and does not expose a constructor from independently supplied parts. This prevents
+  accidental mixing by construction of the experiment; it does not claim that two executions have
+  different Lean types or that malicious Lean code cannot fabricate values.
+- Compilation transforms real resources and transfers virtual guarantees into cryptographic
+  obligations. It does not erase the distinction.
+
+This is why `SourceCtx` should remain an extensional handler presentation while resource identity,
+origin, aliasing, and guarantees live in a separate `ResourceSchema`. Combining these prematurely
+would make semantic substitution depend on compiler metadata; omitting the schema would make trace
+and guarantee claims unverifiable.
+
+## 6. Refinement obligations at the executable boundary
+
+`ExecutableMaterialization` is an attachment point, not the whole L6 story. A production refinement
+theorem may need to relate:
+
+- mathematical values to encoded/serialized representations;
+- field, group, polynomial, or lattice operations to concrete arithmetic;
+- abstract randomness and oracle calls to executable entropy sources and hash APIs;
+- partiality, faults, and termination to the mathematical outcome model;
+- executable memory/FFI traces to mathematical query and cost traces;
+- measured or certified resource use to the stated budget model;
+- constant-time or leakage behavior, when such a property is claimed.
+
+Executable correctness therefore connects back to ideal and adversarial observations; it cannot be
+proved wholly inside a detached materialization record.
+
+## 7. What is fixed now, and what is evidence
+
+Fixed design principles:
+
+1. closed relations consume extensional oracle behavior;
+2. virtual derivations are source-scoped and compose by handler substitution;
+3. security games derive real/virtual closing from one runner-produced artifact rather than accepting split parts;
+4. resource aliasing is explicit and disjoint tensor does not duplicate persistent resources;
+5. security notions expose quantifier order, views, budgets, and losses;
+6. compiler passes expose guarantee-transport and security-transfer obligations;
+7. existing PolyFun/VCVio semantics are extended, not shadowed by ArkLib-private copies.
+
+Still provisional until Lean clients elaborate:
+
+- exact universes and field layouts of `OracleFamily`, `SourceCtx`, `ClaimWith`, and `RunCore`;
+- the final `ResourceSchema` and stable-resource-identity representation;
+- compiler plan and backend capability field names;
+- whether existing `Spec.Chain` is sufficient for n-ary reduction presentation.
+
+The prototype `ArkLib/Interaction` tree on this design branch is valuable evidence and a lemma
+bank. It is not proof that those APIs are current, stable, or mergeable wholesale.
+
+## 8. Success criteria
+
+The architecture has earned its abstraction when all of the following are true:
+
+- sumcheck, FRI, Nova, one polynomial-commitment protocol, and one lattice-backed protocol use the
+  same claim/closing discipline without scheme-local security frameworks;
+- hash and homomorphic backends instantiate distinct capability sets and obtain transfer theorems
+  with explicit losses;
+- ordinary, state-restoration, and knowledge-soundness theorems compose only under their stated
+  hypotheses, with exact resource/error accounting;
+- an existing VCVio Merkle theorem is adapted into an ArkLib compiler capability without restating
+  the primitive game;
+- one executable implementation is related to its mathematical execution and resource trace;
+- the three repositories remain acyclic and are released in a reproducible dependency train.
+
+## 9. Non-goals for the first core
+
+- A closed DSL of every derived oracle; `ofQuery` remains the escape hatch.
+- One monolithic “secure protocol” structure; properties remain separate games plus bridges.
+- Category-theory-first APIs or calling translations “functors” before categories and laws exist.
+- A single transcript type: structural interaction transcripts, verifier views, world query logs,
+  and state-restoration move traces remain distinct with explicit conversions.
+- Solving quantum-access or impossible-relativization cases inside the classical runner.
+- Rebuilding generic UC machinery: PolyFun and VCVio already contain open-process and UC layers;
+  the first oracle-reduction core merely does not depend on them.

--- a/docs/design/00-end-state.md
+++ b/docs/design/00-end-state.md
@@ -176,7 +176,7 @@ Still provisional until Lean clients elaborate:
 - exact universes and field layouts of `OracleFamily`, `SourceCtx`, `ClaimWith`, and `RunCore`;
 - the final `ResourceSchema` and stable-resource-identity representation;
 - compiler plan and backend capability field names;
-- whether existing `Spec.Chain` is sufficient for n-ary reduction presentation.
+- whether existing `TypeTree.Chain` is sufficient for n-ary reduction presentation.
 
 The prototype `ArkLib/Interaction` tree on this design branch is valuable evidence and a lemma
 bank. It is not proof that those APIs are current, stable, or mergeable wholesale.
@@ -201,8 +201,8 @@ The architecture has earned its abstraction when all of the following are true:
 - A closed DSL of every derived oracle; `ofQuery` remains the escape hatch.
 - One monolithic “secure protocol” structure; properties remain separate games plus bridges.
 - Category-theory-first APIs or calling translations “functors” before categories and laws exist.
-- A single transcript type: structural interaction transcripts, verifier views, world query logs,
-  and state-restoration move traces remain distinct with explicit conversions.
+- A single execution-record type: structural branch/execution paths, verifier views, world query
+  logs, and state-restoration move traces remain distinct with explicit conversions.
 - Solving quantum-access or impossible-relativization cases inside the classical runner.
 - Rebuilding generic UC machinery: PolyFun and VCVio already contain open-process and UC layers;
   the first oracle-reduction core merely does not depend on them.

--- a/docs/design/01-foundations.md
+++ b/docs/design/01-foundations.md
@@ -2,7 +2,9 @@
 
 **Normative architectural contract.** This document says what belongs in each library, records the
 foundation that already exists, and isolates the semantic deltas ArkLib actually needs. The
-PR-by-PR landing plan is [`01a-foundation-pr-plan.md`](01a-foundation-pr-plan.md).
+PR-by-PR landing plan is [`01a-foundation-pr-plan.md`](01a-foundation-pr-plan.md). The normative
+true-sight naming cutover is
+[`01b-type-tree-rename-cutover.md`](01b-type-tree-rename-cutover.md).
 
 The inventory was checked on 2026-07-13 against:
 
@@ -63,7 +65,8 @@ Do not rebuild the following:
   refinement (`PFunctor/Dynamical/*`).
 - `Control.Trace` and `PFunctor.Trace` stateless monoid/list emitters, including the polynomial
   list/free-monoid carrier, relabel/filter operations, and sum projections.
-- `Interaction.Spec.Chain` and `StateChain` as existing n-ary/telescope candidates.
+- `Interaction.TypeTree.Chain` and `TypeTree.StateChain` as existing n-ary/telescope candidates
+  (historically under `Interaction.Spec` before PF-6R).
 - `Interaction.Concurrent.Front` and process prefixes for concurrent semantics.
 
 Three existing “prefix-like” objects have different meanings and must not be conflated:
@@ -133,14 +136,28 @@ client. Identity and associativity are stated under explicit behavioral equivale
 (`∀ xs, T.runOpen xs = U.runOpen xs`) or a named state isomorphism, not structure equality across
 existential state carriers.
 
-**PF-6 — N-ary presentation/coherence (gated).** Do **not** add a new `Spec.Presentation` datatype as
-foundation work. First use existing `Spec.Chain`/`StateChain`; when a concrete three-reduction client
-needs operational reassociation, try dependent `Chain.then`, transcript join/split, and typed
-reassociation. A new presentation type requires a recorded failed client and design note.
+**PF-6A — Polynomial interaction normalization (land before the naming cutover).** Identify the
+undecorated type-tree polynomial with the free polynomial and expose its substitution-monoid,
+finite-chain, stopping-tree, fold, and uniqueness structure. This is PR #62; it deliberately keeps
+the historical names so the algebraic change remains reviewable.
+
+**PF-6R — Type-tree true-sight naming (required before further interaction foundations).** Perform
+the complete `Interaction.Spec → Interaction.TypeTree` and `Spec.Transcript → TypeTree.Path`
+cutover, including module paths, namespace-owned APIs, specialization names, tests, maintained
+documentation, and generated imports. Do not retain compatibility aliases. The representation and
+all computation/universal-property statements remain unchanged. See `01b` for the exact map and
+downstream train.
+
+**PF-6B — N-ary presentation/coherence (gated).** Do **not** add a new
+`TypeTree.Presentation` datatype as foundation work. First use existing
+`TypeTree.Chain`/`TypeTree.StateChain`; when a concrete three-reduction client needs operational
+reassociation, try dependent `Chain.then`, path join/split, and typed reassociation. A new
+presentation type requires a recorded failed client and design note.
 
 ### 1.3 PolyFun acceptance
 
-PF-1/2/3/5 are accepted only when both local laws and a downstream client pass:
+PF-1/2/3/5 are accepted only when both local laws and a downstream client pass. PF-6R additionally
+requires the exact negative-search and definitional-behavior gates in `01b`:
 
 - constructor and residual equations reduce by `rfl` where promised;
 - cursor restriction along composition equals direct restriction;

--- a/docs/design/01-foundations.md
+++ b/docs/design/01-foundations.md
@@ -1,0 +1,367 @@
+# 01 — Foundations: Ownership, Existing Substrate, and Required Deltas
+
+**Normative architectural contract.** This document says what belongs in each library, records the
+foundation that already exists, and isolates the semantic deltas ArkLib actually needs. The
+PR-by-PR landing plan is [`01a-foundation-pr-plan.md`](01a-foundation-pr-plan.md).
+
+The inventory was checked on 2026-07-13 against:
+
+- ArkLib `main` at `e2c3710` (Lean 4.30 dependency train);
+- ArkLib's active Lean 4.31 migration candidate `quang/bump-v4.31.0` at `55a9ccc`;
+- VCVio `main` at `cbd4144b` (Lean 4.31; PolyFun pinned at `04a12b6`);
+- PolyFun `main` at `2ed730d` (Lean 4.31).
+
+These hashes are audit evidence, not dependency pins. Candidate integration uses exact revisions;
+only revisions validated by downstream clients receive stable tags. See `01a`. The candidate
+branch is implementation evidence for AR-0, not a fourth semantic baseline.
+
+## 0. Ownership is determined by parametricity, not nouns
+
+The old slogan—trees in PolyFun, worlds/traces in VCVio, protocols in ArkLib—was too coarse.
+Current PolyFun already contains generic runs, games, traces, handlers, and phased machines. The
+rule is:
+
+> **PolyFun owns domain- and effect-independent structural interaction semantics (monad
+> polymorphism is strong evidence, not a necessary condition). VCVio owns
+> oracle-specialized probabilistic execution, worlds, probability, and cryptographic resource
+> semantics. ArkLib owns protocol meaning: roles, claims, relations, security notions, commitment
+> adapters, and compilers.**
+
+Mixed notions split vertically rather than being assigned wholesale:
+
+| Concern | PolyFun | VCVio | ArkLib |
+|---|---|---|---|
+| Partial execution | syntactic `FreeM.Cursor`; generic dynamical prefixes | query/world execution prefix | reachable protocol prefix and verifier fork |
+| Trace | generic list/free-monoid and relabel/filter algebra | dependent query/answer log, probabilistic instrumentation | verifier view, SR moves, compiler segmentation |
+| Transducer | pure causal stream/list transducer | query-log specialization and resource certificate | hash-chain, Merkle, and SR adapters |
+| Phases | generic sequential machine/game wiring | persistent probabilistic world session/checkpoint | commit/open, preprocessing, and extractor games |
+| Budget | generic additive/preordered algebra where useful | oracle query/cost profiles and probability bounds | protocol labels and feasibility constraints |
+| Commitment | no cryptographic content | standalone primitive algorithms/games/theorems | backend capability adapter and compiler transfer |
+
+Dependency direction remains strict:
+
+```text
+PolyFun  ←  VCVio  ←  ArkLib
+```
+
+PolyFun imports neither VCVio nor ArkLib. VCVio imports no ArkLib. ArkLib is the integration layer.
+If a proposed object would reverse an arrow, split its structural and specialized parts.
+
+## 1. PolyFun contract
+
+### 1.1 What is already present
+
+Do not rebuild the following:
+
+- `PFunctor.FreeM.Path` and `PathAlong` for terminal root-to-leaf paths, with extensive dependent
+  append split/pack/unpack laws (`PFunctor/Free/Path.lean`).
+- displayed data and decoration maps, dependent `Over.map`, base transport, identity/composition,
+  and append naturality (`PFunctor/Free/Displayed/Decoration.lean` and `.../Append.lean`).
+- `DynSystem.Prefix`, `Run`, events/tickets, reachability, and generic execution
+  (`PFunctor/Dynamical/Run.lean`).
+- `PointedMachine.seqComp`, handler-parametric execution, responder/game wiring, simulation, and
+  refinement (`PFunctor/Dynamical/*`).
+- `Control.Trace` and `PFunctor.Trace` stateless monoid/list emitters, including the polynomial
+  list/free-monoid carrier, relabel/filter operations, and sum projections.
+- `Interaction.Spec.Chain` and `StateChain` as existing n-ary/telescope candidates.
+- `Interaction.Concurrent.Front` and process prefixes for concurrent semantics.
+
+Three existing “prefix-like” objects have different meanings and must not be conflated:
+
+1. `FreeM.Path s` is a **complete syntactic path** to a leaf.
+2. `DynSystem.Prefix sys st n` is a **finite operational orbit** of fixed length.
+3. `Concurrent.Front S` is a **currently enabled structural event and one-step residual**.
+
+None is the missing partial syntactic path through an arbitrary `FreeM` tree.
+
+### 1.2 Required PolyFun deltas
+
+**PF-1 — Syntactic `FreeM.Cursor` (required).** A cursor selects any residual subtree, including the
+root and internal nodes. It has structural descent, residual, composition, unit/associativity laws,
+an immediate-edge/witness-bearing extension relation, and an equivalence between terminal cursors
+and `Path`. It is not called `Prefix` or `Front`.
+
+Indicative shape:
+
+```lean
+inductive FreeM.Cursor : (s : FreeM P α) → Type _
+  | root (s) : Cursor s
+  | down {a k} (b : P.B a) (tail : Cursor (k b)) : Cursor (.roll a k)
+
+def Cursor.residual : Cursor s → FreeM P α
+def Cursor.comp (c : Cursor s) : Cursor c.residual → Cursor s
+```
+
+**PF-2 — Cursor restriction (required).** A completely arbitrary `Displayed.Shape` cannot be
+restricted along a cursor: from an unconstrained value in `D.node a child` there is no canonical way
+to recover `child b`. Add `Displayed.Shape.ChildProjection`, its dependent
+`Displayed.OverShape.ChildProjection` counterpart, and define the cursor-spine traversal once
+against that capability. Supply the canonical specializations for `Decoration` and
+`Decoration.Over`; prove naturality with existing maps and base transport. Restriction returns data
+on the cursor's **future residual subtree** only. It does not recover data along the visited spine.
+ArkLib separately folds the cursor spine and pairs it with concrete hidden-message prefix data in
+`FullPrefixAt`.
+
+**PF-3 — Cursor decomposition through append (required).** Classify a cursor of dependent
+`FreeM.append s k` as either:
+
+- a cursor in `s` whose residual is explicitly witnessed to be an internal `.roll`; or
+- a completed `p : Path s` plus a cursor in `k p`.
+
+`Cursor.liftAppend` transports the first case through append; `Cursor.joinRight` follows a complete
+prefix path into the second case; an `AppendView` packages the disjoint classification. Split/join
+must be inverse, expose residual equations, commute with cursor composition, agree with terminal
+`Path.append`, and transport decoration restriction. This is the foundation RBR and reduction
+composition actually need.
+
+**PF-4 — Operational-prefix concatenation (gated).** If a concrete interaction-machine runtime needs
+it, extend `DynSystem.Prefix` with dependent append/segment and endpoint/event/ticket laws. Ordinary
+VCVio `OracleComp` phase traces concatenate through monadic execution and `QueryLog.append`; they do
+not depend on this PR. The client must specify the phase-boundary witness and any required endpoint
+transport before PF-4 is promoted.
+
+**PF-5 — Pure causal transducers (required before compiler trace pipelines).** Add an effect-free
+stateful Kleisli–Mealy companion to the existing stateless `Control.Trace`/`PFunctor.Trace` APIs:
+`Control.Transducer ι ο` with state, `runFrom`/`runOpen`, identity, and sequential composition. Reuse
+the existing list/free-monoid trace carriers and relabel/filter algebra rather than introducing a
+second trace representation. Do not encode this as a `MooreMachine`: Moore output is a state
+observation made before an input, whereas a transducer's finite output chunk depends jointly on the
+current state and consumed input. Ordered-prefix causality follows from `runOpen_append`; it is not
+an arbitrary proof field. Terminal `finish` output is a separate `Finalizer`, because flushing can
+violate ordinary prefix monotonicity. Cost is an external certificate owned by the specialized
+client. Identity and associativity are stated under explicit behavioral equivalence
+(`∀ xs, T.runOpen xs = U.runOpen xs`) or a named state isomorphism, not structure equality across
+existential state carriers.
+
+**PF-6 — N-ary presentation/coherence (gated).** Do **not** add a new `Spec.Presentation` datatype as
+foundation work. First use existing `Spec.Chain`/`StateChain`; when a concrete three-reduction client
+needs operational reassociation, try dependent `Chain.then`, transcript join/split, and typed
+reassociation. A new presentation type requires a recorded failed client and design note.
+
+### 1.3 PolyFun acceptance
+
+PF-1/2/3/5 are accepted only when both local laws and a downstream client pass:
+
+- constructor and residual equations reduce by `rfl` where promised;
+- cursor restriction along composition equals direct restriction;
+- append cursor split/join is inverse on a genuinely dependent heterogeneous tree;
+- no cast-freedom claim relies on `#print axioms` (`Eq.rec` is not an axiom); use `rfl`, `simp only`,
+  and source-level absence of proof-generated transports;
+- ArkLib defines one `FullPrefixAt` with PF-1/2 and decomposes composition with PF-3;
+- VCVio specializes PF-5 to a query/world trace and proves one resource-transport theorem.
+
+## 2. VCVio contract
+
+### 2.1 Existing semantic center
+
+The following are landed foundations, not missing abstractions:
+
+- `OracleComp`, `QueryImpl`, `simulateQ`, sum/subspec coercions, `evalDist`, and `ProbComp`.
+- `QueryImpl.Stateful I E σ`, state-separated frames, `run`/`runState`, state transport, linking, and
+  parallel composition (`SimSemantics/StateT/StateSeparating.lean`).
+- `SPMFSemantics` as interpretation plus observation, and existing state-oracle/UC runners.
+- ordered dependent `QueryLog spec := List ((q : spec.Domain) × spec.Range q)`, logging/tracing
+  transformers, output-marginal and failure bridge laws, cache/log projections.
+- structural query bounds, per-index bounds, `ResourceProfile`, `CostModel`, pathwise/expected cost,
+  and profile substitution.
+- caching, lazy/eager random-oracle equivalence, programming policies, replay and seeded forking.
+- TV distance, bind/bad-event bounds, birthday/collision kernels, deferred sampling, and many ROM
+  probability lemmas.
+- `NeverFail` and missing-mass algebra.
+- abstract-advantage `SecurityGame`, negligibility, hybrid/reduction theorems, and composable
+  `ReductionWithCost`.
+- standalone commitment/Merkle algorithms and security theorems, including two-phase extraction.
+
+Consequently V4/V7/V8/V9/V10 below are **consolidation or repair**, not greenfield replacements.
+
+### 2.2 Required VCVio deltas
+
+**V1 — Thin world/session package.** Package existing stateful semantics without creating a second
+evaluator. A world contains a surface oracle interface, hidden state, setup computation, and
+`QueryImpl.Stateful`; running delegates to `runState`/`simulateQ`. Observation and trace
+instrumentation are orthogonal adapters, not fields of the core world.
+
+One heterogeneous interface plus one shared state already represents correlated logical oracles.
+Product-state construction and independence are deferred until a client supplies explicit joint
+initialization/routing semantics; sequencing two initializers through one imported oracle can itself
+correlate them. Initial distributions are setup computations. The first API retains VCVio's current universe-0 runtime boundary;
+universe generalization is a separate PR.
+
+**V2 — Query-event regions and traced execution.** Name the existing dependent event type, add
+list-boundary/region operations (`take`, `drop`, interval, phase split), and projection along a named
+interface embedding. Query position is derived from a list boundary, not stored in every event.
+The oracle-domain tag supplies identity within a given interface. Globally stable resource identity
+across reassociation is client schema data (ArkLib `ResourceSchema`), mapped into/out of VCVio
+events by an adapter.
+
+The traced runner returns output, final state, and trace from one execution. Erasure to the ordinary
+runner, failure preservation, trace concatenation, and projection laws are mandatory.
+
+**V3 — World-trace transducer specialization.** Specialize PolyFun PF-5; do not define another generic
+transducer. Add external certificates relating input/output event counts or `ResourceProfile`s and
+prove certificate composition. Hash/Merkle/SR transducer instances remain ArkLib/backend code.
+
+**V4 — Resource transport consolidation.** Keep `ResourceProfile`, `QueryBound`, `CostModel`, and
+`ReductionWithCost` as the vocabulary. Add named bridges from per-handler step bounds to linked
+runtime imported-query bounds, from traced artifacts to profile inequalities, and through
+instrumentation/transducer composition. Do not introduce a parallel `Budget` or `Ledger` hierarchy.
+
+**V5 — Persistent probabilistic phase artifact.** VCVio VCV-3 implements the common
+oracle-computation case: `resume` continues from final handler state and the old trace length becomes
+the next region boundary. A separate adapter to PolyFun operational machines/PF-4 is gated on a real
+client. This is not a universal “phased adversary” record; commit/open and five-phase interfaces
+remain ArkLib or primitive-specific.
+
+**V6 — Auditable dynamic programming.** Preserve existing static `ProgrammingPolicy`, caching,
+replay, and fork kernels. Add a dynamic program command with an explicit result
+(`fresh`, `alreadyProgrammed`, `queriedBeforeProgram`, conflict according to policy), an audit event,
+and preservation/freshness laws. Add replay-policy adapters only where an actual extractor theorem
+needs them; do not replace working replay implementations with a taxonomy.
+
+**V7 — Error-bearing reduction composition.** Extend existing `SecurityGame` and
+`ReductionWithCost` with a bundled composable security reduction carrying advantage error and cost
+transform. Add additive and substitution-style composition for error functions. Do not make
+failure probability an intrinsic field of every adversary, and do not stabilize a universal
+`AdvCharacteristics` until two non-CY clients demand it. CY-specific extraction-time recurrences
+remain ArkLib theorems over generic function algebra initially.
+
+**V8 — Probability facade and repairs.** Add a scalar conditional-probability facade and finite
+partition lemmas, and only the generic lemmas demanded by real games. Existing exact birthday bounds and lazy/eager
+equivalence count as delivered. Before claiming the ROM kit adequate, repair or quarantine the
+currently trivial `probEvent_unqueried_match_le` and the vacuous `Unique ι` collision-win theorem in
+`QueryTracking/Unpredictability.lean`.
+
+**V9 — One failure boundary.** Preserve the existing meaning: missing `SPMF` mass is monadic
+failure/nontermination. An explicit protocol `fault` is a returned value, not silently identified
+with missing mass. Provide one named `materialize (onMissing : RuntimeFault)` bridge to
+`Outcome α RuntimeFault`. The default
+ArkLib path must either prove `NeverFail` before decoding a `Terminal`, or explicitly choose and
+name `onMissing`. For `α = Terminal Claim ProtocolFault`, runtime failure and returned protocol fault
+remain two distinct branches. No second semantics is introduced.
+
+**V10 — Complete existing game/reduction calculus.** Keep `SecurityGame Adv` and abstract adversary
+class predicates. Add the bundled reduction from V7, dependent/parameter-indexed adversary support
+only if a concrete game cannot use the current form, and setup/keygen inside concrete experiments.
+Do not add the proposed Boolean-only `GameFamily Params experiment` in parallel. Uniformity,
+nonuniformity, and advice are properties of the adversary representation/class, not fields guessed
+by the generic game record.
+
+### 2.3 VCVio acceptance
+
+The Γ foundation is adequate for ArkLib's first security phase when:
+
+1. a heterogeneous correlated world runs through V1 with no special joint-world primitive;
+2. its traced run erases to the same output distribution and failure mass;
+3. two resumed phases produce the same final semantics as sequential execution, and their regions
+   concatenate in order;
+4. query/profile bounds transport through one linked stateful simulation and one PF-5 transducer;
+5. dynamic programming distinguishes query-before-program and preserves unprogrammed answers;
+6. one error-bearing `SecurityReduction` composes both advantage loss and cost transformation;
+7. a finite conditioned bad-event proof uses the V8 facade;
+8. both defective ROM statements named above are repaired or removed from the advertised kit;
+9. an explicit-fault game proves `NeverFail` before ArkLib terminal decoding;
+10. the existing Merkle extraction theorem can be adapted by ArkLib without restating its primitive
+    experiment.
+
+## 3. ArkLib contract
+
+ArkLib owns and must build:
+
+- protocol syntax and the public/oracle observation split;
+- concrete oracle-message access and execution;
+- extensional source contexts plus a separate resource schema for identity, origin, aliasing, and
+  ideal guarantees, with later backend assignment indexed by that schema;
+- virtual-oracle interpretation, substitution, claims, and runner-derived closing (`02`);
+- protocol security games, relations, extractors, implication maps, and state restoration (`03`);
+- commitment-backend adapters, guarantee transport, compiler passes, and concrete proof systems
+  (`04`);
+- legacy bridges and migration ledgers.
+
+ArkLib must not define private replacements for PolyFun cursor/transducer algebra or VCVio
+world/probability/resource/game semantics. A temporary adapter is allowed only when it has:
+
+1. a named upstream issue/PR dependency;
+2. no new theorem stated solely in the temporary vocabulary;
+3. a deletion/migration test in the consuming ArkLib PR.
+
+Standalone primitive theorems may remain in VCVio even when ArkLib consumes them. For example,
+Merkle extraction is a VCVio cryptographic theorem; the ArkLib object is a `CommitBackend` adapter
+and transfer proof.
+
+## 4. Resource identity and the real/virtual boundary
+
+Two layers are both necessary:
+
+- `SourceCtx` is the extensional handler presentation used to interpret virtual query programs.
+- `ResourceSchema` records stable client identity, origin, guarantee, and sharing/aliasing.
+- `BackendAssignment` is a later compiler object indexed by a `ResourceSchema`; it is not intrinsic
+  ideal-resource data.
+
+Pure `SourceHom` routes extensional handlers. `SchemaHom` lies over a `SourceHom` and proves identity,
+sharing, origin, and guarantee coherence. Virtual-oracle substitution depends only on `SourceHom`;
+compiler and trace theorems use `SchemaHom`.
+
+Every reified guarantee descriptor also carries a coherence witness relating it to the slot's
+actual ideal object/refined type. Metadata that merely *claims* a degree/codeword guarantee without
+this witness is ill formed.
+
+VCVio query events are tagged by the currently executed oracle interface. ArkLib proves that its
+schema routing maps those tags coherently across context morphisms. Neither VCVio instrumentation
+nor reassociation of nested sum types can manufacture globally stable identity by itself.
+
+This separation is a foundation decision. Enriching `SourceCtx` directly with all compiler metadata
+would contaminate semantic substitution; omitting `ResourceSchema` would make aliasing, trace
+projection, and guarantee transport prose-only.
+
+## 5. Release and branch discipline
+
+Foundation implementation advances in compatible candidates, not one serialized mega-release:
+
+```text
+base Lean-4.31 PolyFun/VCVio candidate → ArkLib AR-0 and AR-1…AR-8
+PF cursor/transducer candidates → VCVio candidate pin → AR-10A / VCV-4 clients
+VCVio runtime candidate → AR-9A/9B and AR-10B
+VCVio security/ROM/reduction candidate → state restoration and compiler work
+```
+
+- Every PR starts from its repository's current default branch.
+- The design branch is never merged as an implementation batch.
+- Lake manifests use exact/tagged compatible revisions; ArkLib must not override PolyFun with a
+  revision inconsistent with the one VCVio was tested against.
+- Mechanical toolchain/pin changes are isolated from semantic PRs.
+- Candidate revisions are exact commits used for downstream validation; stable tags/frozen
+  interfaces are published only after the named clients pass. This avoids a circular requirement
+  that an upstream API be frozen before the downstream acceptance client can build.
+- CI checks the resolved PolyFun revision and rejects duplicate/inconsistent package instances.
+
+## 6. Freeze discipline
+
+An item freezes only after:
+
+1. its local laws and tests pass;
+2. the first downstream client named in `01a` passes;
+3. adapters to the pre-existing vocabulary are proved;
+4. no parallel type with the same semantics remains unexplained.
+
+The design equations in `02` are **provisional signature sketches** until universe-polymorphic Lean
+declarations and two concrete clients elaborate. Directional principles may be stable while field
+layouts remain fluid. Changes to an accepted interface require a decision-log entry; unimplemented
+or client-unvalidated names do not.
+
+## 7. Cross-library contract tests
+
+The release train is accepted only when these end-to-end checks pass:
+
+1. `restrict (restrict d c) e = restrict d (c.comp e)` and cursor-spine accumulation composes;
+2. append cursor split/join is inverse and is consumed by a composite ArkLib reduction;
+3. VCVio query tracing erases to the same output distribution and missing mass;
+4. ArkLib resource identity survives context routing and maps coherently to VCVio event tags;
+5. query/profile bounds transport through `simulateQ`, linked handlers, and a virtual-oracle
+   substitution client;
+6. world phase regions concatenate in execution order;
+7. explicit fault and missing mass cross exactly one named boundary;
+8. VCVio Merkle extraction instantiates an ArkLib backend capability without duplicating its game;
+9. security experiments are defined over the actual `runArtifact execute` distribution; any theorem
+   about an arbitrary artifact requires support/`GeneratedBy` evidence, and the game API exposes no
+   split-parts experiment constructor;
+10. repository imports preserve `PolyFun ← VCVio ← ArkLib` with no cycle.

--- a/docs/design/01a-foundation-pr-plan.md
+++ b/docs/design/01a-foundation-pr-plan.md
@@ -27,7 +27,7 @@ PolyFun
   PF-1 Cursor ─→ PF-2 Cursor restriction ─→ PF-3 Cursor/append
   PF-4 Operational-prefix concatenation             (gated)
   PF-5 Causal transducer                            (parallel)
-  PF-6 Chain concatenation                          (gated)
+  PF-6A Polynomial normalization → PF-6R TypeTree rename → PF-6B Chain coherence (gated)
        ↓ candidate revision; tag after downstream acceptance
 
 VCVio
@@ -202,21 +202,56 @@ VCVio's query-log adapter is thin and attaches its own output-length/resource ce
 **Not included.** A second trace carrier, a forced `MooreMachine` encoding, or `coherence`/`cost`
 fields—causality is a theorem and cost is external.
 
-### PF-6 — `feat(interaction): dependent concatenation of Spec.Chain` (gated)
+### PF-6A — `feat(interaction): normalize polynomial iteration foundations`
+
+**Prerequisite.** The free polynomial/substitution-monoid stack through PR #55.
+
+**Scope.** Identify the undecorated sequential interaction polynomial definitionally with the free
+polynomial; expose its canonical substitution-monoid structure; present finite `Chain` as the
+sigma-friendly final-sequence approximant; introduce the canonical stopping-tree carrier and prove
+its fold/uniqueness interface. This is PolyFun PR #62 at `11e02c0` in the audited stack.
+
+**Boundary.** Preserve historical names in this PR. The isolated PF-6R cutover follows immediately.
+
+### PF-6R — `refactor(interaction): rename sequential specs to type trees`
+
+**Prerequisite.** PF-6A.
+
+**Semantic unit.** A complete true-sight API cutover with no representation change and no
+compatibility facade.
+
+**Declarations/modules.** Rename `Interaction.Spec` to `Interaction.TypeTree`,
+`Spec.Transcript` to `TypeTree.Path`, sequential `Spec.*` namespace members to `TypeTree.*`, and
+`Basic/Spec{,Fintype}.lean` to `Basic/TypeTree{,Fintype}.lean`. Rename exported specialization and
+conversion names that specifically encode the old carrier, including `DecoratedSpec`, `runSpec`,
+`Chain.toSpec`, `Telescope.toSpec`, paired/monadic `*Spec` specializations, `sampleTranscript`, and
+sequential transcript-operation families. Consolidate the concurrent bridge on `Path`/`StepRel`:
+`ObservedTranscript`, `ofTranscript`, event/transcript conversions, `TranscriptRel`, and
+`matchTranscript` become their path/step counterparts. Rename the sequential episode projection of
+`Concurrent.StepOver` from `spec` to `tree`.
+
+**Exclusions.** Preserve unrelated `Concurrent.Spec`, `SafetySpec`, VCVio `OracleSpec`, and
+Lean/Std `Do.Spec` names.
+
+**Acceptance.** No historical aliases or imports; the PF-6A definitional and universal-property
+canaries remain unchanged modulo names; the full PolyFun validation suite, generated-import check,
+maintained docs, and narrow negative searches pass. Exact map and downstream release train: `01b`.
+
+### PF-6B — `feat(interaction): dependent concatenation of TypeTree.Chain` (gated)
 
 **Promotion trigger.** A concrete ArkLib triple-reduction client cannot state operational
-reassociation using existing `Spec.Chain`/`StateChain`.
+reassociation using existing `TypeTree.Chain`/`TypeTree.StateChain`.
 
 **Module.** `PolyFun/Interaction/Basic/Chain/Append.lean`.
 
 **Candidate declaration.**
 
 ```lean
-Chain.then (c : Chain m) (k : Transcript (toSpec m c) → Chain n) : Chain (m + n)
+Chain.then (c : Chain m) (k : TypeTree.Path (toTypeTree m c) → Chain n) : Chain (m + n)
 ```
 
-Add propositional `toSpec_then`, telescope transcript join/split, and three-stage typed
-reassociation handling `Nat.add` and dependent transcript reindexing explicitly.
+Add propositional `toTypeTree_then`, telescope path join/split, and three-stage typed
+reassociation handling `Nat.add` and dependent path reindexing explicitly.
 
 **Acceptance.** The actual ArkLib client, not an isolated toy. Only a documented failure of this
 route authorizes a new `Presentation` datatype.
@@ -437,26 +472,27 @@ security candidate revisions arrive in separate mechanical bump PRs.
 **Prerequisite.** AR-0 and existing PolyFun append/strategy APIs.
 
 **Declarations.** `HonestProverOutput`, `Prover`, `Verifier`, `Reduction`, `execute`, identity, and
-`comp`. **Theorems:** `execute_comp`, identity laws, transcript split/append. **Acceptance:** two
+`comp`. **Theorems:** `execute_comp`, identity laws, path split/append. **Acceptance:** two
 dependent toy protocols; cast-free constructor equations; no oracle/security content.
 
-### AR-2A — `feat(interaction): oracle syntax and transcript projections`
+### AR-2A — `feat(interaction): oracle type trees and path projections`
 
-**Prerequisite.** AR-0. **Declarations:** `Oracle.Position`, `Oracle.Spec`, `PublicTranscript`,
-`FullTranscript`, execution lens/public projection, `OracleMessagesAt`. **Theorems:** full transcript
-as public transcript plus hidden-message fiber, round trips, payload-independent oracle continuation.
+**Prerequisite.** AR-0 after PF-6R. **Declarations:** `Oracle.Position`, `Oracle.TypeTree`,
+`BranchPath`, `ExecutionPath`, runtime lens/branch projection, `OracleMessagesAt`. **Theorems:**
+execution path as branch path plus hidden-message fiber, round trips, payload-independent oracle
+continuation.
 **Acceptance:** public–oracle–public and dependent-public-branch examples using `rfl`/`simp only`.
 
 ### AR-2B — `feat(interaction): role and oracle decorations`
 
 **Prerequisite.** AR-2A. **Declarations:** `RoleDeco`, `OracleDeco`, projections, accumulated
 visibility, PolyFun-decoration conversions. **Theorems:** map/append/projection naturality.
-**Acceptance:** recover exactly the public and oracle nodes of the AR-2A mixed protocol.
+**Acceptance:** recover exactly the public and oracle nodes of the AR-2A mixed type tree.
 
 ### AR-3A — `feat(interaction): accumulated oracle access`
 
 **Prerequisite.** AR-2B. **Declarations:** `answerAt`, query handles, accumulated message interface
-and implementation, full-transcript realization. **Theorems:** concrete-answer agreement, public
+and implementation, execution-path realization. **Theorems:** concrete-answer agreement, branch
 projection invariance, and future-message unavailability. **Acceptance:** passthrough and one-round
 sumcheck access.
 

--- a/docs/design/01a-foundation-pr-plan.md
+++ b/docs/design/01a-foundation-pr-plan.md
@@ -1,0 +1,581 @@
+# 01a — Foundation Landing Plan: Exact PR Slices
+
+**Operational companion to `01`.** Every item below is intended to be a reviewable PR with one
+semantic center. Medium or large proof payloads are acceptable; mixed ownership, speculative
+frameworks, and unrelated migrations are not.
+
+## 0. Rules of execution
+
+1. **Fresh bases.** Every implementation PR starts from the repository's current default branch.
+   The design branch is a source bank, never a merge base for implementation.
+2. **One semantic addition.** A PR may add the definitions, laws, tests, and documentation needed
+   for one coherent abstraction. It must not also migrate unrelated protocols.
+3. **Mechanical changes are isolated.** Dependency pin/toolchain PRs (`VCV-0`, `AR-0`) are explicit
+   non-semantic exceptions and contain no API redesign.
+4. **Reuse before wrapping.** A new type that overlaps an existing one requires an equivalence or a
+   written reason why the old carrier cannot express the new semantics.
+5. **Client acceptance.** Local toy tests are necessary but insufficient for a foundation freeze;
+   each item names its first downstream client.
+6. **No proof-generated plumbing in core carriers.** Promised computation equations are tested by
+   `rfl`/`simp only` and source inspection, not by `#print axioms`.
+7. **No new sorries.** Prototype sorries are not copied. A blocked theorem narrows or delays the PR.
+
+## 1. Dependency and landing order
+
+```text
+PolyFun
+  PF-1 Cursor ─→ PF-2 Cursor restriction ─→ PF-3 Cursor/append
+  PF-4 Operational-prefix concatenation             (gated)
+  PF-5 Causal transducer                            (parallel)
+  PF-6 Chain concatenation                          (gated)
+       ↓ candidate revision; tag after downstream acceptance
+
+VCVio
+  VCV-0 pin bump to a PF candidate revision
+  VCV-1 Trace views ─┐
+  VCV-2 Runtime ─────┴→ VCV-3 Runtime artifact ─→ VCV-5A/5B Resource transport
+  PF-5 ───────────────→ VCV-4 Trace-transducer specialization
+  VCV-3 ──────────────→ VCV-6 Dynamic programming
+  VCV-7A/7B Conditioning; VCV-8A/B/C ROM repairs; VCV-9 Outcome; VCV-10 Reductions
+       ↓ candidate revision; tag after downstream acceptance
+
+ArkLib
+  AR-0 dependency alignment
+  AR-1 plain reductions
+  AR-2A syntax → AR-2B decorations → AR-3A access → AR-3B concrete execution
+  AR-4A SourceCtx/SourceHom → AR-5 virtual substitution
+  AR-4B ResourceSchema/SchemaHom ───────────────┐
+  AR-5 → AR-6A claims/closing ──────────────────┴→ AR-6B core-run integration
+                                                → AR-7 sumcheck → AR-8 sumcheck bridge
+  PF-1..3 + AR-2B/3A/4B ───────────────────────→ AR-10A structural full prefixes
+  VCV-3 + AR-6B ───────────────────────────────→ AR-9A runtime artifact adapter
+  VCV-9 + AR-9A ───────────────────────────────→ AR-9B outcome boundary
+  AR-10A + AR-9A ──────────────────────────────→ AR-10B trace alignment
+  VCV Merkle + AR-9A/VCV-10 ───────────────────→ AR-11 Merkle backend adapter
+```
+
+Useful parallelism:
+
+- PF-1 and PF-5 can start together; PF-4 waits for a machine client.
+- VCV-7A, VCV-8A, VCV-9, and VCV-10 can land against the current VCVio substrate.
+- After AR-0, AR-1, AR-2A, and AR-4A can proceed independently.
+- Compiler and advanced security work is deliberately outside this foundation train; `05` schedules
+  it after the first runner-backed security client.
+
+Semantic requirement IDs in `01` intentionally match PolyFun PR IDs. VCVio requirements collect
+several slices, so use this mapping rather than assuming numeric equality:
+
+| Requirement | Implementing PRs |
+|---|---|
+| V1 runtime | VCV-2 |
+| V2 trace/artifact | VCV-1, VCV-3 |
+| V3 transducer specialization | VCV-4 |
+| V4 resource transport | VCV-5A, VCV-5B |
+| V5 persistent phases | VCV-3 common case; machine adapter gated |
+| V6 programming/replay delta | VCV-6 |
+| V7 reduction errors/cost | VCV-10 |
+| V8 probability/ROM repair | VCV-7A/B, VCV-8A/B/C |
+| V9 outcome boundary | VCV-9 |
+| V10 game/reduction completion | VCV-10 |
+
+## 2. PolyFun PRs
+
+### PF-1 — `feat(free): cursors for partial FreeM paths`
+
+**Semantic unit.** A syntactic path prefix that selects any residual subtree.
+
+**Module.** New `PolyFun/PFunctor/Free/Cursor.lean`.
+
+**Declarations.** `FreeM.Cursor s`; `Cursor.residual`; `Cursor.root`; `Cursor.down`;
+`Cursor.comp`; `Cursor.length`; `Cursor.IsTerminal`; one-node edge view; witness-bearing
+`Cursor.Extends c d := Σ e : Cursor c.residual, c.comp e = d`; equivalence between terminal cursors
+and `FreeM.Path s` (including the selected leaf payload).
+
+**Central laws.** Residual at root/down; left/right unit and dependent associativity of `comp`;
+length addition; terminal-cursor/`Path` round trips.
+
+**Acceptance.** A heterogeneous dependent tree with an internal cursor and two terminal cursors;
+constructor equations by `rfl`; no collision with `DynSystem.Prefix` or `Concurrent.Front` names.
+
+**Not included.** Decorations, append decomposition, operational runs, or protocol meaning.
+
+**Unlocks.** PF-2/PF-3 and ArkLib's reachable-prefix carrier.
+
+### PF-2 — `feat(displayed): restrict displayed data along cursors`
+
+**Prerequisite.** PF-1.
+
+**Module.** New `PolyFun/PFunctor/Free/Displayed/Cursor.lean`.
+
+**Declarations.** `Displayed.Shape.ChildProjection` and its dependent
+`Displayed.OverShape.ChildProjection` counterpart; one generic cursor-spine restriction algorithm
+parameterized by that capability; canonical `Decoration.restrict` and
+`Decoration.Over.restrict` specializations. An unconstrained `Displayed.Shape` does not admit a
+generic `restrict`, because `D.node a child` need not expose any `child b`. These operations describe
+the future residual subtree, not visited-prefix history.
+
+**Central laws.** Root/down computation; restriction along `Cursor.comp`; naturality with existing
+`Decoration.map`, `Over.map`, and `Over.mapBase`; compatibility with `ofOver`/`toOver`. The generic
+spine traversal is defined once; decoration layers provide only their local child projections.
+
+**Acceptance.** Constructor examples close by `rfl`; a dependent decoration proof closes with
+`simp only`; ArkLib can restrict role and oracle decorations at one protocol cursor.
+
+**Not included.** A claim that every displayed shape is navigable, or a new generic decoration-map
+hierarchy—most of P3 in the old plan already exists.
+
+### PF-3 — `feat(free): cursor decomposition through dependent append`
+
+**Prerequisites.** PF-1 and the existing `FreeM.Path.append/split` kit; PF-2 for decoration corollaries.
+
+**Module.** New `PolyFun/PFunctor/Free/Cursor/Append.lean`.
+
+**Semantic unit.** Classify a cursor through `FreeM.append s k` without casts.
+
+**Declarations.** `Cursor.IsNode`; `Cursor.liftAppend`; `Cursor.joinRight`; and a dependent
+`Cursor.AppendView` with two disjoint cases: a cursor in `s` carrying an explicit witness that its
+residual is an internal node, or completed `p : Path s` plus cursor in `k p`; `split`, `join`, and
+residual projections. Include the direct `Decoration` and `Decoration.Over` restriction corollaries.
+
+**Central laws.** Split/join inverses; residual equations; compatibility with terminal
+`Path.split/append`; `liftAppend` and `joinRight` respect cursor composition; restriction through
+both cases agrees with `Decoration.append` and `Decoration.Over.append`.
+
+**Acceptance.** A dependent two-stage tree exercises both cases. The first ArkLib composition
+client decomposes a reachable cursor into stage-one/stage-two cases.
+
+### PF-4 — `feat(dynamical): concatenate finite operational prefixes` (gated)
+
+**Promotion trigger.** A concrete interaction-machine runtime needs phase segments; ordinary
+`OracleComp`/`QueryLog` phases do not.
+
+**Module.** `PFunctor/Dynamical/Run/Prefix.lean` or a focused extension of `Run.lean`.
+
+**Declarations.** Dependent `DynSystem.Prefix.append` plus an explicit `segment/drop` carrying the
+endpoint equality/transport; optional inclusion relation; bridges from `Run.take`.
+
+**Central laws.** Endpoint of append; unit/associativity; event and ticket list concatenation;
+`Run.take (m+n)` decomposition propositionally through the segment endpoint (not promised `rfl`).
+
+**Acceptance.** A two-phase pointed machine with an explicit halting/phase-boundary witness whose
+global event list is the append of both segments.
+
+**Not included.** Probabilistic worlds or commit/open games.
+
+### PF-5 — `feat(control): causal finite-trace transducers`
+
+**Module.** New `PolyFun/Control/Transducer.lean`.
+
+**Existing substrate and boundary.** `Control.Trace` and `PFunctor.Trace` already provide stateless
+monoid/list emission and the canonical polynomial trace carrier; PF-5 reuses those representations
+and their relabel/filter algebra. A transducer is the stateful Kleisli–Mealy companion whose output
+chunk depends on both state and input. It is not represented as a `MooreMachine`, whose output is a
+state observation before an input is consumed.
+
+**Indicative interface.**
+
+```lean
+structure Transducer (ι ο : Type*) where
+  State : Type*
+  init : State
+  step : State → ι → State × List ο
+
+def Transducer.runFrom
+def Transducer.runOpen
+def Transducer.id
+def Transducer.comp
+```
+
+Define `BehaviorEq T U := ∀ xs, T.runOpen xs = U.runOpen xs` (or a stronger named state isomorphism
+when needed).
+
+`Finalizer` is separate and supplies `finish : State → List ο` only when a client needs terminal
+flushing.
+
+**Central laws.** `runFrom_append`; ordered-prefix causality of `runOpen`; streaming law;
+identity/composition and associativity under `BehaviorEq`; optional canonical state isomorphisms are
+separate stronger results.
+
+**Acceptance.** Compose filter and expand transducers and compare with `PFunctor.Trace.mapPartial`.
+VCVio's query-log adapter is thin and attaches its own output-length/resource certificate.
+
+**Not included.** A second trace carrier, a forced `MooreMachine` encoding, or `coherence`/`cost`
+fields—causality is a theorem and cost is external.
+
+### PF-6 — `feat(interaction): dependent concatenation of Spec.Chain` (gated)
+
+**Promotion trigger.** A concrete ArkLib triple-reduction client cannot state operational
+reassociation using existing `Spec.Chain`/`StateChain`.
+
+**Module.** `PolyFun/Interaction/Basic/Chain/Append.lean`.
+
+**Candidate declaration.**
+
+```lean
+Chain.then (c : Chain m) (k : Transcript (toSpec m c) → Chain n) : Chain (m + n)
+```
+
+Add propositional `toSpec_then`, telescope transcript join/split, and three-stage typed
+reassociation handling `Nat.add` and dependent transcript reindexing explicitly.
+
+**Acceptance.** The actual ArkLib client, not an isolated toy. Only a documented failure of this
+route authorizes a new `Presentation` datatype.
+
+## 3. VCVio PRs
+
+### VCV-0 — `chore: advance the tested PolyFun candidate revision`
+
+**Mechanical prerequisite.** Update the exact PolyFun pin after the PF PRs needed by the next VCVio
+slice land; refresh the manifest and build/lint/test. This may happen more than once as candidate
+revisions advance. No semantic declaration changes. A stable tag is published only after the named
+downstream VCVio/ArkLib clients pass.
+
+### VCV-1 — `feat(query-tracking): dependent trace views and boundaries`
+
+**Module.** New `VCVio/OracleComp/QueryTracking/TraceView.lean`.
+
+**Declarations.** Name `QueryEvent E := (q : E.Domain) × E.Range q` while retaining `QueryLog E` as
+the carrier; boundary marks `Fin (trace.length + 1)`; `prefixAt`, `suffixAt`, `interval`; predicate
+and sum-component projection; typed projection along an existing `SubSpec`/route carrying the
+dependent response transport.
+
+**Central laws.** Zero/end; prefix+suffix reconstruction; nested interval; append-boundary equations;
+projection over append; length bounds.
+
+**Acceptance.** Slice and project an `E₁ + E₂` trace while preserving order. Position is derived from
+boundaries, not duplicated in events.
+
+**Unlocks.** Exact Δ/world trace regions and phase marks.
+
+### VCV-2 — `feat(stateful): reusable oracle runtime package`
+
+**Module.** New `VCVio/OracleComp/SimSemantics/StateT/Runtime.lean`.
+
+**Indicative interface.**
+
+```lean
+structure OracleRuntime (I : OracleSpec ιI) (E : OracleSpec ιE) where
+  State : Type
+  init : OracleComp I State
+  handler : QueryImpl.Stateful I E State
+```
+
+The first PR uses the currently supported universe-0 runtime boundary. `runState` samples `init` once
+and delegates to existing `Stateful.runState`; `run` erases state.
+
+**Central laws.** Map functoriality; `ofHandler`; and the exact sequential law: after `runState A`
+returns `(a,s)`, continue `simulateQ handler (f a)` from `s` without resampling `init`.
+
+**Important restriction.** No generic initialized-runtime `link`, product, or independence theorem
+is promised. Initializing an outer runtime through an inner handler changes order and can couple
+states. Such a constructor requires an explicitly supplied joint initializer in a later client PR.
+
+**Acceptance.** One heterogeneous runtime exposes two logical oracles sharing a sampled secret and
+the continuation law shows initialization occurs exactly once. Existing `withStateOracle`/UC
+runners are related by adapters, not replaced in this PR.
+
+### VCV-3 — `feat(query-tracking): runner-produced runtime artifacts`
+
+**Prerequisites.** VCV-1 and VCV-2.
+
+**Module.** New `VCVio/OracleComp/QueryTracking/RuntimeArtifact.lean`.
+
+**Declarations.** `QueryImpl.Stateful.withQueryLog`; a core artifact containing output, final state,
+and ordered query log; `OracleRuntime.runArtifact`; `resume` from final state. A resume/session view,
+not every artifact, records the old log length as a region boundary.
+
+**Central laws.** Trace erasure equals `runState`; state+trace erasure equals `run`; failure mass is
+preserved; resumption threads exactly the artifact's state; two runs append traces and place the
+checkpoint at the first length.
+
+**Acceptance.** Two phases in one lazy-RO runtime preserve one cache and yield
+`globalTrace = phase1Trace ++ phase2Trace`. The artifact is the only input to resumption.
+
+**Unlocks.** ArkLib runner-backed `ExecutionArtifact` and the common `OracleComp` case of semantic
+V5. A PolyFun-machine adapter is gated on a later client.
+
+### VCV-4 — `feat(query-tracking): certified query-trace transducers`
+
+**Prerequisites.** PF-5, VCV-0, and VCV-1.
+
+**Module.** New `VCVio/OracleComp/QueryTracking/Transducer.lean`.
+
+**Declarations.** Query-log specialization of `Control.Transducer`; streaming runner; predicate and
+component filters; external `OutputLengthBound`/`TransducesWithin` certificate.
+
+**Central laws.** Specialization agrees with PolyFun `runOpen`; certificate identity/composition;
+component filtering preserves event order.
+
+**Acceptance.** Compose component filtering with a toy backtracking transducer and prove both
+streaming equality and `|out| ≤ f |in|`.
+
+### VCV-5A — `feat(query-tracking): imported-query bounds through stateful handlers`
+
+**Prerequisite.** Existing `QueryBound`/`Stateful.link`; VCV-3 only for artifact corollaries.
+
+**Module.** New `VCVio/OracleComp/QueryTracking/ResourceTransport.lean`.
+
+**Semantic unit.** One exact structural bound; no new ledger.
+
+**Central theorem shape.** Given `IsPerIndexQueryBound A qE` and a uniform-in-state bound
+`∀ e s, IsPerIndexQueryBound ((handler e).run s) (qI e)`, the imported-interface query count of the
+linked run is bounded by the explicit finite convolution/sum of `qE` through `qI`.
+
+**Acceptance.** A two-component finite handler yields the explicit per-component and global sum.
+
+### VCV-5B — `feat(query-tracking): resource-profile and artifact transport adapters`
+
+**Prerequisites.** VCV-3, VCV-4, VCV-5A. Relate VCV-5A to existing `ResourceProfile`, `CostModel`,
+artifact surface-trace counts, and transducer certificates. Keep imported-query bounds distinct from
+surface artifact counts. **Acceptance:** ArkLib uses one adapter through virtual substitution.
+
+### VCV-6 — `feat(query-tracking): auditable dynamic oracle programming`
+
+**Prerequisite.** VCV-3.
+
+**Module.** New `VCVio/OracleComp/QueryTracking/DynamicProgrammingOracle.lean`.
+
+**Declarations.** A command interface containing query and `program(q,a)`; cache plus ordered audit
+state; disjoint precedence: `inserted` for fresh unqueried points, `alreadySame` for an existing
+identical assignment, `conflict` for an existing different programmed assignment, and
+`sampledBeforeProgram` when a query sampled the point first. Programming after sampling rejects and
+does not overwrite in the foundation policy.
+
+**Central laws.** Inserted points answer the programmed value; failed programming preserves cache;
+unrelated points are unchanged; audit events characterize query-before-program/conflict; a preloaded
+dynamic world agrees with existing static `withProgramming`.
+
+**Acceptance.** Phase one queries `x`; phase two programs `x` and fresh `y`; `x` reports the policy
+failure, `y` is installed, unrelated answers persist.
+
+**Not included.** Rewriting existing `ReplayFork`/`SeededFork` APIs.
+
+### VCV-7A — `feat(eval-dist): scalar conditional probability`
+
+**Module.** New `VCVio/EvalDist/Conditioning.lean`.
+
+**Declarations/laws.** Scalar `condProb A B := Pr[A ∩ B] / Pr[B]` for returned-value events with
+`Pr[B] ≠ 0`; missing mass is outside both events. Prove monotonicity, complement, Bayes, and a finite
+conditioned union bound. Do not introduce a normalized distribution in this PR.
+
+**Acceptance.** A genuine conditioned bad-event proof uses the facade. It must not merely restate an
+unconditioned structural induction.
+
+### VCV-7B — `feat(eval-dist): finite conditional partitions` (split if needed)
+
+**Prerequisite.** VCV-7A. Add total probability over a finite returned-value partition and the
+partition lemmas needed by the first salted game. Keep this separate if VCV-7A is already large.
+
+### VCV-8A — `fix(random-oracle): quarantine vacuous unpredictability theorems`
+
+**Prerequisite.** Existing logging/birthday theory only.
+
+Replace or quarantine the trivial `probEvent_unqueried_match_le` and vacuous `Unique ι`
+collision-win statement; add the nonvacuous one-oracle distinct-input collision form.
+
+### VCV-8B — `feat(random-oracle): adaptive target-hit and fresh-response bounds`
+
+**Prerequisites.** VCV-5A and existing `HasUnpredictableSample`. Prove adaptive fresh-response and
+target-hit ≤ structural query budget × point mass. A nontrivial example uses every hypothesis.
+
+### VCV-8C — `feat(random-oracle): hidden-salt queried bound`
+
+**Prerequisites.** VCV-7A/7B and VCV-8B. Prove the conditioned hidden-salt corollary used by SR/BCS.
+
+### VCV-9 — `feat(eval-dist): explicit outcome observation`
+
+**Module.** New `VCVio/EvalDist/Outcome.lean`.
+
+**Declarations.** `Outcome α RuntimeFault`; `materialize (onMissing : RuntimeFault)` from the
+existing `SPMF α`/`PMF (Option α)` representation.
+
+**Central laws.** Success and outer runtime-fault probabilities; `NeverFail` iff the outer
+`onMissing` branch has probability zero; map/bind compatibility. If `α` itself contains a protocol fault, that
+returned branch remains distinct.
+
+**Acceptance.** A failing `OptionT ProbComp` maps missing mass exactly to the chosen `fault`, while a
+never-failing game has zero materialized fault probability.
+
+### VCV-10 — `feat(asymptotics): composable error- and cost-aware security reductions`
+
+**Module.** New `VCVio/CryptoFoundations/Asymptotics/Reduction.lean`.
+
+**Declarations.** `SecurityReduction g h` with adversary map, adversary-class preservation,
+pointwise advantage inequality, and adversary/parameter-indexed additive error; identity/composition;
+`CostedSecurityReduction` paired with existing
+`ReductionWithCost`.
+
+**Central laws.** For `R₁ : G → H` and `R₂ : H → K`,
+`εcomp A n = ε₁ A n + ε₂ (R₁.mapAdversary A) n`; cost transforms compose; security transfers when
+the target adversary class is preserved and each admissible source adversary's error is negligible.
+
+**Acceptance.** Two toy reductions normalize to the expected composed advantage error and cost
+transform.
+
+**Not included.** Boolean-only game experiments, setup fields, universal `AdvCharacteristics`, or a
+second `GameFamily` hierarchy.
+
+## 4. ArkLib PRs
+
+All ArkLib PRs below start from current ArkLib `main` after AR-0. Prototype files on the design
+branch are source banks; declarations are reintroduced in reviewable slices.
+
+### AR-0 — `chore: align the PolyFun/VCVio/Lean compatibility train`
+
+**Prerequisites.** Exact candidate revisions of PolyFun/VCVio known to build together; this does not
+wait for every foundation PR or a post-client stable tag.
+
+Start by reviewing and rebasing the existing `quang/bump-v4.31.0` candidate (`55a9ccc` at the
+2026-07-13 audit), which already pins VCVio `cbd4144b` and its tested PolyFun `04a12b6`; do not
+duplicate its compatibility fixes. Update Lean/Mathlib, VCVio, CompPoly, and documentation dependencies; eliminate any direct PolyFun
+override inconsistent with VCVio; refresh the manifest; add CI checks for resolved revisions and
+duplicate packages. Cold clone, cache fetch, full build, lint, and tests must pass. Later runtime and
+security candidate revisions arrive in separate mechanical bump PRs.
+
+### AR-1 — `feat(interaction): plain dependent reduction kernel`
+
+**Prerequisite.** AR-0 and existing PolyFun append/strategy APIs.
+
+**Declarations.** `HonestProverOutput`, `Prover`, `Verifier`, `Reduction`, `execute`, identity, and
+`comp`. **Theorems:** `execute_comp`, identity laws, transcript split/append. **Acceptance:** two
+dependent toy protocols; cast-free constructor equations; no oracle/security content.
+
+### AR-2A — `feat(interaction): oracle syntax and transcript projections`
+
+**Prerequisite.** AR-0. **Declarations:** `Oracle.Position`, `Oracle.Spec`, `PublicTranscript`,
+`FullTranscript`, execution lens/public projection, `OracleMessagesAt`. **Theorems:** full transcript
+as public transcript plus hidden-message fiber, round trips, payload-independent oracle continuation.
+**Acceptance:** public–oracle–public and dependent-public-branch examples using `rfl`/`simp only`.
+
+### AR-2B — `feat(interaction): role and oracle decorations`
+
+**Prerequisite.** AR-2A. **Declarations:** `RoleDeco`, `OracleDeco`, projections, accumulated
+visibility, PolyFun-decoration conversions. **Theorems:** map/append/projection naturality.
+**Acceptance:** recover exactly the public and oracle nodes of the AR-2A mixed protocol.
+
+### AR-3A — `feat(interaction): accumulated oracle access`
+
+**Prerequisite.** AR-2B. **Declarations:** `answerAt`, query handles, accumulated message interface
+and implementation, full-transcript realization. **Theorems:** concrete-answer agreement, public
+projection invariance, and future-message unavailability. **Acceptance:** passthrough and one-round
+sumcheck access.
+
+### AR-3B — `feat(interaction): oracle prover/verifier execution`
+
+**Prerequisites.** AR-1, AR-2B, AR-3A. **Declarations:** oracle prover/verifier/reduction wrappers and
+executor. **Theorems:** routing agrees with AR-3A; erasure agrees with AR-1; public-output projection
+commutes with execution. **Acceptance:** end-to-end passthrough and one-round execution.
+
+### AR-4A — `feat(oracle-reduction): extensional sources and routing`
+
+**Prerequisite.** AR-0. **Declarations:** universe-polymorphic `OracleFamily`/`Behavior`, extensional
+`SourceCtx`, pure `SourceHom`, tensor/weaken/rename/`asSource`. **Theorems:** `SourceHom`
+identity/composition, interpretation naturality, tensor disjointness, handler reassociation.
+**Acceptance:** equal-signature components remain distinct by routing; no metadata fields.
+
+### AR-4B — `feat(oracle-reduction): resource identity and guarantee schemas`
+
+**Prerequisites.** AR-4A and an ideal-only guarantee descriptor module. **Declarations:**
+`ResourceId`, `ResourceOrigin`, `ResourceSchema`, explicit sharing, `SchemaHom` lying over
+`SourceHom`, and a witness connecting every reified guarantee descriptor to the actual slot
+object/refined type. **Theorems:** schema composition, stable identity under routing, sharing without
+cloning, guarantee-coherence transport. **Acceptance:** incoherent guarantee metadata is
+unconstructible. `BackendAssignment` is absent and will later be indexed by this schema.
+
+### AR-5 — `feat(oracle-reduction): virtual-oracle substitution algebra`
+
+**Prerequisite.** AR-4A; schema corollaries may use AR-4B. **Declarations:** `VirtualOracle`, `eval`,
+`ofQuery`, reindex/weaken, `subst`, semantic equivalence. **Theorems:** evaluation, identity,
+associativity up to source equivalence, and `SourceHom` naturality. **Acceptance:** passthrough,
+linear combination, shared/disjoint two-stage substitution.
+
+### AR-6A — `feat(oracle-reduction): claim representations and closing`
+
+**Prerequisite.** AR-5. **Declarations:** `ClaimWith`, open/closed/data claims, `answerData`, generic
+`closeWith`. **Theorems:** honest realization, `SourceHom` naturality, data/virtual behavior
+equivalence. **Acceptance:** passthrough and linear-combination closing.
+
+### AR-6B — `feat(oracle-reduction): core execution output and run-derived closing`
+
+**Prerequisites.** AR-3B, AR-4B, AR-6A. **Declarations:** trace-free `CoreRun` pairing one execution's
+public result, hidden input/message resources, prover payload, and virtual claim outcome;
+`executeCore`; `closingEnv`/`closed` projections. **Theorems:** execute/closing realization and honest
+data realization. **Acceptance:** supported execution closes by projecting one `CoreRun`. This is an
+API discipline, not a nominal run identity; Δ/Γ traces are not fields yet.
+
+### AR-7 — `feat(sumcheck): one-round completeness through closing`
+
+**Prerequisites.** AR-3B, AR-6B. Port one single-round sumcheck with a coherent degree guarantee,
+query-derived scalar, honest realization, and perfect completeness through closing. **Acceptance:**
+sorry-free; D1 exercised without soundness/compilation.
+
+### AR-8 — `feat(sumcheck): legacy correspondence for the first slice`
+
+**Prerequisite.** AR-7. Add only the sumcheck-specific legacy adapter/correspondence, migration
+ledger, execution theorem, and completeness theorem. **Acceptance:** one real consumer migrates
+without a flag day. Extract a generic supported-fragment adapter only after a second client.
+
+### AR-10A — `feat(interaction): structural full prefixes at cursors`
+
+**Prerequisites.** PF-1/2/3, AR-2B, AR-3A, AR-4B. **Declarations:** `FullPrefixAt` containing a public
+cursor, the concrete hidden-message prefix/fiber accumulated along its spine, reachability evidence,
+and prefix resource schema. This is distinct from `Decoration.restrict`, which describes the future
+residual subtree. **Theorems:** no future resources, monotonicity under witnessed cursor extension,
+and composite split/join. **Acceptance:** two-round protocol, verifier fork, sequential composite.
+
+### AR-9A — `feat(security): logged and world-backed execution artifact adapter`
+
+**Prerequisites.** AR-6B and VCV-1/2/3/5 candidate revisions. **Declarations:** `LoggedRun` adding Δ
+`QueryLog` to `CoreRun`, `executeLogged`, and ArkLib `ExecutionArtifact` as a dependent view of the
+VCVio runtime artifact. **Theorems:** erasure, phase concatenation, schema/event routing, and
+closing/trace projection under the actual runner distribution (or explicit `GeneratedBy`/support
+evidence). **Acceptance:** lazy RO and correlated logical oracles; game experiments run the artifact
+producer rather than accepting arbitrary split parts; no private duplicate semantics.
+
+### AR-9B — `feat(security): terminal outcomes and the failure boundary`
+
+**Prerequisites.** AR-9A and VCV-9. **Declarations:** `Terminal` decoding/materialization and the
+single named missing-mass boundary. **Theorems:** `NeverFail` decoding and outcome probabilities.
+**Acceptance:** accept/reject/explicit-fault plus a failing computation materialized only through the
+named bridge.
+
+### AR-10B — `feat(security): align protocol prefixes with execution artifacts`
+
+**Prerequisites.** AR-10A and AR-9A. Add instrumentation relating each protocol node/phase boundary
+to zero or more Δ/Γ query events; do not assert generic prefix equality. Prove boundary monotonicity,
+trace-region concatenation, and agreement of the reachable full prefix with the artifact projection.
+**Acceptance:** a node issuing zero queries and a node issuing multiple queries.
+
+### AR-11 — `feat(commitment): adapt VCVio Merkle extraction as a backend capability`
+
+**Prerequisites.** AR-4B, AR-9A/9B, VCVio's existing Merkle extraction theorem, VCV-10. Add a minimal
+Merkle `CommitBackend` adapter, event/resource translation, and guarantee-transport proof. Prove the
+capability with VCVio's same bound and without restating the primitive game. **Acceptance:** one
+compiler-facing conformance theorem; unsupported proximity/batching capabilities remain absent.
+
+## 5. Freeze and release checkpoints
+
+### Checkpoint A — base compatibility and structural candidates
+
+Publish exact candidate revisions sufficient for AR-0; do not wait for all foundation work. When
+PF-1/2/3 and PF-5 are locally green, advance VCVio/ArkLib candidate pins. Freeze/tag them only after
+the actual AR-10A and VCV-4 clients pass. PF-4 remains gated.
+
+### Checkpoint B — probabilistic runtime
+
+VCV-1/2/3/5A/5B/9 pass their acceptance tests and enable AR-9A/9B through a runtime candidate
+revision. VCV-7A/B and VCV-8A/B/C form a later security/ROM candidate; VCV-6 enables reprogramming;
+VCV-10 enables computational backend transfer. Stable tags follow downstream acceptance and always
+record the tested PolyFun revision.
+
+### Checkpoint C — first ArkLib vertical slice
+
+AR-0 through AR-7 pass, including one-round sumcheck completeness through run-derived closing. At
+this point the carrier signatures may freeze provisionally. AR-8 proves migration is possible;
+AR-10A accepts the cursor substrate; AR-9A/9B and AR-10B open the security track.
+
+### Checkpoint D — foundation accepted for compiler work
+
+The ten cross-library tests in `01` §7 pass, AR-11 adapts a VCVio Merkle theorem rather than
+restating it, and the ordinary-soundness composition theorem in `03` is expressible with exact
+resource transport. Only then should `04` capability and compiler interfaces freeze.

--- a/docs/design/01b-type-tree-rename-cutover.md
+++ b/docs/design/01b-type-tree-rename-cutover.md
@@ -1,0 +1,267 @@
+# 01b — Type-Tree True-Sight Rename Cutover
+
+**Normative naming decision and operational PR map.** This document fixes the names of the
+sequential interaction carrier and its oracle-reduction refinement, and specifies the complete
+cross-repository cutover. It complements the semantic inventory in `01` and the landing train in
+`01a`; it does not add a new mathematical abstraction.
+
+## 1. Decision
+
+The generic sequential carrier is a well-founded dependent type tree:
+
+```lean
+Interaction.TypeTree :=
+  PFunctor.FreeM TypeTree.basePFunctor PUnit
+
+TypeTree.basePFunctor.A := Type u
+TypeTree.basePFunctor.B := id
+
+TypeTree.Path tree := PFunctor.FreeM.Path tree
+```
+
+Each internal node chooses a move type `X`; a value `x : X` selects the continuation. `Protocol`
+is not used for this bare carrier: roles, participants, local syntax, execution, and security
+meaning live in later decorations and bundles.
+
+The oracle-reduction refinement is an oracle type tree:
+
+```lean
+Interaction.Oracle.TypeTree :=
+  PFunctor.FreeM Oracle.TypeTree.basePFunctor PUnit
+
+Oracle.Position.Branch (.public X) := X
+Oracle.Position.Branch (.oracle X) := PUnit
+```
+
+At an oracle node, the prover's runtime message remains a value `x : X`. Only the **branch index**
+is `PUnit`: every `x` selects the same structural continuation. The runtime lens remembers this
+distinction:
+
+```lean
+Oracle.TypeTree.runtimeLens :
+  Oracle.TypeTree.basePFunctor ⟶ TypeTree.basePFunctor
+
+public x ↦ x
+oracle x ↦ PUnit.unit
+```
+
+This yields two canonical paths:
+
+- `Oracle.TypeTree.BranchPath tree := PFunctor.FreeM.Path tree` records exactly the values that
+  select structural continuations;
+- `Oracle.TypeTree.ExecutionPath tree := PFunctor.FreeM.PathAlong runtimeLens tree` records the
+  concrete values exchanged during execution, including prover oracle messages.
+
+`BranchPath` does not mean that one party controls every move. It is the control-flow/branch path.
+`ExecutionPath` is the global execution record, not the verifier's direct observation. The
+projection `ExecutionPath → BranchPath` is identity at public nodes and sends every oracle payload
+to `PUnit.unit`.
+
+The higher-level name `Protocol` is reserved for a bundle containing at least an oracle type tree,
+roles, and oracle-interface decorations. `Reduction` remains the executable statement/witness
+transformation built over that protocol data.
+
+## 2. Stack placement
+
+The PolyFun rename is **PF-6R**, stacked directly after PF-6A and before PF-6B:
+
+```text
+#54 FreeP/substitution monoid
+  → #55 free substitution-monoid universal property
+  → PF-6A / #62 polynomial interaction normalization
+  → PF-6R complete TypeTree naming cutover
+  → PF-6B dependent TypeTree.Chain composition/coherence (gated)
+```
+
+PF-6A deliberately preserved the historical public names so its algebraic normalization remained
+reviewable. PF-6R is the isolated mechanical/API migration promised by that boundary. PF-6B must be
+written only against the new names.
+
+## 3. PF-6R: exact PolyFun cutover
+
+**Title:** `refactor(interaction): rename sequential specs to type trees`
+
+**Base:** exact PF-6A head `11e02c0101933b7966123017b40cffdfed1399bf` until PF-6A is merged or
+restacked.
+
+### 3.1 Module and carrier names
+
+| Historical API | Cutover API |
+|---|---|
+| `PolyFun.Interaction.Basic.Spec` | `PolyFun.Interaction.Basic.TypeTree` |
+| `PolyFun/Interaction/Basic/Spec.lean` | `PolyFun/Interaction/Basic/TypeTree.lean` |
+| `PolyFun.Interaction.Basic.SpecFintype` | `PolyFun.Interaction.Basic.TypeTreeFintype` |
+| `PolyFun/Interaction/Basic/SpecFintype.lean` | `PolyFun/Interaction/Basic/TypeTreeFintype.lean` |
+| `Interaction.Spec` | `Interaction.TypeTree` |
+| sequential `namespace Spec` | `namespace TypeTree` |
+| `Spec.Transcript` | `TypeTree.Path` |
+
+All sequential namespace members move with the carrier, including `Node`, `Decoration`,
+`MonadDecoration`, `Ownership`, `Sampler`, `Fintype`, `Chain`, `StateChain`, `Telescope`, `done`,
+`node`, `append`, `replicate`, `stepPoly`, and `substMonoid`.
+
+### 3.2 Names that encode the old carrier
+
+The cutover includes exported names whose `Spec` or `Transcript` component specifically denotes the
+sequential type tree:
+
+| Historical family | Cutover family |
+|---|---|
+| `TypeTree`'s historical `DecoratedSpec` / `decoratedSpecEquiv` | `TypeTree.Decorated` / `TypeTree.decoratedEquiv` |
+| `InteractionOver.runSpec` | `InteractionOver.runTypeTree` |
+| `Chain.toSpec` and theorem family | `Chain.toTypeTree` and theorem family |
+| `Telescope.toSpec`, `toSpecAlgebra` | `Telescope.toTypeTree`, `toTypeTreeAlgebra` |
+| `TwoParty.perspectiveSpec` | `TwoParty.typeTreePerspective` |
+| `SyntaxOver.TwoParty.pairedSpec` | `SyntaxOver.TwoParty.pairedTypeTree` |
+| `ShapeOver.TwoParty.pairedSpec` | `ShapeOver.TwoParty.pairedTypeTree` |
+| `InteractionOver.TwoParty.pairedSpec` | `InteractionOver.TwoParty.pairedTypeTree` |
+| `pairedMonadicSpec` / `monadicSpec` specialization families | `pairedMonadicTypeTree` / `monadicTypeTree` |
+| `sampleTranscript` | `samplePath` |
+| sequential `Transcript.*` operations | `TypeTree.Path.*` operations |
+| `Chain.splitTranscript` / `appendTranscript` | `Chain.splitPath` / `appendPath` |
+
+The bridge into `Interaction.Concurrent` must use the same vocabulary rather than preserve a
+second “transcript” facade:
+
+| Historical concurrent bridge | Cutover bridge |
+|---|---|
+| `StepOver.spec` | `StepOver.tree` |
+| `Observed.ofTranscript` | `Observed.ofPath` |
+| `ObservedTranscript` | `ObservedPath` |
+| `eventOfTranscript` / `transcriptOfEvent` | `eventOfPath` / `pathOfEvent` |
+| `ProcessOver.TranscriptRel` | `ProcessOver.StepRel` |
+| `Observation.Process.TranscriptRel` | `Observation.Process.StepRel` |
+| `SafetyRefinement.matchTranscript` | `SafetyRefinement.matchPath` |
+
+`StepRel` is deliberate consolidation: these relations include both the source state and selected
+path and are already aliases of `PFunctor.DynSystem.StepRel`; they are not relations on bare
+transcripts. Local binder names may remain `spec` when they are not exported. The acceptance gate
+is about public vocabulary and documentation, not cosmetic churn in every proof binder.
+
+The paired-specialization theorem families follow their renamed declarations (for example,
+`pairedSpec_focal_sender` becomes `pairedTypeTree_focal_sender`). Likewise every theorem whose
+name begins with `toSpec_`, `splitTranscript_`, or another renamed declaration follows that
+declaration; PF-6R must not leave old theorem names behind merely because their statements compile.
+
+### 3.3 Audited repository surface
+
+The implementation sweep covers all of the following, not only `Basic/Spec.lean`:
+
+- sequential `Basic` modules and the `TwoParty`/`Multiparty` specializations built over them;
+- the `Concurrent` bridge wherever a step embeds a sequential tree or complete path;
+- `PolyFunTest/Interaction`, including the PF-6A normalization canaries, dependent-chain examples,
+  two-/multiparty examples, and concurrent examples;
+- the generated `PolyFun.lean` umbrella import;
+- root agent guidance and maintained `docs/reading` / `docs/wiki` pages.
+
+The audit at PF-6A head found a minimum direct edit surface of 38 source files and five test files
+under the narrow old-name search above. Import-only and prose-only dependents enlarge the final
+diff; the acceptance search, rather than this count, is authoritative.
+
+### 3.4 Explicit exclusions
+
+PF-6R does **not** rename unrelated uses of “specification”:
+
+- `Interaction.Concurrent.Spec`, a separate concurrent source syntax;
+- `DynSystem.SafetySpec`, `Process.SafetySpec`, and other proposition/policy specifications;
+- VCVio `OracleSpec`, the dependent query-response signature;
+- Lean/Std `Do.Spec` theorem namespaces;
+- domain specifications whose name does not denote `Interaction.TypeTree`.
+
+`Interaction.Concurrent.Spec` may receive its own true-sight review later. Mixing that decision into
+PF-6R would make the sequential cutover non-mechanical.
+
+### 3.5 No compatibility facade
+
+The final PR contains no deprecated aliases for `Interaction.Spec`, `Spec.Transcript`, old module
+paths, or old specialization names. This foundation stack is not yet frozen, and keeping aliases
+would preserve two vocabularies throughout every downstream theorem. Git history and the explicit
+rename table above provide migration history.
+
+The PR is semantically conservative: underlying `FreeM` representations, universes, reducibility,
+`@[match_pattern]` behavior, constructor equations, append, path splitting, substitution-monoid
+structure, and universal-property statements do not change.
+
+## 4. Downstream cutover train
+
+The cross-repository migration is atomic by dependency revision, not by pretending one GitHub PR
+can edit three repositories.
+
+### 4.1 VCVio pin/cutover
+
+Advance the PolyFun pin to PF-6R and update all sequential imports and names in one VCVio PR. The
+current audit finds nine VCVio files using the sequential carrier, concentrated in the UC runtime,
+scheduler, and `Std.Do` bridge. Public functions such as `specOf` that return a type tree become
+`treeOf` when exported; unrelated `OracleSpec` and `Std.Do.Spec` names remain unchanged.
+
+### 4.2 ArkLib generic interaction cutover
+
+After the VCVio candidate is green, advance ArkLib's dependency pins and migrate its generic
+interaction layer from `Interaction.Spec`/`Spec.Transcript` to `Interaction.TypeTree`/
+`TypeTree.Path`. The current core-rebuild audit finds 45 ArkLib files on this surface. This is a
+mechanical dependency-alignment PR; it must not also redesign reductions or security notions.
+
+### 4.3 ArkLib oracle type-tree cutover
+
+Land the oracle-specific names with AR-2A, or isolate them in a naming-only commit immediately
+before AR-2A if the prototype is already under review:
+
+| Prototype name | Normative name |
+|---|---|
+| `Interaction.Oracle.Spec` | `Interaction.Oracle.TypeTree` |
+| `ArkLib.Interaction.Oracle.Spec` module / `Oracle/Spec.lean` | `ArkLib.Interaction.Oracle.TypeTree` / `Oracle/TypeTree.lean` |
+| `Oracle.Spec.basePFunctor` | `Oracle.TypeTree.basePFunctor` |
+| `Oracle.Spec.executionLens` | `Oracle.TypeTree.runtimeLens` |
+| `Oracle.Spec.toInteractionSpec` | `Oracle.TypeTree.toTypeTree` |
+| `Oracle.Spec.toSpecRoles` | `Oracle.TypeTree.toTypeTreeRoles` |
+| `Oracle.Spec.PublicTranscript` | `Oracle.TypeTree.BranchPath` |
+| `Oracle.Spec.FullTranscript` | `Oracle.TypeTree.ExecutionPath` |
+| `FullTranscript.toInteractionTranscript` / `.ofInteractionTranscript` | `ExecutionPath.toTypeTreePath` / `.ofTypeTreePath` |
+| `projectPublicFull` | `ExecutionPath.toBranchPath` |
+| `projectPublic` | eliminate in favor of `ExecutionPath.ofTypeTreePath` then `.toBranchPath` |
+| `PublicTranscript.*` operation families | `BranchPath.*` operation families |
+| `transcriptAppend` and dependent theorem family | `ExecutionPath.append` and theorem family |
+| `Oracle.Spec.Chain.toSpec` / `Telescope.toSpec` | `Oracle.TypeTree.Chain.toTypeTree` / `Telescope.toTypeTree` |
+| `Spec.OracleMessagesAt` | `Oracle.TypeTree.OracleMessagesAt` |
+| `Oracle.Spec.Protocol` / projection `.spec` | `Oracle.Protocol` / projection `.tree` |
+
+The current core-rebuild prototype has 23 `ArkLib/Interaction` files on this oracle naming surface.
+`OracleSpec` remains the VCVio query-response signature and must not be changed by this cutover.
+Compiler-local records that are genuinely cryptographic transcripts keep that word. A path-aligned
+record such as BCS's prototype `SharedTranscript`, however, becomes `SharedExecutionPath`; the
+criterion is what the object is, not which layer currently defines it.
+
+## 5. PF-6R acceptance and validation
+
+The exact-head PR must satisfy all of the following:
+
+1. `TypeTree.done` and `TypeTree.node` remain reducible match patterns over the same `FreeM`
+   constructors.
+2. `TypeTree.Path tree` is definitionally `PFunctor.FreeM.Path tree`.
+3. PF-6A's `stepPoly`, substitution-monoid, chain, stopping-tree, and universal-property canaries
+   compile under their new namespaces without additional transports.
+4. A dependent two-branch example distinguishes both paths and confirms append/split equations.
+5. `./scripts/update-lib.sh` regenerates `PolyFun.lean`; no generated file is hand-edited.
+6. `lake build --wfail`, `lake test`, `lake lint`, `lake exe lint-style`, umbrella imports, and
+   documentation integrity all pass on the exact head.
+7. Negative searches find no historical sequential imports or public names in source, tests,
+   generated imports, agent guidance, or maintained docs. Search patterns must be narrow enough to
+   allow `Concurrent.Spec`, `SafetySpec`, `OracleSpec`, and `Std.Do.Spec`.
+8. The diff contains no semantic changes disguised by the rename: compare normalized declarations
+   or inspect `git diff --word-diff-regex` around every non-identifier change.
+
+Before running Lean validation in the new worktree, apply the user-wide dependency-cache policy:
+verify the exact Mathlib URL, revision, and `lean-toolchain`, then reuse a healthy matching cache.
+
+## 6. Review slicing
+
+The PR is large in changed lines but has one semantic claim: **the public names now identify the
+objects already formalized**. Review it in four passes:
+
+1. module moves and generated imports;
+2. carrier/namespace/path names and definitional canaries;
+3. exported specialization/projection names;
+4. docs, tests, negative searches, and downstream pin evidence.
+
+Any proof repair requiring a new cast, changed theorem hypothesis, altered universe, or weaker
+equation is a blocker and must be split from PF-6R. PF-6B begins only after this cutover is green.

--- a/docs/design/02-oracle-reduction-core.md
+++ b/docs/design/02-oracle-reduction-core.md
@@ -1,0 +1,192 @@
+# 02 — Oracle Reduction Core: Claims, Closing, and Composition
+
+**Normative.** The Δ-side design: what an oracle reduction is, what its output claim is, how claims
+close and compose. Supersedes the round-3 document's §§0–6.8 with the round-4 repairs applied; the
+raw history remains on the preserved
+[`archive/oracle-reduction-v2-pre-split`](https://github.com/Verified-zkEVM/ArkLib/tree/archive/oracle-reduction-v2-pre-split/docs/design/archive)
+branch.
+
+## 1. Ontology
+
+An oracle reduction transforms claims about oracles into new claims about (possibly derived) oracles. Four layers, four purposes:
+
+| Layer | Object | Records | Consumed by |
+|---|---|---|---|
+| backing | `SourceCtx` env/handler | what this execution can query | executor, composer, extractor |
+| derived view | `VirtualOracle`; `eval` | typed query program; behavior by interpretation | verifier, composer, compiler |
+| relation boundary | `ClosedClaim` | statement + output behavior | relations/games |
+| representation | `Materialization`, commitments | concrete storage, binding, cost | honest prover, compiler |
+
+Three objects around any oracle, never conflated: **(1)** concrete data (a polynomial), **(2)** arbitrary behavior (answers to all queries), **(3)** a query program deriving answers from other resources. The verifier defines (3); relations consume (2); the honest prover often has (1). The stable point:
+
+> the plan is the operational representation; behavior is its mathematical meaning; concrete data is an optional witness to that behavior.
+
+**The running example** (one FRI round) and the full motivation (why selection-only and data-only designs fail; the `main`-branch autopsy) are preserved in the archive; the two sentences that matter: a real FRI round contains *both* a derived virtual fold view *and* a fresh prover-sent word `g`, checked against each other by sampling — so output schemas must record which slots are derived and which are fresh; and the old `embed`-only design is why `main` could never state lenses, verifier append, or any composition security theorem.
+
+## 2. Representation-indexed claims
+
+One intended claim shape, three representations (round-4 unification). These snippets are design
+equations; exact universes and implicit arguments remain provisional until AR-4A through AR-7 in
+`01a` elaborate:
+
+```lean
+structure ClaimWith (Rep : OracleFamily → Type) (Stmt : Type) (Out : OracleFamily) where
+  stmt    : Stmt
+  oracles : Rep Out
+
+abbrev OracleClaim (srcSpec) Stmt Out := ClaimWith (VirtualOracle srcSpec) Stmt Out  -- open
+abbrev ClosedClaim Stmt Out          := ClaimWith OracleFamily.Behavior Stmt Out    -- closed
+abbrev DataClaim Stmt Out            := ClaimWith (fun O => ∀ i, O.Obj i) Stmt Out  -- honest data
+-- HonestProverOutput = DataClaim × Witness
+```
+
+Representation morphisms into behavior: `eval` (open → closed, per handler) and `answerData` (data → closed). `ProverOutputRealizes` is the statement that the honest prover's `DataClaim` and the verifier's closed claim map to the same point — naturality, not a bespoke condition. `stmt` is produced by the verifier's own (possibly query-dependent) terminal computation; scalar outputs computed from oracle queries (sumcheck's `Tᵢ := sᵢ(rᵢ)`, STIR shift values) live in `stmt`, never in the oracle component. `stmt` is *run*-determined, not env-determined — the joint execution artifact (`03` §2) ties them; there is no theorem "`ClosedClaim` is a function of `Env`" and none should be attempted.
+
+## 3. Core objects
+
+### 3.1 Families and behavior
+
+```lean
+structure OracleFamily where
+  ι      : Type
+  Obj    : ι → Type
+  oracle : ∀ i, OracleInterface (Obj i)
+
+abbrev OracleFamily.Behavior (Out : OracleFamily) := QueryImpl ([Out.Obj]ₒ' Out.oracle) Id
+```
+
+(Repair C5: interface instances are explicit structure data; use ArkLib's explicit-instance spec notation `[…]ₒ'` throughout — a structure field is not a typeclass instance.)
+
+Structured semantics is an optional presentation (`SemanticPresentation`: `Sem`, `behavior : Sem → Behavior`), with injectivity (`FaithfulPresentation`) opt-in. Relations authored on a presentation owe behavioral invariance.
+
+### 3.2 Source contexts
+
+```lean
+structure SourceCtx where
+  ι    : Type
+  spec : OracleSpec ι          -- the *signature* (call it srcSpec when passed alone)
+  Env  : Type                  -- what realizes it
+  impl : Env → QueryImpl spec Id
+```
+
+`SourceCtx` is deliberately extensional. Pure `SourceHom` routes handlers and is the only morphism
+needed by semantic substitution. A separate `ResourceSchema` records stable identity, origin,
+aliasing/sharing, and reified ideal guarantees; each guarantee has a witness connecting its
+descriptor to the actual slot object/refined type. `SchemaHom` lies over a `SourceHom` and proves
+schema coherence. A later `BackendAssignment` is indexed by the schema. This keeps semantic
+substitution independent of compiler metadata without leaving provenance prose-only.
+
+For a reduction at ambient `shared` and public transcript `pt`, the source context has **three** parts:
+
+```lean
+def sourcesAt (shared) (pt) : SourceCtx :=
+  (setupSources shared).tensor ((inputSources shared).tensor (messageSources shared pt))
+```
+
+- **Setup part:** preprocessing/indexer oracles, CRS handles, correlated public parameters. Each setup source is classified in the companion `ResourceSchema` as public data (in `shared`), read-only Δ behavior (here), or a persistent Γ runtime (`03` §1). Systems without setup take this part empty.
+- **Input part:** `InputImpl` — arbitrary deterministic behavior for the input-oracle interfaces. Soundness quantification is unchanged and unweakened.
+- **Transcript part:** the structural hidden-message fiber
+
+```lean
+def Spec.OracleMessagesAt : (s : Spec) → Spec.PublicTranscript s → Type
+  | .done, _ => PUnit
+  | .public _ rest, ⟨x, pt⟩ => OracleMessagesAt (rest x) pt
+  | .oracle X cont, ⟨_, pt⟩ => X × OracleMessagesAt (cont ⟨⟩) pt
+```
+
+with `answerAt` (taking the `OracleDeco`) the structural sibling of `answerQuery`. Not "always inhabited": the correct statement is that **every realized full transcript canonically produces one** — the conversion is the theorem the execution layer exports.
+
+### 3.3 Guarantees travel with oracles (D1 — normative)
+
+Prover-sent oracle message types **may be refined**: sumcheck's round message is `degree ≤ d` polynomials; an IOP proof slot may be typed as a codeword. This is the ideal model working as intended: the verifier can never inspect the underlying object, so the slot's *type is the interface guarantee* — the same way the literature hands the IOP verifier oracles *promised* to satisfy a predicate, with soundness stated against the promise. Consequences:
+
+1. `OracleMessagesAt` stores concrete typed payloads. Malicious transcript-oracle behavior ranges over *representable* values of the declared message type. This is faithful to both the runtime (the prover physically sends a value) and the textbook (IOP strings are literal strings).
+2. Behavior-generality applies where it must: input oracles in games, and closed output claims. A *promise-free* slot is declared by choosing an unrefined message type; the two styles coexist per-slot.
+3. **The compiler owes GuaranteeTransport** (`04` §2): each type-level guarantee on an oracle slot becomes, under compilation, an explicit obligation of the commitment scheme's commit/open phases (degree enforcement, proximity testing, well-formedness proofs). A guarantee that no backend can discharge blocks compilation of that slot — by design, loudly.
+4. Relations still carry *claim-level* validity (proximity parameters, admissibility); the type carries *slot-level* interface promises. Rule of thumb: if the honest prover establishes it by construction and the ideal verifier consumes it as an interface assumption, it may live in the type; if it is what the protocol *establishes or tests*, it lives in the relation.
+
+### 3.4 Virtual oracles
+
+```lean
+structure VirtualOracle (srcSpec : OracleSpec ι) (Out : OracleFamily) where
+  query : QueryImpl ([Out.Obj]ₒ' Out.oracle) (OracleComp srcSpec)
+
+def VirtualOracle.eval (v) (ρ : QueryImpl srcSpec Id) : Out.Behavior :=
+  fun q => simulateQ ρ (v.query q)
+```
+
+No stored denotation, no stored coherence: `eval` *is* the denotation; smart constructors ship `eval`-simplification lemmas; coherence is by construction. This is the algebraic-effects reading of the existing `simulate` field — `OracleComp` the free program, handlers the models, `simulateQ` interpretation, substitution handler-composition.
+
+### 3.5 Closing
+
+```lean
+def OracleClaim.closeWith (c) (ρ : QueryImpl srcSpec Id) : ClosedClaim Stmt Out :=
+  ⟨c.stmt, c.oracles.eval ρ⟩
+```
+
+`closeWith` is a semantic helper. Games never let a prover pair an arbitrary claim with an unrelated handler: the **joint execution artifact** (`03` §2) produces the claim and its closing handler together, and closing is a projection. (Round-4 repair C1/C2: the former `AcceptedRun`/`runClosed` sketches are replaced by the artifact; both were untyped as written — the transcript index, prover payload, and Γ trace all live in the artifact.) Closing forgets the *presentation*, never needed resources: anything a later stage needs is an exported output slot (identity view); a fused implementation may optimize through old sources beneath the interface.
+
+## 4. Constructors
+
+Minimal set: `id`/passthrough, `reindex`, `tensorWeaken`, `rebase`, `subst`, and the escape hatch `ofQuery`. Algebraic constructors (`linComb`, `fold`, `quotient` with its validity predicate in the relation) land when a protocol port first needs them, each with its `eval` lemma and, where applicable, a `Materialization`. Boundaries ("lenses", historically): projection direction = a virtual view + `subst`; reverse direction = materialization/witness transport with its own coherence — call them dependent refinement boundaries unless lens laws are actually proved.
+
+## 5. Composition
+
+Handler substitution with explicit interfaces:
+
+```lean
+def SourceCtx.tensor (S T : SourceCtx) : SourceCtx          -- disjoint sources
+def OracleFamily.asSource (A : OracleFamily) : SourceCtx    -- Env := A.Behavior, impl := id
+
+def VirtualOracle.subst
+    (v : VirtualOracle S.spec A)
+    (w : VirtualOracle (A.asSource.tensor T).spec B) :
+    VirtualOracle (S.tensor T).spec B
+
+theorem eval_subst : (subst v w).eval (ρS + ρT) = w.eval (v.eval ρS + ρT)
+```
+
+Stage two sees the *declared middle interface* (`A.asSource` — behavior only) plus its own suffix resources; never stage one's hidden environment. Sharing/renaming/weakening are explicit context morphisms; duplicating a handle is contraction along a resource identity, not tensoring. Laws (`subst_assoc`, identities) are stated up to `SourceEquiv` (spec iso + env equiv + naturality), under **two named equivalences**: `≈sem` (same behavior under every handler) and `≈op` (typed trace equivalence preserving order/multiplicity/cost). Semantic laws need `≈sem`; compiler theorems need `≈op`, witnessed through VCVio runtime artifacts and resource transport. **Reduction-level operational associativity is not promised**; if a three-stage client requires it, first extend PolyFun's existing `Spec.Chain` under gated PF-6. A new presentation datatype is a fallback, not a foundation assumption.
+
+What `subst` does *not* subsume: interactive-phase monad retargeting (`retargetMonads` / `retargetAmbientWithRoute`) remains — it rewrites receiver-node access during interaction, not terminal claims. Sequential execution decomposition must be proved order-preserving (no generic commutativity for `OracleComp` worlds); the commutative-monad proof from the plain layer is scoped to the pure stateless case.
+
+Deliberately separate (not `subst`): shared-prefix products, lock-step repetition, batched shared challenges — later combinators with their own challenge scoping.
+
+## 6. Core security shape (Δ side; games live in 03)
+
+```lean
+structure ClaimSchema where
+  PublicCtx : Type
+  Claim     : PublicCtx → Type
+
+structure Problem (S : ClaimSchema) where
+  Witness        : ∀ ctx, S.Claim ctx → Type      -- claim-dependent (committed relations!)
+  admissible     : ∀ ctx, S.Claim ctx → Prop
+  rel            : ∀ ctx claim, Witness ctx claim → Prop
+  rel_admissible : ∀ ctx claim wit, rel ctx claim wit → admissible ctx claim
+
+def Problem.language (P) (ctx) (claim) : Prop := ∃ w, P.rel ctx claim w
+abbrev Relation (S) := { P : Problem S // P.admissible = fun _ _ => True }  -- promise-free
+```
+
+(Repair C4: one object; `Relation` is the degenerate case; oracle schemas are the specialization `Claim ctx := ClosedClaim (Stmt ctx) (Out ctx)`.) Relations receive public context, a **closed claim**, and a witness — never the environment, the plan, or provenance. `admissible` covers promises, well-formedness, size bounds, and accumulator invariants (input promise / output-admissibility obligation / inductive invariant are different *proof roles* of the same mechanism, kept as named aliases). Impl-facing predicates are **generated adapters** by evaluation + closing; legacy handwritten predicates owe a two-way equivalence proof, per protocol (repair C6 — there is no generic bridge, and the legacy namespace survives until every consumer is bridged).
+
+Completeness = statement agreement + `ProverOutputRealizes` + `rel_out` on the closed claim; the old `OutputRealizes` is a derived interpreter lemma; literal data equality only under `Faithful` interfaces. Soundness/KS/RBR games, extractors, outcomes (`accept/reject/fault`), and error accounting are `03`'s subject — they require the execution layer.
+
+## 7. Materialization
+
+```lean
+structure Materialization (Src : SourceCtx) (v : VirtualOracle Src.spec Out)
+    (ConcreteSrc OutData : Type) where
+  forget      : ConcreteSrc → Src.Env
+  materialize : ConcreteSrc → OutData
+  answerData  : OutData → Out.Behavior
+  correct     : ∀ src, answerData (materialize src) = v.eval (Src.impl (forget src))
+-- ExecutableMaterialization extends it with cost.
+```
+
+Total (all real uses in the repo are); never load-bearing for security; the honest home of the two retired reification APIs; the attachment point for L6 refinement work.
+
+## 8. Universe and notation discipline
+
+Pinned universes matching the current stack (`Spec : Type 1`, families in `Type`, `OracleSpec.{0,0}`); polymorphization is a tracked follow-up. Naming: `srcSpec` for bare signatures, `Src : SourceCtx` for contexts; `OStatementIn/Out` spellings per the consensus note; declaration-name references, not line numbers.

--- a/docs/design/02-oracle-reduction-core.md
+++ b/docs/design/02-oracle-reduction-core.md
@@ -76,31 +76,36 @@ descriptor to the actual slot object/refined type. `SchemaHom` lies over a `Sour
 schema coherence. A later `BackendAssignment` is indexed by the schema. This keeps semantic
 substitution independent of compiler metadata without leaving provenance prose-only.
 
-For a reduction at ambient `shared` and public transcript `pt`, the source context has **three** parts:
+For a reduction at ambient `shared` and branch path `path`, the source context has **three** parts:
 
 ```lean
-def sourcesAt (shared) (pt) : SourceCtx :=
-  (setupSources shared).tensor ((inputSources shared).tensor (messageSources shared pt))
+def sourcesAt (shared) (path) : SourceCtx :=
+  (setupSources shared).tensor ((inputSources shared).tensor (messageSources shared path))
 ```
 
 - **Setup part:** preprocessing/indexer oracles, CRS handles, correlated public parameters. Each setup source is classified in the companion `ResourceSchema` as public data (in `shared`), read-only Δ behavior (here), or a persistent Γ runtime (`03` §1). Systems without setup take this part empty.
 - **Input part:** `InputImpl` — arbitrary deterministic behavior for the input-oracle interfaces. Soundness quantification is unchanged and unweakened.
-- **Transcript part:** the structural hidden-message fiber
+- **Execution-path part:** the structural hidden-message fiber
 
 ```lean
-def Spec.OracleMessagesAt : (s : Spec) → Spec.PublicTranscript s → Type
+def Oracle.TypeTree.OracleMessagesAt :
+    (s : Oracle.TypeTree) → Oracle.TypeTree.BranchPath s → Type
   | .done, _ => PUnit
-  | .public _ rest, ⟨x, pt⟩ => OracleMessagesAt (rest x) pt
-  | .oracle X cont, ⟨_, pt⟩ => X × OracleMessagesAt (cont ⟨⟩) pt
+  | .public _ rest, ⟨x, tail⟩ => OracleMessagesAt (rest x) tail
+  | .oracle X cont, ⟨_, tail⟩ => X × OracleMessagesAt (cont ⟨⟩) tail
 ```
 
-with `answerAt` (taking the `OracleDeco`) the structural sibling of `answerQuery`. Not "always inhabited": the correct statement is that **every realized full transcript canonically produces one** — the conversion is the theorem the execution layer exports.
+with `answerAt` (taking the `OracleDeco`) the structural sibling of `answerQuery`. Not "always
+inhabited": the correct statement is that **every realized execution path canonically produces
+one** — the conversion is the theorem the execution layer exports.
 
 ### 3.3 Guarantees travel with oracles (D1 — normative)
 
 Prover-sent oracle message types **may be refined**: sumcheck's round message is `degree ≤ d` polynomials; an IOP proof slot may be typed as a codeword. This is the ideal model working as intended: the verifier can never inspect the underlying object, so the slot's *type is the interface guarantee* — the same way the literature hands the IOP verifier oracles *promised* to satisfy a predicate, with soundness stated against the promise. Consequences:
 
-1. `OracleMessagesAt` stores concrete typed payloads. Malicious transcript-oracle behavior ranges over *representable* values of the declared message type. This is faithful to both the runtime (the prover physically sends a value) and the textbook (IOP strings are literal strings).
+1. `OracleMessagesAt` stores concrete typed payloads. Malicious execution-path oracle behavior
+   ranges over *representable* values of the declared message type. This is faithful to both the
+   runtime (the prover physically sends a value) and the textbook (IOP strings are literal strings).
 2. Behavior-generality applies where it must: input oracles in games, and closed output claims. A *promise-free* slot is declared by choosing an unrefined message type; the two styles coexist per-slot.
 3. **The compiler owes GuaranteeTransport** (`04` §2): each type-level guarantee on an oracle slot becomes, under compilation, an explicit obligation of the commitment scheme's commit/open phases (degree enforcement, proximity testing, well-formedness proofs). A guarantee that no backend can discharge blocks compilation of that slot — by design, loudly.
 4. Relations still carry *claim-level* validity (proximity parameters, admissibility); the type carries *slot-level* interface promises. Rule of thumb: if the honest prover establishes it by construction and the ideal verifier consumes it as an interface assumption, it may live in the type; if it is what the protocol *establishes or tests*, it lives in the relation.
@@ -124,7 +129,7 @@ def OracleClaim.closeWith (c) (ρ : QueryImpl srcSpec Id) : ClosedClaim Stmt Out
   ⟨c.stmt, c.oracles.eval ρ⟩
 ```
 
-`closeWith` is a semantic helper. Games never let a prover pair an arbitrary claim with an unrelated handler: the **joint execution artifact** (`03` §2) produces the claim and its closing handler together, and closing is a projection. (Round-4 repair C1/C2: the former `AcceptedRun`/`runClosed` sketches are replaced by the artifact; both were untyped as written — the transcript index, prover payload, and Γ trace all live in the artifact.) Closing forgets the *presentation*, never needed resources: anything a later stage needs is an exported output slot (identity view); a fused implementation may optimize through old sources beneath the interface.
+`closeWith` is a semantic helper. Games never let a prover pair an arbitrary claim with an unrelated handler: the **joint execution artifact** (`03` §2) produces the claim and its closing handler together, and closing is a projection. (Round-4 repair C1/C2: the former `AcceptedRun`/`runClosed` sketches are replaced by the artifact; both were untyped as written — the branch-path index, prover payload, and Γ trace all live in the artifact.) Closing forgets the *presentation*, never needed resources: anything a later stage needs is an exported output slot (identity view); a fused implementation may optimize through old sources beneath the interface.
 
 ## 4. Constructors
 
@@ -146,7 +151,7 @@ def VirtualOracle.subst
 theorem eval_subst : (subst v w).eval (ρS + ρT) = w.eval (v.eval ρS + ρT)
 ```
 
-Stage two sees the *declared middle interface* (`A.asSource` — behavior only) plus its own suffix resources; never stage one's hidden environment. Sharing/renaming/weakening are explicit context morphisms; duplicating a handle is contraction along a resource identity, not tensoring. Laws (`subst_assoc`, identities) are stated up to `SourceEquiv` (spec iso + env equiv + naturality), under **two named equivalences**: `≈sem` (same behavior under every handler) and `≈op` (typed trace equivalence preserving order/multiplicity/cost). Semantic laws need `≈sem`; compiler theorems need `≈op`, witnessed through VCVio runtime artifacts and resource transport. **Reduction-level operational associativity is not promised**; if a three-stage client requires it, first extend PolyFun's existing `Spec.Chain` under gated PF-6. A new presentation datatype is a fallback, not a foundation assumption.
+Stage two sees the *declared middle interface* (`A.asSource` — behavior only) plus its own suffix resources; never stage one's hidden environment. Sharing/renaming/weakening are explicit context morphisms; duplicating a handle is contraction along a resource identity, not tensoring. Laws (`subst_assoc`, identities) are stated up to `SourceEquiv` (spec iso + env equiv + naturality), under **two named equivalences**: `≈sem` (same behavior under every handler) and `≈op` (typed trace equivalence preserving order/multiplicity/cost). Semantic laws need `≈sem`; compiler theorems need `≈op`, witnessed through VCVio runtime artifacts and resource transport. **Reduction-level operational associativity is not promised**; if a three-stage client requires it, first extend PolyFun's existing `TypeTree.Chain` under gated PF-6B. A new presentation datatype is a fallback, not a foundation assumption.
 
 What `subst` does *not* subsume: interactive-phase monad retargeting (`retargetMonads` / `retargetAmbientWithRoute`) remains — it rewrites receiver-node access during interaction, not terminal claims. Sequential execution decomposition must be proved order-preserving (no generic commutativity for `OracleComp` worlds); the commutative-monad proof from the plain layer is scoped to the pure stateless case.
 
@@ -189,4 +194,7 @@ Total (all real uses in the repo are); never load-bearing for security; the hone
 
 ## 8. Universe and notation discipline
 
-Pinned universes matching the current stack (`Spec : Type 1`, families in `Type`, `OracleSpec.{0,0}`); polymorphization is a tracked follow-up. Naming: `srcSpec` for bare signatures, `Src : SourceCtx` for contexts; `OStatementIn/Out` spellings per the consensus note; declaration-name references, not line numbers.
+Pinned universes matching the current stack (`Oracle.TypeTree : Type 1`, families in `Type`,
+`OracleSpec.{0,0}`); polymorphization is a tracked follow-up. Naming: `srcSpec` for bare
+signatures, `Src : SourceCtx` for contexts; `OStatementIn/Out` spellings per the consensus note;
+declaration-name references, not line numbers.

--- a/docs/design/03-adversarial-oracle-execution.md
+++ b/docs/design/03-adversarial-oracle-execution.md
@@ -27,25 +27,26 @@ witness. A paired output prevents accidental split-projection mixing; provenance
 runner distribution, not from the carrier type:
 
 ```lean
-structure CoreRun (pt : Spec.PublicTranscript (Context shared)) where
-  msgs       : Spec.OracleMessagesAt (Context shared) pt   -- prover oracle payloads
+structure CoreRun (path : Oracle.TypeTree.BranchPath (Context shared)) where
+  msgs       : Oracle.TypeTree.OracleMessagesAt (Context shared) path
+    -- prover oracle payloads
   inputEnv   : InputImpl shared                             -- the game's input behavior
-  outcome    : Terminal (OracleClaim (srcSpecAt shared pt) (Stmt pt) (Out pt)) Fault
-  proverOut  : ProverPayload pt
+  outcome    : Terminal (OracleClaim (srcSpecAt shared path) (Stmt path) (Out path)) Fault
+  proverOut  : ProverPayload path
 
-def executeCore … : OracleComp Γ.Surface ((pt : _) × CoreRun pt)
+def executeCore … : OracleComp Γ.Surface ((path : _) × CoreRun path)
 
-structure LoggedRun (pt : _) where
-  core       : CoreRun pt
-  deltaTrace : QueryLog (srcSpecAt shared pt)
+structure LoggedRun (path : _) where
+  core       : CoreRun path
+  deltaTrace : QueryLog (srcSpecAt shared path)
 
-def executeLogged … : OracleComp Γ.Surface ((pt : _) × LoggedRun pt)
+def executeLogged … : OracleComp Γ.Surface ((path : _) × LoggedRun path)
 
 def OracleRuntime.runArtifact (Γ : OracleRuntime Import Surface) :
     OracleComp Surface α → OracleComp Import (RuntimeArtifact Γ α)
 
 -- ArkLib dependent view of the VCVio artifact; constructor remains controlled
-abbrev ExecutionArtifact := RuntimeArtifact Γ ((pt : _) × LoggedRun pt)
+abbrev ExecutionArtifact := RuntimeArtifact Γ ((path : _) × LoggedRun path)
 ```
 
 `executeCore`/`CoreRun` are trace-free and belong to AR-6B. `LoggedRun`, the runtime adapter, and the
@@ -55,9 +56,9 @@ games; it is not a nominal run identifier or a proof of sampling provenance.
 Derived projections: `closingEnv` (from one `CoreRun`'s `inputEnv`+`msgs`), `closed`, and `VerifierLocalView` — defined **from the enclosing `LoggedRun.deltaTrace`** (Δ-queries are not in the Γ trace; recovering the view by replay would need a determinism theorem, so it is logged, not asserted), extractor views, RBR prefixes, compiler traces. Probability is the evaluation distribution of the VCVio runtime runner. Missing `SPMF` mass retains VCVio's existing failure/nontermination meaning; explicit protocol `fault` is a returned value. Terminal decoding either proves `NeverFail` or invokes the one named VCVio outcome materialization.
 
 Define `WorldTrace Γ` only as the named view/alias of `QueryLog Γ.Surface` equipped with ArkLib
-resource-schema routing; it is not a parallel carrier. **Four transcripts, never conflated:**
-`InteractionTranscript` / `VerifierLocalView` / `WorldTrace` / `SRMoveTrace`. “Full transcript” in
-legacy code means the first; compiled extractors consume the third.
+resource-schema routing; it is not a parallel carrier. **Four execution records, never
+conflated:** `ExecutionPath` / `VerifierLocalView` / `WorldTrace` / `SRMoveTrace`. “Full transcript”
+in legacy code means `ExecutionPath`; compiled extractors consume `WorldTrace`.
 
 ## 3. Outcomes
 
@@ -112,7 +113,8 @@ structure SRMove (Π : PublicCoinIOP) where
 
 Axes (orthogonal, per round-3): adversary access / execution control / oracle evidence / output shape / algorithm class / model. Named points ArkLib defines:
 
-- `Extractor.OfflineFullTranscript` — the current IOP-layer object (concrete `InteractionTranscript`); correct at L3.
+- `Extractor.OfflineExecutionPath` — the current IOP-layer object (concrete
+  `Oracle.TypeTree.ExecutionPath`); correct at L3.
 - `Extractor.OfflineLoggedExecution` — eats `WorldTrace`s (adversary's and verifier's); the CY compiled-layer straightline notion. **Never silently substitute the former for the latter: doing so assumes away Merkle extraction** (round-4 correction).
 - `Extractor.QueryOnly`, `BlackBox.{OnePass, PrefixOracle, CheckpointRestore}`, `PrefixWitnessTransport`, `SpecialSoundnessTree`, `RBRTranscriptTree` — each a capability-record product, with view-reduction implications proved where they exist.
 

--- a/docs/design/03-adversarial-oracle-execution.md
+++ b/docs/design/03-adversarial-oracle-execution.md
@@ -1,0 +1,152 @@
+# 03 — Adversarial Oracle Execution: Worlds, Games, Extractors, Budgets
+
+**Normative core (§§1–5, 8–9), fluid periphery (§§6–7).** The Γ-side companion to `02`: the
+semantics in which security is stated and proved. Built on the PolyFun/VCVio deltas in `01` and
+`01a`; ArkLib owns only the protocol-shaped games and views on top. The preserved
+[CY coverage audit](https://github.com/Verified-zkEVM/ArkLib/blob/archive/oracle-reduction-v2-pre-split/docs/design/archive/gpt-cy-coverage.md)
+is the requirements catalog, but current source inventories determine whether a requirement is a
+new object, an adapter, or a theorem repair.
+
+## 1. Worlds
+
+`Γ` is a VCVio **oracle runtime** (V1), optionally interpreted through a traced artifact (V2) and resumed as a session (V5): a thin package over `QueryImpl.Stateful` with a setup computation and persistent state. Public observation and query-log instrumentation are orthogonal adapters, not fields of every runtime. Δ (claim resources, `02` §3.2) is read-only and per-reduction; Γ is persistent, shared by all parties and phases, threaded in execution order — never duplicated by claim-context tensor and never closed into a claim. No product-state runtime or independence theorem is assumed without explicit joint initialization and base semantics.
+
+- ROM = the lazy-function world; CY's oracle distributions `O(λ, N)` = one **joint** world presenting an indexed family of logical oracles (2r ROs for BCS), sampled jointly; independence/domain-separation are theorems.
+- AGM = adversary-class restriction + instrumented trace (basis ownership and extension rules specified per theorem); not a resource.
+- Relativized relations (relation itself queries the model RO) are out of scope by decision (cf. 2024/728).
+- The common theorem layer uses a trivial/no-extra-world runtime; every nontrivial Γ-theorem names
+  its runtime family explicitly.
+
+## 2. The execution artifact
+
+The experiment has a staged, runner-controlled output. AR-6B first pairs the real resources and
+virtual claim; AR-9A adds Δ logging and then asks the VCVio runtime to attach Γ state/query trace.
+Security experiments are defined by the distribution `evalDist (Γ.runArtifact executeLogged)`.
+Theorems do not quantify over arbitrary artifacts unless given a `GeneratedBy`/support-membership
+witness. A paired output prevents accidental split-projection mixing; provenance comes from the
+runner distribution, not from the carrier type:
+
+```lean
+structure CoreRun (pt : Spec.PublicTranscript (Context shared)) where
+  msgs       : Spec.OracleMessagesAt (Context shared) pt   -- prover oracle payloads
+  inputEnv   : InputImpl shared                             -- the game's input behavior
+  outcome    : Terminal (OracleClaim (srcSpecAt shared pt) (Stmt pt) (Out pt)) Fault
+  proverOut  : ProverPayload pt
+
+def executeCore … : OracleComp Γ.Surface ((pt : _) × CoreRun pt)
+
+structure LoggedRun (pt : _) where
+  core       : CoreRun pt
+  deltaTrace : QueryLog (srcSpecAt shared pt)
+
+def executeLogged … : OracleComp Γ.Surface ((pt : _) × LoggedRun pt)
+
+def OracleRuntime.runArtifact (Γ : OracleRuntime Import Surface) :
+    OracleComp Surface α → OracleComp Import (RuntimeArtifact Γ α)
+
+-- ArkLib dependent view of the VCVio artifact; constructor remains controlled
+abbrev ExecutionArtifact := RuntimeArtifact Γ ((pt : _) × LoggedRun pt)
+```
+
+`executeCore`/`CoreRun` are trace-free and belong to AR-6B. `LoggedRun`, the runtime adapter, and the
+security-game experiment belong to AR-9A. Pairing prevents accidental split-part use in supported
+games; it is not a nominal run identifier or a proof of sampling provenance.
+
+Derived projections: `closingEnv` (from one `CoreRun`'s `inputEnv`+`msgs`), `closed`, and `VerifierLocalView` — defined **from the enclosing `LoggedRun.deltaTrace`** (Δ-queries are not in the Γ trace; recovering the view by replay would need a determinism theorem, so it is logged, not asserted), extractor views, RBR prefixes, compiler traces. Probability is the evaluation distribution of the VCVio runtime runner. Missing `SPMF` mass retains VCVio's existing failure/nontermination meaning; explicit protocol `fault` is a returned value. Terminal decoding either proves `NeverFail` or invokes the one named VCVio outcome materialization.
+
+Define `WorldTrace Γ` only as the named view/alias of `QueryLog Γ.Surface` equipped with ArkLib
+resource-schema routing; it is not a parallel carrier. **Four transcripts, never conflated:**
+`InteractionTranscript` / `VerifierLocalView` / `WorldTrace` / `SRMoveTrace`. “Full transcript” in
+legacy code means the first; compiled extractors consume the third.
+
+## 3. Outcomes
+
+```lean
+inductive Terminal (Claim Fault) | accept : Claim → _ | reject | fault : Fault → _
+```
+
+Malformed parses/openings fail **closed** (reject); `fault` is model failure, `Pr[fault] ≤ ε_fault` (preferably 0) in every exported theorem; composition short-circuits on non-accept; extractor failure is *inside* the KS bad event. Migration note: legacy protocols encode rejection in `StatementOut` (`Option`, `Bool`); each port ships a `LegacyOutcome` decoder + correspondence lemma — outcomes are a per-protocol port, not a flag-day (round-4 H2).
+
+## 4. Games
+
+Quantifier order is part of a notion's identity and its **name**. The registry (per README ground rule 5) records for each game: sampling order, adversary phases, trace visibility, budget type, error/time functional signature.
+
+- **Adaptive vs. static:** `H ← O; (x, π) ← A^H` vs. `x` fixed before sampling. Both constructors provided; NARG-level defaults to adaptive (CY).
+- **Phased games**: PolyFun supplies generic machine wiring; ordinary VCVio oracle phases use
+  `resume` plus monadic execution and `QueryLog.append` (PF-4 is needed only by a future operational
+  machine adapter); ArkLib defines the commit/open or five-phase adversary game. Preprocessing keeps
+  the *honest indexer inside the same runtime* between adversary phases.
+- **Soundness:** `Pr[accept out ∧ out ∈ Language R_out]`-style events over artifact projections, for admissible false inputs; **output-admissibility** is a separate probabilistic obligation of each reduction (`ε_adm`). The exact composition contract (normative, common-case scope: finite classical trees, deterministic read-only Δ, no terminal-view Γ queries, explicit challenge kernels, order-preserving sequential decomposition, fail-closed parsing):
+
+```text
+Sound(r₁, R₀ → R₁, ε₁)
+∧ OutputAdmissible(r₁, R₁, ε_adm)
+∧ (∀ reachable mid, history, Sound(r₂[mid, history], R₁ → R₂, ε₂(mid, history)))
+∧ SequentialDecomposition(r₁, r₂)
+⇒ Sound(r₁ ; r₂, R₀ → R₂, ε₁ + ε_adm + sup ε₂ + ε_fault)
+```
+
+  proved by splitting the accepting event on the intermediate claim (true / false-but-admissible / inadmissible). With persistent Γ, the suffix theorem is parameterized by the actual prefix history; same-labeled ROs do not compose by label. Terminal offline KS does **not** generically compose — the valid routes remain prefix-measurable middle extraction, auxiliary-input-robust stage-one KS, or RBRTE grafting.
+- **Knowledge:** the event includes extractor failure; no realization clause (coherence is completeness's). `KS → soundness` needs a causally-available witness supplier, not the bare existential.
+
+## 5. State restoration (first-class, scheduled early — D5)
+
+The SR game is ArkLib's but is *the* hypothesis of compiled-layer theorems (CY: BCS soundness is stated against ε_SR at salt size λ+s_FS — unstateable without it). Definition shape, faithful to CY 16854:
+
+```lean
+structure SRMove (Π : PublicCoinIOP) where
+  round : Fin Π.rounds
+  inst  : Π.Instance
+  prfx  : Π.ProofPrefix round     -- all proof strings through the round
+  salts : Π.SaltPrefix round      -- SALTED: moves carry salt strings
+
+-- World: one random function per round, keyed on the ENTIRE move.
+-- Prover: ≤ B moves, arbitrary purported prefixes (not one consistent execution),
+--   consistent answers on repeats; final output re-derives every challenge.
+-- SRTrace : the move-response log (a WorldTrace instance).
+```
+
+`SRSoundness(s, N, B)`, straightline and **rewinding** `SRKnowledgeSoundness` (extractor gets the SR trace; rewinding adds black-box access; error/time are explicit functions of the prover's experiment-specific failure probability and runtime, transported through VCV-10 reductions). SR is *not* checkpoint/restore (different request type); bridges from RBR (`(B+r)·ε_RBR`), from special soundness, and to Fiat–Shamir are registry entries with named losses.
+
+## 6. Extractors: taxonomy + composition calculus
+
+Axes (orthogonal, per round-3): adversary access / execution control / oracle evidence / output shape / algorithm class / model. Named points ArkLib defines:
+
+- `Extractor.OfflineFullTranscript` — the current IOP-layer object (concrete `InteractionTranscript`); correct at L3.
+- `Extractor.OfflineLoggedExecution` — eats `WorldTrace`s (adversary's and verifier's); the CY compiled-layer straightline notion. **Never silently substitute the former for the latter: doing so assumes away Merkle extraction** (round-4 correction).
+- `Extractor.QueryOnly`, `BlackBox.{OnePass, PrefixOracle, CheckpointRestore}`, `PrefixWitnessTransport`, `SpecialSoundnessTree`, `RBRTranscriptTree` — each a capability-record product, with view-reduction implications proved where they exist.
+
+**Composition calculus (the round-4 gap):** compiled-layer extractors are causal transducer pipelines ending in an inner extractor — CY's BCS-KS extractor is `segment-at-FS-events → stateful multi-config Merkle extraction → hash-chain backtrack → SR-trace adapter → E_IOP-SR`. The pure transducer and causality algebra is PolyFun PF-5; VCVio specializes it to query logs and supplies external resource certificates; ArkLib supplies the concrete adapters, extractor composition, black-box transport, and substitution of inflated error/time functions. Stateful *online* extraction remains with the Merkle backend (`04`) and consumes the shared runtime artifacts.
+
+## 7. RBR, trees, and the implication map
+
+- **One constrained execution tree** (on PolyFun `FreeM.Cursor` plus cursor-restricted decorations): shared prover prefixes, verifier fork nodes with explicit conditional challenge kernels, pairwise-distinct sibling challenges, Γ-history agreement, stable ArkLib resource identities. It is bridged to, but not identified with, `DynSystem.Prefix` and concurrent `Front`.
+- **CY-compatible notions coexist with ArkLib's stronger ones**: `CYStateFunction`/`CYRBRS`/`CYRBRK` (whole-transcript extractor) alongside `ArkRBRK` (edge-local prefix witnesses); proved: `ArkRBRK → CYRBRK → {straightline KS, SRKS}` with the (B+r) losses. Textbook theorems are never forced through the stronger API. The current `KnowledgeClaimTree` is renamed as the *reversible* strong variant; the relaxed probabilistic object replaces it as the RBRKS endpoint.
+- RBR state is indexed by **full prefixes** (concrete messages included; public projection separate); `SourcesAt p` monotone under extension; no future resources at `p`.
+
+## 8. Budgets, errors, time
+
+Per D4 (exact bounds), all core from the start, by extending VCVio's existing
+`ResourceProfile`, query-bound, cost-model, and reduction APIs:
+
+```
+-- VCVio: existing generic resource profile / query-cost carriers
+ResourceProfile Cost ProtocolResource
+-- ArkLib: protocol-specific labels and feasibility refinements
+ProtocolResource := oracleQuery (id) | srMove | commitment | configuration | opening
+ProtocolBudget := ResourceProfile Cost ProtocolResource refined by feasibility predicates
+ε, T : ProtocolBudget → Params → FailureRate → RuntimeBound → ℝ≥0∞
+```
+
+No parallel `Ledger` or universal `AdvCharacteristics` is introduced. Failure probability is
+experiment-specific, while resource profiles and cost transforms reuse VCVio's existing carriers.
+Composition modes are additive and substitution-style (the CY BCS-KS shape); concrete expected-time
+recurrences remain ArkLib theorems until multiple clients justify a generic VCVio API. Budget
+transport accompanies every reduction/transducer ("the SR prover makes ≤ Q_FS moves"), and
+reduction running time remains explicit.
+
+## 9. Deferred with named obligations
+
+- **ZK/WI:** programmable worlds (V6), query-before-program events, Merkle local-view simulators, per-leaf + FS salts, paired WI experiments. Recorded; not in the first migration.
+- **Indifferentiability** (oracle-distribution replacement): simulator + trace translator + view equivalence — a cryptographic theorem, *not* compiler lowering; needed for "general oracle settings" parity with CY.
+- **Quantum:** separate linear execution model; explicitly out of the classical core.

--- a/docs/design/04-oracle-elimination-compiler.md
+++ b/docs/design/04-oracle-elimination-compiler.md
@@ -1,0 +1,107 @@
+# 04 — Oracle Elimination: Compiler Passes, Backends, and Guarantee Transport
+
+**Normative interfaces, fluid internals.** How ideal oracle reductions become real argument systems.
+Validated against Chiesa–Yogev's BCS chapters (whose modular proof factors exactly as this pipeline:
+`BCS = HashChainFS(iBCS)`); the preserved
+[CY coverage audit](https://github.com/Verified-zkEVM/ArkLib/blob/archive/oracle-reduction-v2-pre-split/docs/design/archive/gpt-cy-coverage.md)
+is this document's conformance suite.
+
+## 1. The pipeline
+
+```
+ideal oracle reduction (Δ oracles, Γ = ∅ or small)
+  ├─ RepresentOracles   oracle resources/messages ↦ commitment handles (in Γ-worlds)
+  ├─ LowerAccesses      ideal reads ↦ responses + verified opening arguments
+  ├─ TransportBoundary  inline | seal-and-link | derive (CommitAction)
+  └─ FiatShamir         public coins ↦ challenges from the world (hash-chain or basic)
+→ NARG = the Δ = ∅, one-message case of the same Reduction type, in world Γ
+```
+
+Passes are separate because their hypotheses differ; **but their security proofs cross pass boundaries through the runner-produced query trace** (FS-event order controls Merkle-trace segmentation controls extraction controls SR moves). Therefore passes exchange proof-relevant VCVio runtime artifacts and certified PolyFun/VCVio transducers, not just rewritten syntax + semantic equivalence. Each pass exposes: source/target security games, protocol-erasure theorem, relation transformer, schedule invariant, a VCV-10 `SecurityReduction` with explicit error/cost transform, and its concrete transducer adapters.
+
+The target object is not a new framework: a compiled NARG *is* an oracle reduction with empty claim-oracle context, living entirely in Γ — CY's adaptive NARG games are the Δ=∅ instances of `03` §4.
+
+## 2. GuaranteeTransport (D1 — the pass invariant)
+
+Every type-level guarantee on an ideal oracle slot (degree bound, codeword membership, well-formedness) must be explicitly discharged by the compilation of that slot. Crucially, the guarantee must be **reified** — an arbitrary refined Lean type does not expose its predicate to the compiler, so subtype inspection cannot be the API:
+
+```lean
+structure OracleGuarantee where
+  Raw    : Type                 -- unrefined carrier
+  good   : Raw → Prop           -- the reified promise
+  oracle : OracleInterface Raw
+
+abbrev OracleGuarantee.IdealObj (G) := {x : G.Raw // G.good x}
+-- Ideal slots are typed as G.IdealObj; slot metadata carries G itself.
+
+structure GuaranteeTransport (G : OracleGuarantee) (A : CommitBackend …) where
+  -- accepted openings of this slot are consistent with SOME good raw object
+  enforce       : AcceptedOpenings A → … (Σ x : G.Raw, G.good x ∧ OpeningsRealize A x)
+  error         : ErrorFunctional      -- ε_{G} enters the additive/substitution budget
+  enforce_bound : …
+```
+
+`ResourceMeta` (or the slot schema) carries the `OracleGuarantee` descriptor explicitly; `BackendAssignment` matches descriptors to backend capabilities, and a slot whose guarantee no selected backend can discharge is a **compilation error surfaced at assignment time**. Promise-free slots use `good := fun _ => True`.
+
+Instances: bounded-degree slots → PCS degree enforcement or low-degree tests. **Proximity testing does not discharge an exact-codeword guarantee**: it establishes closeness, not consistency with an exact codeword behavior — an exact-codeword slot needs either an explicit guarantee-*relaxing* reduction whose output relation records proximity (FRI/STIR used as guarantee-restoring reductions, with the relaxation visible in the relation), followed by a decoding/query-agreement bridge, or a backend that extracts an exact codeword consistent with every accepted opening. Plain vector slots → trace coherence only. This is the precise sense in which "proofs go off the wire" at compilation: the ideal promise becomes a cryptographic obligation, and the obligation's error appears in the final bound.
+
+## 3. Modes at output boundaries
+
+1. **Inline (fixed consumer):** compose first; lower the actual finite consumer through the virtual plan; each source query becomes an opening. Needs `FiniteConsumer`/staged plans (response-adaptive consumers need staged query programs, not just static bundles). No commitment for derived views. Ordinary soundness needs **trace coherence** (all accepted answers embed in one total behavior per handle); stronger binding only when the ideal relation promises representability or forks must agree.
+2. **Seal-and-link (reusable boundary):** materialize, commit, change the relation to `Com_A[R]`, and prove a **malicious link** (consistency reduction / alias theorem). Honest `Materialization.correct` is never sufficient.
+3. **Derive (`CommitAction`):** backend-specific public action on commitments for a certified plan fragment (Nova: linear/quadratic-in-challenge plans over Pedersen). Capability-indexed; no generic homomorphic action exists.
+
+`Com_A[R]` is heterogeneous by construction (`BackendAssignment`: per-resource backend, setup, encoding, ownership); the homogeneous `Com_F[R]` is the special case. The committed-schema transformer is normative — randomized commitment execution must never hide inside `Prop`:
+
+```lean
+def ComProblem (A : BackendAssignment) (P : Problem S) : Problem (ComSchema A S) where
+  Witness ctx cc := Σ decoded : S.Claim ctx,
+                    P.Witness ctx decoded × A.OpeningWitness cc decoded
+  admissible ctx cc := …  -- WellFormedSetup ∧ EncodesPromise ∧ P.admissible on decoded
+  rel ctx cc w := P.rel ctx w.1 w.2.1 ∧ A.RealizesHandles cc w.1 w.2.2
+```
+
+Commitment randomness and openings live in the **witness**; `RealizesHandles` is a deterministic relation (or the accepted outcome of a separately modeled commitment protocol). Witnesses are claim-dependent (`02` §6) precisely because of this transformer.
+
+## 4. Backends as game-indexed capability records
+
+A capability is a **complete game record**: experiment + phase structure + trace inputs + budget functional + extractor/simulator + error/time functionals + monotonicity/superadditivity facts. Never a bare `Prop`. The Merkle/ROM backend — the CY conformance target — needs at least:
+
+```
+Correctness, Binding, HonestTreeBinding,
+SingleTraceExtractability,            -- two-phase; extractor eats commit-phase WorldTrace;
+                                      -- partial-tree reconstruction; arbitrary completion;
+                                      -- bad event = later-opening disagreement
+StatefulMultiExtractability,          -- online transducer state; trace INCREMENTS;
+                                      -- repeated-root coherence; non-union-bound error
+MultiConfigurationExtractability,     -- per-configuration projection of one global trace
+RootHiding, SelectiveOpeningPrivacy (local-view simulator), Equivocation
+```
+
+with explicit tree-shape/padding/encoding data (leaf-vs-internal query classification requires disjoint encodings — an *injectivity proof*, not a `domainSep` tag) and salt parameters. The current `Commitments/Functional/Basic.lean` placeholder (`extractability` ending in `False`, single-commitment binding) must never be cited by a compiler theorem.
+
+`BCSPublicView` (commitments + challenges + clear messages) is distinct from the erased `SharedTranscript` skeleton; query functions read the former.
+
+## 5. Fiat–Shamir
+
+Consumes: public-coin replayable structure, exact serialization/absorption order, domain separation, and **state-restoration security of the interactive argument produced by the earlier passes** (CY's modular route). Hash-chain and basic variants both provided; hash-chain needs backtracking transducers. FS and RepresentOracles share a typed **public event log** substrate (`TranscriptTransform`) but remain separate passes (BCS applies without replayability; FS requires it).
+
+## 6. Nova (the algebraic conformance case)
+
+Kept as in the round-3 document (archive §6.10.6), now with D1 phrasing: the ideal relaxed-R1CS fold is an L3 reduction whose output slots are `linComb` plans; W/E slots carry no guarantee beyond shape (relaxed R1CS has no proximity promise — GuaranteeTransport is trivial there, which is *why* no consistency sampling appears); Pedersen's `commitWithOpening` linearity is the `CommitAction`; security = three-branch language-special-soundness tree + binding across forks → relational extraction for `Com[R_rel]`; the FRI contrast (Merkle roots admit no fold action → fresh word + sampled consistency + proximity guarantee restoration) is the two modes side by side.
+
+## 7. Theorem matrix and schedule
+
+The pass × property matrix (normative; reproduced from round 3 so this document has no hidden archive dependency):
+
+| Pass | Functional correctness | Ordinary soundness | Knowledge/extraction | Zero knowledge |
+|---|---|---|---|---|
+| `RepresentOracles` | honest commitment correctness; public-view projection | none by itself | none by itself | commitment leakage only |
+| `LowerAccesses` | opening correctness + plan/trace erasure | trace coherence; stronger binding only when the ideal relation needs it | multi-extraction/WEE or backend tree extraction, with fork coherence | bounded-query ideal simulator + selective/adaptive hiding + opening simulation |
+| fixed-consumer inline | composed evaluator equals lowered consumer | inherited after access lowering | inherited only with the preceding extraction theorem | leakage of the concrete consumer trace is charged |
+| seal-and-link boundary | materialization + link correctness | sound link argument + target-handle coherence | extractable link or RBRTE-compatible witness relation | simulatable link argument |
+| `CommitAction` boundary | representation commuting square | action correctness + required binding across forks | leaf openings/witnesses + relational tree bridge | action leakage + simulator compatibility |
+| batching (own transform) | batch verifier equals individual obligations | native batch soundness or proved reduction | native multi-instance extraction | batch-proof simulation |
+| `FiatShamir` | transcript/challenge agreement | state-restoration soundness in the chosen RO model | state-restoration function binding/extraction or RBRTE theorem | programmable-RO/QROM simulator as applicable |
+
+Recursive compilation of opening protocols needs a well-founded measure (unrepresented oracle nodes, then depth). Errors and times remain explicit functions (substitution mode for KS: `ε_NARG-KS = ε_IOP-SRKS(λ+s_FS, N, Q, δ_A + ε_MT + ε_chain) + …`), transported by VCVio's existing cost/resource carriers and VCV-10 reductions rather than a new universal characteristics record. Compilation fixes a topological schedule (key binding → absorption → challenges → queries → openings → decision) recorded in `ResourceMeta`; budget splits (`Q_MT + Q_FS ≤ Q`) are `ResourceProfile` feasibility constraints, and bounds like `ε_rbr + Q·ε_bind` are corollaries only when the conditional union bound is proved.

--- a/docs/design/05-roadmap.md
+++ b/docs/design/05-roadmap.md
@@ -94,7 +94,7 @@ Guarantee-transport obligations are surfaced by backend assignment from the firs
 
 ## Phase 7+ — Widening [XL, prioritize by demand]
 
-ZK/WI (programmable worlds, salting, local-view simulators); preprocessing/holography (five-phase games); parallel/shared-prefix combinators; **computational backends** (needs VCV-10): curve (KZG/Pedersen/IPA capability records — Nova generalizes) and lattice, with a gate: *one DLOG/AGM- or SIS-based backend theorem proved end-to-end through a `SecurityReduction`*; indifferentiability; full L6 refinement obligations from `00`; reduction-level associativity via gated PF-6 only if a client demands it.
+ZK/WI (programmable worlds, salting, local-view simulators); preprocessing/holography (five-phase games); parallel/shared-prefix combinators; **computational backends** (needs VCV-10): curve (KZG/Pedersen/IPA capability records — Nova generalizes) and lattice, with a gate: *one DLOG/AGM- or SIS-based backend theorem proved end-to-end through a `SecurityReduction`*; indifferentiability; full L6 refinement obligations from `00`; reduction-level associativity via gated PF-6B only if a client demands it.
 
 ## Dependency sketch
 

--- a/docs/design/05-roadmap.md
+++ b/docs/design/05-roadmap.md
@@ -1,0 +1,121 @@
+# 05 — Implementation Roadmap
+
+**Fluid by design.** Phases have exit gates, decision points, and fallbacks; the course is charted, not forced. Tracks run in parallel where dependencies allow. Effort words: S ≈ days, M ≈ 1–3 weeks, L ≈ 1–2 months, XL ≈ open-ended program.
+
+## 0. Standing rules
+
+- Nothing security-shaped changes without its bridge/comparison theorem (per protocol, not global — there is no generic legacy bridge).
+- The legacy security namespace lives until the last consumer is bridged; new work in `Security.V2`-style parallel namespaces. **No flag days.**
+- Foundation gaps found mid-phase are routed by `01`'s parametricity rule and added as explicit PR
+  dependencies in `01a`. Temporary adapters need an upstream issue, no adapter-only theorems, and a
+  deletion test.
+- The design branch is documentation/prototype provenance. All implementation PRs start from the
+  current default branch; there is no bulk merge of the prototype tree.
+- `grep sorry ArkLib/Interaction/` budget: ≤ 1 (the pre-existing ClaimTree lemma) through Phase 4.
+- Every phase ends with a short written retro appended to this file: what redirected, which interfaces moved.
+
+## Tracks
+
+- **T-F (Foundation train):** the exact PF/VCV PRs in `01a`, with existing APIs consolidated rather
+  than rebuilt. [L, parallel where the dependency graph permits]
+- **T-C (Core, ArkLib Δ):** `02` objects and laws.
+- **T-X (Execution/Security, ArkLib Γ):** `03` objects and games.
+- **T-K (Compiler):** `04`.
+- **T-P (Protocols):** ports exercising everything above.
+
+## Phase 0 — Release-train alignment [M]
+
+Land the required PolyFun PRs and compatible revision, then the VCVio pin/runtime PRs and compatible
+revision, then ArkLib AR-0. The current mismatch is material: ArkLib is on Lean 4.30 while current
+PolyFun/VCVio are on 4.31, and the design worktree pins older incompatible revisions.
+Reuse and rebase the existing `quang/bump-v4.31.0` candidate rather than replaying its migration
+fixes; its current manifest alignment is evidence to validate, not a substitute for the gate.
+**Gate:** cold-clone builds in all three repositories; exactly one resolved PolyFun revision; no
+default-branch dependency and no ArkLib override inconsistent with VCVio.
+
+## Phase 1 — Elaborating substrate (T-C; AR-1 through AR-6B) [L]
+
+Reintroduce the plain reduction kernel, oracle syntax/observation split, concrete message access,
+resource schema/context morphisms, virtual substitution, and claims/runner-derived closing as the
+separate
+AR PRs in `01a`. `SourceCtx` stays extensional; resource identity/origin/guarantee metadata lives in
+`ResourceSchema`.
+**Gate:** each PR's local laws and client tests; zero new sorries; legacy untouched; record signatures
+remain provisional until the sumcheck slice.
+
+## Phase 2 — Minimum viable slice (AR-7/AR-8) [M] ← D3
+
+**Programmatic single-round sumcheck perfect completeness through `closeWith`**: query-derived scalar `stmt`, passthrough oracle slot with its degree-bounded message type (D1 exercised), honest-data realization, real `TerminalOutput`. No Spartan, no FRI, no soundness, no associativity.
+**Gate:** the theorem, sorry-free, with the D1 pattern documented in code.
+**Decision point:** if `ClaimWith` indexing fights elaboration here, fall back to three concrete records + morphisms (the unification is a convenience, not a wall).
+
+## Phase 3 — Two more semantic slices and composition [L; cost needs VCV-5A/B]
+
+Build on AR-4A/B and AR-5 rather than adding the substitution algebra here. Add terminal-routing simplification
+in programmatic composition and the Spartan/FRI slices. Semantic laws use extensional equivalence;
+operational trace/cost preservation waits for VCV-3/5A/5B and the ArkLib execution-artifact adapter.
+Land AR-10A and exercise PF-3 cursor/append decomposition in the two-round composite; Γ trace
+alignment remains AR-10B in Phase 4.
+**Gate:** boundary-as-`subst` demonstrated; constructors land with `eval` lemmas.
+**Fallback:** if `retargetMonads`-as-`subst`-action fights Lean, keep it hand-written; the claim algebra carries the proofs regardless.
+
+## Phase 4 — Execution artifact + outcomes + ordinary security [L]
+
+Needs AR-9A/9B/10B, VCV-1/2/3/5A/5B/9/10, and PF-1/2/3.
+
+Adapt the VCVio runner-produced artifact and outcome boundary; add cursor-backed reachable prefixes;
+`ClaimSchema`/`Problem`; closed-claim relations; completeness and **ordinary-soundness composition**
+(output admissibility + conditional suffix theorem) in a parallel security namespace; per-protocol
+bridges for the three slices. Use existing VCVio resource/cost carriers and the VCV-10 reduction
+calculus rather than new ledger/characteristics types.
+**Gate:** slice bridges proved two-way; soundness composition theorem sorry-free; no legacy consumer broken.
+**Risk:** this is the semantic heart; if a bridge fails, *stop and diagnose the quantifier* — that is the audit's designed tripwire, not an obstacle.
+
+## Phase 5 — State restoration + trace calculus [L] ← D5: before compiler
+
+Needs PF-5, VCV-4/6/7A/7B/8A/8B/8C/10, and Phase 4. PF-4 is added only if a
+PolyFun operational-machine adapter becomes an actual client.
+
+Salted SR games and traces; ArkLib segmentation/backtracking/SR adapters over PolyFun transducers and
+VCVio resource certificates; straightline and rewinding SRKS; extractor taxonomy; constrained
+execution trees over `FreeM.Cursor`; `CY*` vs `Ark*` RBR notions and bridges. Dynamic programming and
+conditioned ROM bounds come from the repaired VCVio APIs, not theorem-local worlds.
+**Gate:** the full bridge set — `RBR→SR`; `ArkRBRK → CYRBRK → {ordinary KS, SRKS}`; single- and multi-round special soundness → ordinary KS and SRKS, each under explicit replay, entropy, budget, and error hypotheses; the KS-composition non-theorem documented with its three valid strengthenings.
+
+## Phase 6 — Compiler, staged (T-K, needs Phases 3+5 and accepted backend adapters) [XL]
+
+Order (**interfaces before passes**): capability/game adapters + guarantee descriptors/backend
+assignment → typed read plans → represent/lower/transport passes → concrete adapters. The Merkle
+adapter must consume VCVio's existing primitive extraction theorem rather than restating its game;
+Pedersen uses the Nova conformance slice. Then iBCS transfer, Fiat–Shamir, exact BCS soundness, and
+BCS-KS through the extractor pipeline.
+**Gate per stage:** its row of the `04` security matrix plus the cross-library Checkpoint D in `01a`.
+Guarantee-transport obligations are surfaced by backend assignment from the first stage.
+
+## Phase 7+ — Widening [XL, prioritize by demand]
+
+ZK/WI (programmable worlds, salting, local-view simulators); preprocessing/holography (five-phase games); parallel/shared-prefix combinators; **computational backends** (needs VCV-10): curve (KZG/Pedersen/IPA capability records — Nova generalizes) and lattice, with a gate: *one DLOG/AGM- or SIS-based backend theorem proved end-to-end through a `SecurityReduction`*; indifferentiability; full L6 refinement obligations from `00`; reduction-level associativity via gated PF-6 only if a client demands it.
+
+## Dependency sketch
+
+```
+PF/VCV PR train → AR-0 → Phase 1 → 2 → 3
+                       ↘ AR-9A/B, AR-10A/B → Phase 4 → 5 → 6 → 7+
+                         (protocol slices feed every freeze gate)
+```
+
+## Risk register (top five)
+
+1. **Phase-4 bridge failure** → designed tripwire; diagnose, don't route around.
+2. **Foundation/release slippage** → semantic ArkLib work begins only after AR-0; independent PF and
+   VCV probability/reduction PRs proceed in parallel; temporary adapters obey `01` §3.
+3. **`ClaimWith`/dependent-index friction** → Phase-2 fallback ready.
+4. **Trace-slicing proof burden** (list-partition obligations everywhere) → use VCV-1 trace regions
+   and PF-5/VCV-4 transducers; resist theorem-local plumbing.
+5. **Scope gravity toward the compiler** → Phases 4–5 are the value; the compiler without them is the `main`-branch failure mode again.
+
+## Re-direction principles
+
+When implementation contradicts this plan: (a) accepted interfaces move only with a decision-log
+entry; unvalidated signature sketches remain fluid; (b) consolidations that delete parallel objects
+are favored; (c) if two phases want the same structure, route it by `01`'s parametricity rule.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -26,12 +26,13 @@ compilers. Compilation factors into represent/lower/transport/Fiat–Shamir pass
 | [`00-end-state.md`](00-end-state.md) | The ambition: all of SNARKs, and what we write down now to enable it | directional |
 | [`01-foundations.md`](01-foundations.md) | Ownership by parametricity; current inventory; precise semantic deltas | **normative** |
 | [`01a-foundation-pr-plan.md`](01a-foundation-pr-plan.md) | Exact PolyFun, VCVio, and ArkLib PR slices and release train | operational |
+| [`01b-type-tree-rename-cutover.md`](01b-type-tree-rename-cutover.md) | Complete `TypeTree` / oracle branch-and-execution-path naming cutover | **normative** |
 | [`02-oracle-reduction-core.md`](02-oracle-reduction-core.md) | Claims, virtual oracles, closing, composition, core security (Δ side) | **normative** |
 | [`03-adversarial-oracle-execution.md`](03-adversarial-oracle-execution.md) | Worlds, traces, transducers, games, state restoration, extractors, budgets (Γ side) | normative core, fluid periphery |
 | [`04-oracle-elimination-compiler.md`](04-oracle-elimination-compiler.md) | The compiler passes, commitment capability records, BCS/Nova, guarantee transport | normative interfaces, fluid internals |
 | [`05-roadmap.md`](05-roadmap.md) | Phases, slices, gates, parallel tracks, risks, re-direction principles | fluid by design |
 
-Reading order for a new contributor: 00 → 01 → 01a overview → 02 → 03 → 04 → 05.
+Reading order for a new contributor: 00 → 01 → 01a overview → 01b → 02 → 03 → 04 → 05.
 
 ## Resolved decisions (log)
 
@@ -40,6 +41,12 @@ Reading order for a new contributor: 00 → 01 → 01a overview → 02 → 03 �
 - **D3 — First milestone** is the minimum-viable slice (single-round sumcheck completeness through claim-closing), before the three-slice triple. See `05` Phase 2.
 - **D4 — Exact quantitative theorems are the target.** Bounds must match or beat Chiesa–Yogev. The budget/error-functional algebra is therefore core (Γ side), not deferred; proof *strategies* may be refactored when consolidation is found.
 - **D5 — State restoration and world traces are scheduled before the compiler**, in parallel with the core security cutover.
+- **D6 — True-sight interaction names.** The generic sequential carrier is
+  `Interaction.TypeTree`, with `TypeTree.Path` as its complete branch. Its oracle-reduction
+  refinement is `Interaction.Oracle.TypeTree`, with `BranchPath` for structural continuation
+  choices and `ExecutionPath` for concrete runtime messages. At an oracle node the message remains
+  `x : X`; only the branch index is `PUnit`. `Protocol` is reserved for the decorated bundle. The
+  cutover is complete, without historical aliases; see `01b`.
 
 ## Ground rules carried forward from the audits
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,58 @@
+# ArkLib Oracle Reduction Design Suite (v2)
+
+**Date:** 2026-07-13. **Status:** normative architecture, pre-implementation.
+**Provenance:** the original Sol/Fable adversarial and literature audits plus a fresh source-level
+audit of current ArkLib, VCVio, and PolyFun default branches. The raw audit history remains on the
+preserved [`archive/oracle-reduction-v2-pre-split`](https://github.com/Verified-zkEVM/ArkLib/tree/archive/oracle-reduction-v2-pre-split/docs/design/archive)
+branch; the current-tree findings are incorporated into `00`, `01`, and `01a`.
+
+## The design in one paragraph
+
+An oracle reduction's output claim is a **statement plus a source-scoped virtual oracle** — a typed
+query program over declared backing resources whose extensional meaning is derived under the
+handler produced by the *same* execution. Relations consume **closed claims** and never see
+derivation history. Composition is handler substitution with explicit context morphisms. A separate
+resource schema tracks real identity, origin, aliasing, and guarantees; a later backend assignment
+is indexed by that schema. Generic
+domain-independent cursor/run/trace/transducer algebra lives in PolyFun; VCVio supplies oracle/probability worlds,
+instrumentation, resources, and games; ArkLib supplies protocol claims, security notions, and
+compilers. Compilation factors into represent/lower/transport/Fiat–Shamir passes whose invariant is
+**guarantee transport**: ideal slot guarantees become explicit commit/open/link obligations.
+
+## Documents
+
+| Doc | Contents | Stability |
+|---|---|---|
+| [`00-end-state.md`](00-end-state.md) | The ambition: all of SNARKs, and what we write down now to enable it | directional |
+| [`01-foundations.md`](01-foundations.md) | Ownership by parametricity; current inventory; precise semantic deltas | **normative** |
+| [`01a-foundation-pr-plan.md`](01a-foundation-pr-plan.md) | Exact PolyFun, VCVio, and ArkLib PR slices and release train | operational |
+| [`02-oracle-reduction-core.md`](02-oracle-reduction-core.md) | Claims, virtual oracles, closing, composition, core security (Δ side) | **normative** |
+| [`03-adversarial-oracle-execution.md`](03-adversarial-oracle-execution.md) | Worlds, traces, transducers, games, state restoration, extractors, budgets (Γ side) | normative core, fluid periphery |
+| [`04-oracle-elimination-compiler.md`](04-oracle-elimination-compiler.md) | The compiler passes, commitment capability records, BCS/Nova, guarantee transport | normative interfaces, fluid internals |
+| [`05-roadmap.md`](05-roadmap.md) | Phases, slices, gates, parallel tracks, risks, re-direction principles | fluid by design |
+
+Reading order for a new contributor: 00 → 01 → 01a overview → 02 → 03 → 04 → 05.
+
+## Resolved decisions (log)
+
+- **D1 — Guarantees travel with oracles in the ideal model.** Prover-sent oracle message types MAY be refined (e.g. `degree ≤ d` polynomials). This is not a violation of "validity lives in relations": in the ideal model the verifier cannot inspect the object, so the *type* of the oracle slot is the interface guarantee — exactly as in the literature, where an IOP verifier is handed oracles *promised* to be codewords or bounded-degree polynomials, with soundness stated against that promise. Compilation is what takes guarantees "off the wire": the oracle-elimination compiler transfers each type-level guarantee into a commitment-scheme obligation (commit/open-phase degree or proximity enforcement). See `02` §3.3 and `04` §2 (GuaranteeTransport, with the reified `OracleGuarantee` descriptor). Input oracles in soundness games remain quantified as arbitrary behavior *for their interface*; the interface itself may encode the promise.
+- **D2 — Three-document split**, plus foundations, end-state, and roadmap; recorded in ArkLib history on branch `design/oracle-reduction-v2`.
+- **D3 — First milestone** is the minimum-viable slice (single-round sumcheck completeness through claim-closing), before the three-slice triple. See `05` Phase 2.
+- **D4 — Exact quantitative theorems are the target.** Bounds must match or beat Chiesa–Yogev. The budget/error-functional algebra is therefore core (Γ side), not deferred; proof *strategies* may be refactored when consolidation is found.
+- **D5 — State restoration and world traces are scheduled before the compiler**, in parallel with the core security cutover.
+
+## Ground rules carried forward from the audits
+
+1. Behavior is the unique extensional relation carrier; no quotients; two equivalences (`≈sem`, `≈op`) never conflated.
+2. Closing forgets the presentation, not needed resources; needed resources are exported slots.
+3. Operational machinery never outruns theorem support (the `main`-branch failure mode).
+4. Security definitions are never weakened without an explicit, documented decision; quantifier order is part of a notion's name.
+5. Every capability/property is a concrete game record (experiment, phases, trace inputs, budgets, error/time functions) — never a bare `Prop` name.
+
+**Interface stability legend.** Stable today are architectural invariants (extensional closed claims,
+source-scoped virtual programs, runner-derived closing, explicit aliasing, guarantee transport, and the
+three-library dependency direction). Lean record signatures are provisional until their `01a`
+client gates pass; in particular `ClaimWith`, `SourceCtx`, `ResourceSchema`, `RunCore`, and
+`ExecutionArtifact` are signature sketches rather than frozen elaborated APIs. Compiler planning
+types (`TypedPlan`, `TranscriptTransform`, `FiniteConsumer`, `CompilePolicy`) remain fluid until
+their phase lands.


### PR DESCRIPTION
## What changed

This PR adds the focused oracle-reduction v2 design plan as eight normative documents:

- end-state and ontology
- cross-library foundation requirements and PR sequencing
- oracle-reduction core
- adversarial execution model
- oracle-elimination compiler
- implementation roadmap
- suite navigation and status

The plan includes the corrected PF-2 boundary—displayed cursor restriction requires an explicit child-projection capability—and the corrected PF-5 boundary—a stateful Kleisli–Mealy transducer reusing the existing trace carriers.

## Scope

This branch is now a single documentation commit over current `main`. It contains no ArkLib implementation, dependency, generated-file, or validation-script changes.

The previous mixed branch tip and raw audit/model-output provenance are preserved on [`archive/oracle-reduction-v2-pre-split`](https://github.com/Verified-zkEVM/ArkLib/tree/archive/oracle-reduction-v2-pre-split). They are intentionally outside this review.

## Why

The earlier branch combined the design suite with a long-lived implementation lineage, producing a 128-file, roughly 37k-line PR. Splitting it makes the architecture independently reviewable and leaves implementation work to focused, dependency-ordered PRs.

## Validation

- `git diff --check origin/main...HEAD`
- `python3 scripts/check-docs-integrity.py`
- verified the PR diff contains exactly eight files under `docs/design/`