### PR TITLE
fix(binius): encode witnesses over the Boolean cube, not the diagonal

### DIFF
--- a/ArkLib/ProofSystem/Binius/BinaryBasefold/Basic.lean
+++ b/ArkLib/ProofSystem/Binius/BinaryBasefold/Basic.lean
@@ -792,10 +792,39 @@ def BBF_SumcheckMultiplierParam : SumcheckMultiplierParam L ℓ (SumcheckBaseCon
     degCombinator := 1
     combinator_natDegree_le := by intro _; exact Polynomial.natDegree_X_le }
 
+/-- The [DP24] coefficient vector of a multilinear witness `t`: its Boolean-hypercube table,
+read in the LSB-first bit order of `Nat.binaryFinMapToNat` (`ω = ∑ⱼ 2^j·wⱼ`, so coefficient `ω`
+is `t` at the point `w j = getBit j ω`). This is the inverse of the index mapping used by the
+novel-coefficients decoder above (`hypercube_evals`, via `Nat.binaryFinMapToNat`).
+
+This explicit map avoids the silent coercion in the old spelling `fun ω => t.val.eval ω`, which
+evaluated `t` at the constant point `fun _ => ↑ω` instead of at the Boolean cube point. -/
+def witnessNovelCoeffs (t : L⦃≤ 1⦄[X Fin ℓ]) : Fin (2^ℓ) → L :=
+  fun ω => t.val.eval (fun j => (Nat.getBit j.val ω.val : L))
+
+-- Regression probe: the old diagonal encoding mapped `X 0` and `X 1` to the same table. The
+-- cube-table encoding distinguishes them at `ω = 1`, whose first two bits are `(1, 0)`.
+example :
+    witnessNovelCoeffs (L := L) (ℓ := 2)
+      ⟨MvPolynomial.X ⟨0, by omega⟩, by
+        rw [MvPolynomial.mem_restrictDegree_iff_degreeOf_le]
+        intro j; rw [MvPolynomial.degreeOf_X]; split <;> omega⟩
+      ⟨1, by norm_num⟩ ≠
+    witnessNovelCoeffs (L := L) (ℓ := 2)
+      ⟨MvPolynomial.X ⟨1, by omega⟩, by
+        rw [MvPolynomial.mem_restrictDegree_iff_degreeOf_le]
+        intro j; rw [MvPolynomial.degreeOf_X]; split <;> omega⟩
+      ⟨1, by norm_num⟩ := by
+  have h0 : Nat.getBit 0 1 = 1 := rfl
+  have h1 : Nat.getBit 1 1 = 0 := rfl
+  simp only [witnessNovelCoeffs, MvPolynomial.eval_X, h0, h1, Nat.cast_one, Nat.cast_zero]
+  exact one_ne_zero
+
 /-- This condition ensures that the folding witness `f` is properly generated from `t` -/
 def getMidCodewords {i : Fin (ℓ + 1)} (t : L⦃≤ 1⦄[X Fin ℓ]) -- original polynomial t
     (challenges : Fin i → L) : (sDomain 𝔽q β h_ℓ_add_R_rate (i := ⟨i, by omega⟩) → L) :=
-  let P₀ : L⦃< 2^ℓ⦄[X] := polynomialFromNovelCoeffsF₂ 𝔽q β ℓ (by omega) (fun ω => t.val.eval ω)
+  let P₀ : L⦃< 2^ℓ⦄[X] :=
+    polynomialFromNovelCoeffsF₂ 𝔽q β ℓ (by omega) (witnessNovelCoeffs (L := L) t)
   let f₀ : (sDomain 𝔽q β h_ℓ_add_R_rate 0) → L := fun x => P₀.val.eval x.val
   let fᵢ := iterated_fold 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
     (i := 0)
@@ -829,7 +858,8 @@ export Sumcheck.Structured (sumcheckConsistencyProp)
     evaluated on the initial domain S^(0), must be close within unique decoding radius to f^(0) -/
 def firstOracleWitnessConsistencyProp (t : MultilinearPoly L ℓ)
     (f₀ : sDomain 𝔽q β h_ℓ_add_R_rate 0 → L) : Prop :=
