### PR TITLE
refactor(coding-theory): consolidate agreement helpers

### DIFF
--- a/ArkLib/Data/CodingTheory/Basic/Distance.lean
+++ b/ArkLib/Data/CodingTheory/Basic/Distance.lean
@@ -164,6 +164,34 @@ lemma hammingDist_eq_disagreementCols_card (u v : n → R) :
     hammingDist u v = (disagreementCols u v).card := by
   simp only [hammingDist, disagreementCols, ne_eq]
 
+section Agreement
+
+variable {u v : n → R}
+
+/-- The number of positions at which the two words `u` and `v` agree. -/
+def agree (u v : n → R) : ℕ := ({i | u i = v i} : Finset _).card
+
+@[simp]
+lemma agree_add_hammingDist :
+    agree u v + Δ₀(u, v) = Fintype.card n := by
+  simpa [agree, hammingDist, Finset.card_univ] using
+    Finset.card_filter_add_card_filter_not (s := Finset.univ)
+      (p := fun i ↦ u i = v i)
+
+/-- `agree` is the complement of `disagreementCols`. -/
+lemma agree_add_card_disagreementCols (u v : n → R) :
+    agree u v + (disagreementCols u v).card = Fintype.card n := by
+  simp [←hammingDist_eq_disagreementCols_card]
+
+@[simp]
+lemma agree_self : agree u u = Fintype.card n := by simp [agree, Finset.card_univ]
+
+@[simp]
+lemma agree_le_card : agree u v ≤ Fintype.card n := by
+  simpa [agree, Finset.card_univ] using Finset.card_filter_le Finset.univ _
+
+end Agreement
+
 /-- `Matrix.neqCols` is `Code.disagreementCols` on the transposes: the columns on which two
 matrices differ are the coordinates on which their transposes, read as words over the
 alphabet of columns, disagree. -/
@@ -214,28 +242,6 @@ theorem mem_hammingBall_iff (y x : n → R) (r : ℕ) :
 section Agreement
 
 variable {u v : n → R}
-
-/-- The number of positions at which the two words `u` and `v` agree. -/
-def agree (u v : n → R) : ℕ := ({i | u i = v i} : Finset _).card
-
-@[simp]
-lemma agree_add_hammingDist :
-  agree u v + Δ₀(u, v) = Fintype.card n := by
-  simpa [agree, hammingDist, Finset.card_univ] using
-    Finset.card_filter_add_card_filter_not (s := Finset.univ)
-      (p := fun i ↦ u i = v i)
-
-/-- `agree` is the complement of `disagreementCols`. -/
-lemma agree_add_card_disagreementCols (u v : n → R) :
-  agree u v + (disagreementCols u v).card = Fintype.card n := by
-  simp [←hammingDist_eq_disagreementCols_card]
-
-@[simp]
-lemma agree_self : agree u u = Fintype.card n := by simp [agree, Finset.card_univ]
-
-@[simp]
-lemma agree_le_card : agree u v ≤ Fintype.card n := by
-  simpa [agree, Finset.card_univ] using Finset.card_filter_le Finset.univ _
 
 section Counting
 

--- a/ArkLib/Data/CodingTheory/ListDecodability/Bounds/AgreementHypergraph.lean
+++ b/ArkLib/Data/CodingTheory/ListDecodability/Bounds/AgreementHypergraph.lean
@@ -101,29 +101,21 @@ theorem agreementWeight_ge_of_hammingDist_le
     (S.card : ℝ) * Fintype.card ι * (1 - δ) - Fintype.card ι ≤
       (agreementWeight y S : ℝ) := by
   classical
-  let agree : (ι → A) → ℕ := fun c =>
-    (Finset.univ.filter (fun i => c i = y i)).card
-  have hagree : ∀ c, agree c + hammingDist c y = Fintype.card ι := by
-    intro c
-    unfold agree hammingDist
-    simpa only [Finset.card_univ] using
-      (Finset.card_filter_add_card_filter_not
-        (s := Finset.univ) (fun i : ι => c i = y i))
   have hpoint : ∀ c ∈ S,
-      (Fintype.card ι : ℝ) * (1 - δ) ≤ (agree c : ℝ) := by
+      (Fintype.card ι : ℝ) * (1 - δ) ≤ (Code.agree c y : ℝ) := by
     intro c hc
-    have hcast : (agree c : ℝ) + hammingDist c y = Fintype.card ι := by
-      exact_mod_cast hagree c
+    have hcast : (Code.agree c y : ℝ) + hammingDist c y = Fintype.card ι := by
+      exact_mod_cast (Code.agree_add_hammingDist (u := c) (v := y))
     nlinarith [hdist c hc]
   have hlower :
       (S.card : ℝ) * Fintype.card ι * (1 - δ) ≤
-        ∑ c ∈ S, (agree c : ℝ) := by
+        ∑ c ∈ S, (Code.agree c y : ℝ) := by
     have hsum := Finset.sum_le_sum hpoint
     simpa only [Finset.sum_const, nsmul_eq_mul, mul_assoc] using hsum
   have hdouble :
-      (∑ c ∈ S, (agree c : ℝ)) =
+      (∑ c ∈ S, (Code.agree c y : ℝ)) =
         ∑ i : ι, ((S.filter (fun c => c i = y i)).card : ℝ) := by
