### PR TITLE
fix(kb): require a keyword boundary in the declaration-opener regex

### DIFF
--- a/scripts/kb/extract_declarations.py
+++ b/scripts/kb/extract_declarations.py
@@ -56,6 +56,7 @@ DECL_RE = re.compile(
         (?:private\s+|protected\s+|noncomputable\s+|partial\s+|mutual\s+)*
         (?P<kind>theorem|lemma|def|abbrev|alias|structure|inductive
                  |instance|class|opaque|axiom)
+        (?![A-Za-z0-9_'])
         (?:\s+(?P<name>[A-Za-z_][\w.'']*))?
         (?P<tail>.*)$
     """,


### PR DESCRIPTION
## What

One-token fix to `scripts/kb/extract_declarations.py`: a negative lookahead after the declaration-keyword alternation in `DECL_RE`, so keywords no longer match as prefixes of longer identifiers.

## Why

Every `classical` tactic line currently parses as a `class` declaration — **286 phantom records** in the committed `declarations.json` — plus 38 more from lines starting with `defines`, `instances`, `lemmas`, `structures`, `theorems`, `axioms`. These phantoms have already polluted downstream consumers: an abf26 review wave had to manually exclude 8 of them in `ProximityGap/Errors.lean`.

## Verification

Regenerated the catalog with the fix and diffed against the committed `docs/kb/_generated/declarations.json` row-by-row:

- **324 records removed, all synthetic `_anon_*` phantoms** (by kind: 286 class, 28 def, 4 instance, 2 lemma, 2 structure, 1 theorem, 1 axiom);
- **0 named declarations removed, 0 added** (5,565 → 5,241 records);
- `scripts/kb/lint.py` and `scripts/check-docs-integrity.py` pass.

Per repo policy, `docs/kb/_generated/**` is not touched here — the main-branch KB workflow will open the refresh PR after merge.

## Related

Complementary to the kernel-level accounting in #708 (`lake exe axiomsweep`): this catalog stays the source-level index (file/line/docstring, buildless); #708 is the evidence-grade axiom/sorry gate. This fix just stops the source-level index from inventing declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