-  let P₀ : L⦃< 2 ^ ℓ⦄[X] := polynomialFromNovelCoeffsF₂ 𝔽q β ℓ (by omega) (fun ω => t.val.eval ω)
+  let P₀ : L⦃< 2 ^ ℓ⦄[X] :=
+    polynomialFromNovelCoeffsF₂ 𝔽q β ℓ (by omega) (witnessNovelCoeffs (L := L) t)
   -- The constraint: P_0 evaluated on S^(0) is close within unique decoding radius to f^(0)
   2 * hammingDist (fun x => P₀.val.eval x.val) f₀ < BBF_CodeDistance ℓ 𝓡 ⟨0, by omega⟩
 

--- a/ArkLib/ProofSystem/Binius/FRIBinius/CoreInteractionPhase.lean
+++ b/ArkLib/ProofSystem/Binius/FRIBinius/CoreInteractionPhase.lean
@@ -99,7 +99,8 @@ def sumcheckFoldCtxLens : OracleContext.Lens
       let t : L⦃≤ 1⦄[X Fin ℓ'] := outerWitIn.t'
       let H : L⦃≤ 2⦄[X Fin (ℓ' - 0)] := outerWitIn.H
 
-      let P₀ : L⦃< 2^ℓ'⦄[X] := polynomialFromNovelCoeffsF₂ K β ℓ' (by omega) (fun ω => t.val.eval ω)
+      let P₀ : L⦃< 2^ℓ'⦄[X] := polynomialFromNovelCoeffsF₂ K β ℓ' (by omega)
+        (BinaryBasefold.witnessNovelCoeffs (L := L) t)
       let f₀ : (sDomain K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate))
         ⟨0, by omega⟩ → L := fun x => P₀.val.eval x.val
 


### PR DESCRIPTION
## The bug

Three sites in the Binius formalization built the novel-polynomial-basis coefficient vector of a multilinear witness `t` with the spelling

```lean
fun ω => t.val.eval ω
```

where `ω : Fin (2^ℓ)`. This does **not** read `t`'s Boolean-hypercube table: Lean silently coerces `ω` to a single ring element and evaluates `t` at the *constant* point `fun _ => ↑ω` — the diagonal. Distinct witnesses collapse to identical coefficient tables (e.g. `X 0` and `X 1` become indistinguishable), so the encoded codeword did not determine the witness.

Affected sites (all on `main`):
- `Binius.BinaryBasefold.getMidCodewords`
- `Binius.BinaryBasefold.firstOracleWitnessConsistencyProp`
- `Binius.FRIBinius.CoreInteractionPhase.sumcheckFoldCtxLens` (honest-prover lens)

## The fix

New shared encoder in `BinaryBasefold/Basic.lean`:

```lean
def witnessNovelCoeffs (t : L⦃≤ 1⦄[X Fin ℓ]) : Fin (2^ℓ) → L :=
  fun ω => t.val.eval (fun j => (Nat.getBit j.val ω.val : L))
```

Coefficient `ω` is `t` evaluated at the Boolean cube point whose bits are the LSB-first binary digits of `ω` — the inverse of the index order used by the existing decoder (`hypercube_evals` via `Nat.binaryFinMapToNat`). All three consumers now use it.

A compiled regression probe (`example`) checks that the encoder distinguishes `X 0` from `X 1` at `ω = 1`, which the old diagonal spelling provably could not — so the bug cannot silently regress.

## Validation

- `lake build` of both affected modules on top of current `main` (`a4ac38e0e`): green, 3,709 jobs, only pre-existing baseline warnings.
- `#print axioms` on `witnessNovelCoeffs` and all three updated consumers: `[propext, Classical.choice, Quot.sound]` — no `sorryAx`.
- Full `./scripts/validate.sh` (build, imports, docs integrity, KB lint): passed.
- `lint-style` on the two changed files: identical diagnostic set to `main` (line-number shifts only); no new style findings.

This is the isolated extraction of the cube-table correction that was previously bundled inside draft #615; it is independent of the generic ring-switching work and is a prerequisite for rebasing that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)