-    unfold agree
+    unfold Code.agree
     simp_rw [Finset.natCast_card_filter]
     rw [Finset.sum_comm]
   have hfiber : ∀ i : ι,

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
@@ -1856,10 +1856,8 @@ theorem rs_listDecoding_card_lt_field {deg : ℕ} {domain : ι ↪ F} {δ : ℝ�
             -- Chain in ℝ: (n-1)/n ≤ δᵣ ≤ δ, δ + sqrtRate ≤ 1 ⟹ sqrtRate ≤ 1/n.
             -- But √(rate) > rate ≥ 1/n ⟹ sqrtRate > 1/n. Contradiction.
             have hv_dist' : (δᵣ(w, v) : ℝ≥0) ≤ δ := (hclose v hv).2
-            have hsqrt_le_one : ReedSolomon.sqrtRate 1 domain ≤ 1 := by
-              simp only [ReedSolomon.sqrtRate]
-              exact NNReal.sqrt_le_one.mpr (by exact_mod_cast
-                @DivergenceOfSets.reedSolomon_rate_le_one ι _ _ F _ _ domain)
+            have hsqrt_le_one : ReedSolomon.sqrtRate 1 domain ≤ 1 :=
+              ReedSolomon.sqrtRate_le_one 1 domain
             have h_add_le : δ + ReedSolomon.sqrtRate 1 domain ≤ 1 :=
               (le_tsub_iff_right hsqrt_le_one).mp (le_of_lt hδ)
             have h_add_real : (δ : ℝ) + (ReedSolomon.sqrtRate 1 domain : ℝ) ≤ 1 := by

--- a/ArkLib/Data/CodingTheory/ReedSolomon/ListDecodability.lean
+++ b/ArkLib/Data/CodingTheory/ReedSolomon/ListDecodability.lean
@@ -12,7 +12,7 @@ import ArkLib.Data.CodingTheory.ReedSolomon
 
   This file proves that the Reed–Solomon code
   `RS[F, L, m]` of rate `ρ` is `(1 - √ρ - η, 1/(2η√ρ))`-list decodable for every `η > 0`
-  (`RSListDecoding.listDecodable_reedSolomon`) which appears as theorem 4.3
+  (`ReedSolomon.listDecodable_reedSolomon`) which appears as theorem 4.3
   in [ACFY24].
   The bound is independent of the size of `F`.
 
@@ -73,8 +73,12 @@ lemma card_le_of_subset_closeCodewords [Nonempty ι] (domain : ι ↪ F) {m : �
           rw [Finset.sum_const, nsmul_eq_mul, hL]
       _ ≤ ∑ c ∈ T, (Code.agree c y : ℝ) := Finset.sum_le_sum hclose
   -- the sum of all pairwise agreements
-  have hA : ∑ c ∈ T, ∑ c' ∈ T, (Code.agree c c' : ℝ) ≤ L * (n + (L - 1) * (s ^ 2 * n)) := by
-    have hrow : ∀ c ∈ T, ∑ c' ∈ T, (Code.agree c c' : ℝ) ≤ n + (L - 1) * (s ^ 2 * n) := by
+  have hA :
+      ∑ c ∈ T, ∑ c' ∈ T, (Code.agree c c' : ℝ) ≤
+        L * (n + (L - 1) * (s ^ 2 * n)) := by
+    have hrow :
+        ∀ c ∈ T, ∑ c' ∈ T, (Code.agree c c' : ℝ) ≤
+          n + (L - 1) * (s ^ 2 * n) := by
       intro c hc
       have hsplit : ∑ c' ∈ T, (Code.agree c c' : ℝ) =
         (Code.agree c c : ℝ) + ∑ c' ∈ T.erase c, (Code.agree c c' : ℝ) :=
@@ -126,13 +130,12 @@ open NNReal in
 /-- **Theorem 4.3.** The Reed–Solomon code `RS[F, domain, m]` of rate `ρ` is
 `(1 - √ρ - η, 1/(2η√ρ))`-list decodable, for every `η > 0`. -/
 theorem listDecodable_reedSolomon [Nonempty ι] (domain : ι ↪ F) {m : ℕ} (hm : 0 < m)
-  {η : ℝ≥0} (hη : 0 < η) :
-  Code.IsListDecodable (ReedSolomon.code domain m : Set (ι → F))
-    (1 - (ReedSolomon.sqrtRate m domain) - η)
-    (1 / (2 * η * (ReedSolomon.sqrtRate m domain))) := by
+    {η : ℝ≥0} (hη : 0 < η) :
+    Code.IsListDecodable (ReedSolomon.code domain m : Set (ι → F))
+      (1 - (ReedSolomon.sqrtRate m domain) - η)
+      (1 / (2 * η * (ReedSolomon.sqrtRate m domain))) := by
   rw [Code.isListDecodable_iff_forall_finset_card_le]
   intro y T hT
   exact card_le_of_subset_closeCodewords domain hm hη y T fun c hc ↦ hT _ hc
 
 end ReedSolomon
-


### PR DESCRIPTION
Follow-up to #717.

## Summary

- co-locate Code.agree with Code.disagreementCols and reuse the shared agreement API in the hypergraph bound
- reuse ReedSolomon.sqrtRate_le_one in the BCIKS20 proof
- fix the Reed-Solomon list-decodability declaration reference and formatting hygiene

## Validation

- lake build ArkLib.Data.CodingTheory.Basic.Distance ArkLib.Data.CodingTheory.ReedSolomon.ListDecodability ArkLib.Data.CodingTheory.ListDecodability.Bounds.AgreementHypergraph ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.AffineSpaces
- ./scripts/check-imports.sh
- python3 scripts/check-docs-integrity.py
- python3 scripts/kb/lint.py
- git diff --check