### PR TITLE
feat(scripts): port axiomsweep fixture matrix and native-trust gate from VCV-io#513

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,12 @@ jobs:
           bash scripts/build_timing_report.sh run warm_rebuild "$BUILD_TIMING_RESULTS" -- \
             bash -eo pipefail -c 'lake build'
 
+      # The fixture matrix is enforcing: it certifies the sweep tool itself (gate
+      # directions, native-trust floor, exit-code contract), independent of any
+      # taint verdict about the library.
+      - name: Test the axiom sweep tool
+        run: ./scripts/test-axiomsweep.sh
+
       # Taint findings are report-only during the initial soak (flip to enforcing by
       # failing on exit 1 too); infrastructure failures (exit != 1: missing baseline,
       # tool build breakage) always fail so the soak cannot silently rot.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,11 @@ Start with [`README.md`](README.md) for project overview.
 6. Only build site or blueprint output when touching `blueprint/` or `home_page/`:
    `./scripts/validate.sh --site`.
 7. When filling or adding a `sorry` (or anything that must stay axiom-clean), run
-   `./scripts/validate.sh --axioms`; refresh `scripts/axiom_baseline.json` with
-   `lake exe axiomsweep --update-baseline` and commit the diff if the change is
-   intentional.
+   `./scripts/validate.sh --axioms`; it first certifies the sweep tool against its
+   fixture matrix (`./scripts/test-axiomsweep.sh`), then runs the regression gate.
+   Refresh `scripts/axiom_baseline.json` with `lake exe axiomsweep --update-baseline`
+   and commit the diff if the change is intentional. The baseline covers `sorryAx`
+   debt only — native-compiler trust is never allowlistable.
 
 ## Where To Work
 

--- a/docs/wiki/generated-files.md
+++ b/docs/wiki/generated-files.md
@@ -11,7 +11,7 @@ Edit the source of truth, not the output.
 | `blueprint/src/print.pdf` | generated blueprint PDF inside source tree | No | `leanblueprint pdf` |
 | `home_page/docs/` | copied API docs for the site | No | `./scripts/build-web.sh` |
 | `dependency_graphs/` | generated dependency visualizations | No | rerun scripts under `scripts/dependency_analysis/` |
-| `scripts/axiom_baseline.json` | kernel-level axiom/`sorry` regression baseline | No | `lake exe axiomsweep --update-baseline` after a built `lake build`; commit the diff in the PR that intentionally adds or removes taint |
+| `scripts/axiom_baseline.json` | kernel-level axiom/`sorry` regression baseline | No | `lake exe axiomsweep --update-baseline` after a built `lake build`; commit the diff in the PR that intentionally adds or removes taint. The update refuses to write while never-allowlistable native-trust taint is present |
 | `docs/kb/_generated/references.json` | normalized bibliography export | No | `python3 ./scripts/kb/sync_from_bib.py` |
 | `docs/kb/_generated/lean-citations.json` | generated map from Lean files to cited keys | No | `python3 ./scripts/kb/extract_lean_citations.py` |
 | `docs/kb/_generated/declarations.json` | declaration catalog across `ArkLib/` (file, line, kind, namespace, name, brief signature, docstring head) | No | `python3 ./scripts/kb/extract_declarations.py` |

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -53,7 +53,10 @@ If the task is specifically Lean warning cleanup, follow
 ./scripts/validate.sh --axioms
 ```
 
-This adds `lake exe axiomsweep --check`: a kernel-level sweep of every `ArkLib.*`
+This first runs `./scripts/test-axiomsweep.sh` — the executable fixture matrix under
+`scripts/AxiomSweepTestFixtures/` that certifies the sweep tool itself (gate directions,
+the native-trust floor, and the exit-code contract) — and then
+`lake exe axiomsweep --check`: a kernel-level sweep of every `ArkLib.*`
 declaration's axiom dependencies (the `#print axioms` information, library-wide) diffed
 against the committed baseline `scripts/axiom_baseline.json`. It fails only on *new*
 `sorryAx` or non-standard-axiom taint, so pre-existing gaps stay allowed. If you
@@ -63,7 +66,14 @@ intentionally add a tagged `sorry` (or close one), refresh and commit the baseli
 lake exe axiomsweep --update-baseline
 ```
 
-CI runs the same check report-only while the baseline soaks (see `ci.yml`).
+The baseline is an allowlist for `sorryAx` debt only. Native-compiler trust
+(`Lean.ofReduceBool`, `Lean.trustCompiler`, and the per-declaration
+`…._native.<tactic>.ax_<n>_<n>` axioms that `native_decide`-style tactics mint) is held to
+a zero-debt rule: no baseline edit can green it, and `--update-baseline` refuses to write
+while such taint is present — remove the dependency instead.
+
+CI runs the fixture matrix as an enforcing step and the library check report-only while
+the baseline soaks (see `ci.yml`).
 
 ### Docstrings, blueprint, or website changes
 
@@ -135,6 +145,7 @@ lake exe toyproblem-runtime
 ./scripts/check-imports.sh
 python3 ./scripts/check-docs-integrity.py
 python3 ./scripts/kb/lint.py
+./scripts/test-axiomsweep.sh
 lake exe axiomsweep --check
 ```
 
@@ -155,8 +166,8 @@ python3 -m pip install leanblueprint
 - [`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
   runs the timing-enabled main build on PRs and pushes to `main`, measures a
   clean build, a warm rebuild, and the `./scripts/validate.sh` path, runs the
-  axiom sweep report-only, then uploads timing artifacts and posts a comparison
-  report on same-repo PRs.
+  axiom-sweep fixture matrix (enforcing) and the library sweep report-only, then
+  uploads timing artifacts and posts a comparison report on same-repo PRs.
 - [`../../.github/workflows/check-imports.yml`](../../.github/workflows/check-imports.yml)
   checks that `ArkLib.lean` matches the tracked source tree.
 - [`../../.github/workflows/docs-integrity.yml`](../../.github/workflows/docs-integrity.yml)

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -50,3 +50,11 @@ supportInterpreter = true
 name = "toyproblem-runtime"
 srcDir = "scripts"
 root = "ToyProblemRuntime"
+
+# Isolated executable fixtures for the axiom-sweep mutation matrix
+# (scripts/test-axiomsweep.sh). Not a default target: it deliberately contains
+# synthetic kernel taint of every shape the sweep reasons about.
+[[lean_lib]]
+name = "AxiomSweepTestFixtures"
+srcDir = "scripts"
+globs = ["AxiomSweepTestFixtures.+"]

--- a/scripts/AxiomSweep.lean
+++ b/scripts/AxiomSweep.lean
@@ -41,10 +41,19 @@ The committed baseline (`scripts/axiom_baseline.json`) records the currently-kno
 `sorryAx`-tainted declarations and any declarations depending on non-standard axioms
 (anything beyond `propext`, `Classical.choice`, `Quot.sound` — so native trust axioms
 surface here too: `native_decide`-style tactics mint per-declaration
-`…._native.<tactic>.ax_*` axioms, recorded under their owning declaration). `--check`
-fails exactly when a declaration is tainted that the baseline does not cover. When gaps
-are closed, `--check` reports them and stays green; run `--update-baseline` to shrink the
-file in the same PR.
+`…._native.<tactic>.ax_<number>_<number>` axioms, recorded under their owning
+declaration). `--check` fails exactly when a declaration is tainted that the baseline
+does not cover. When gaps are closed, `--check` reports them and stays green; run
+`--update-baseline` to shrink the file in the same PR.
+
+The baseline is an allowlist for `sorryAx` debt only. Native trust is held to PolyFun's
+zero-debt rule instead: `neverAllowlistable` rejects any `._native.` axiom outside the
+explicit `grandfatheredNativeTrust` list, so no baseline edit can widen the trusted
+computing base. Exit codes are a contract with CI — `1` is a taint verdict, anything else
+an infrastructure failure — which is why `main` traps uncaught exceptions into `2`.
+
+`scripts/test-axiomsweep.sh` exercises all of this against the `AxiomSweepTestFixtures`
+library, whose fixtures carry synthetic taint of each shape this file reasons about.
 -/
 
 open Lean
@@ -57,11 +66,32 @@ def defaultRoots : Array Name := #[`ArkLib]
 /-- Axioms that carry no extra trust assumptions beyond Lean's standard foundation. -/
 def standardAxioms : List Name := [``propext, ``Classical.choice, ``Quot.sound]
 
-/-- Axioms that may never be baselined: bare native-compiler trust. A baseline edit
-cannot green these — remove the dependency instead. (Zero hits today; this floor keeps
-the baseline from ever becoming a second, laxer policy.) -/
+/-- Whether `a` names native-compiler trust: either a bare compiler axiom, or one of the
+per-declaration axioms `native_decide`-style tactics mint, which this toolchain names
+`Owner._native.<tactic>.ax_<n>_<n>` rather than routing through `Lean.ofReduceBool`. -/
+def isNativeTrust (a : String) : Bool :=
+  a == "Lean.ofReduceBool" || a == "Lean.trustCompiler" || (a.splitOn "._native.").length > 1
+
+/-- The native trust this repository has already accepted, listed by full axiom name so
+any acceptance is auditable in source rather than hidden in a JSON allowlist. ArkLib has
+accepted none: the list is empty, and the floor below keeps it that way unless an entry
+is consciously added here.
+
+Fails closed: if a private-name index or module path shifts, an entry stops matching and
+`--check` goes red until someone consciously re-accepts it. -/
+def grandfatheredNativeTrust : List String := []
+
+/-- Axioms that may never be baselined: native-compiler trust beyond what
+`grandfatheredNativeTrust` already accepts. Unlike `sorryAx` debt — honest work in
+progress, which the baseline is allowed to track — new native trust is a widening of the
+trusted computing base, so no baseline edit can green it; remove the dependency instead.
+
+This is the counterpart of PolyFun's zero-debt gate. PolyFun refuses a nonempty baseline
+outright; ArkLib cannot, since it carries genuine `sorryAx` debt, so the floor applies the
+same "cannot pre-authorize future taint" rule to the part of the baseline where widening
+the TCB is at stake. -/
 def neverAllowlistable (a : String) : Bool :=
-  a == "Lean.ofReduceBool" || a == "Lean.trustCompiler"
+  isNativeTrust a && !grandfatheredNativeTrust.contains a
 
 /-- Phase 1: DFS. Compute, for every constant reachable from the work list, an
 under-approximation of the set of axioms it transitively depends on, memoised across
@@ -144,14 +174,28 @@ structure Baseline where
   nonstandard : Array NonstandardEntry
   deriving FromJson, ToJson
 
-/-- Collapse the volatile counter suffix of native trust axioms
+/-- Whether `s` is a nonempty string of ASCII decimal digits. -/
+def isDecimal (s : String) : Bool :=
+  !s.isEmpty && s.toList.all fun c => '0' ≤ c && c ≤ '9'
+
+/-- Collapse exactly the generated counter suffix of native trust axioms
 (`Foo._native.native_decide.ax_1_1` → `Foo._native.native_decide`), so baselines key by
-owning declaration rather than a rebuild-volatile counter. -/
+owning declaration rather than a rebuild-volatile counter. Names that merely contain
+`._native.` or resemble a generated suffix are preserved: collapsing them would let two
+distinct axioms share one baseline key, so real taint could hide behind an accepted
+entry. -/
 def normalizeAxiomName (s : String) : String :=
   match s.splitOn "._native." with
   | [owner, tail] =>
     match tail.splitOn "." with
-    | tactic :: _ => owner ++ "._native." ++ tactic
+    | [tactic, counter] =>
+      match counter.splitOn "_" with
+      | ["ax", major, minor] =>
+        if !owner.isEmpty && !tactic.isEmpty && isDecimal major && isDecimal minor then
+          owner ++ "._native." ++ tactic
+        else
+          s
+      | _ => s
     | _ => s
   | _ => s
 
@@ -280,6 +324,22 @@ def runCheck (cur : Baseline) (basePath : String) : IO UInt32 := do
   IO.println "axiomsweep: check passed (no new axiom/sorry taint)."
   return 0
 
+/-- Rewrite the baseline from the current build. Refuses while never-allowlistable taint
+is present: `--check` would reject the result anyway (the floor is enforced there, not
+here), so writing it would only produce a baseline that looks authoritative and is not.
+Recording new `sorryAx` debt is fine — that is what the baseline is for. -/
+def runUpdate (cur : Baseline) (basePath : String) : IO UInt32 := do
+  let floor := cur.nonstandard.filter fun e => e.axioms.any neverAllowlistable
+  if !floor.isEmpty then
+    IO.eprintln s!"axiomsweep: refusing to update {basePath} while \
+      {floor.size} declaration(s) depend on never-allowlistable axioms:"
+    for e in floor do IO.eprintln s!"  {e.name} : {e.axioms.filter neverAllowlistable}"
+    IO.eprintln "axiomsweep: remove the dependency; the baseline cannot pre-authorize it."
+    return 1
+  IO.FS.writeFile basePath ((toJson cur).pretty ++ "\n")
+  IO.println s!"axiomsweep: wrote baseline to {basePath}"
+  return 0
+
 structure Config where
   roots : Array Name := #[]
   out? : Option String := none
@@ -302,7 +362,10 @@ def parseArgs : List String → Config → Except String Config
 end AxiomSweep
 
 open AxiomSweep in
-unsafe def main (args : List String) : IO UInt32 := do
+/-- Tool body. Exit codes are a contract with CI, which reads `1` as a taint verdict and
+anything else as an infrastructure failure; `main` wraps this so an uncaught exception
+cannot masquerade as the former. -/
+unsafe def run (args : List String) : IO UInt32 := do
   let cfg ← match parseArgs args {} with
     | .ok cfg => pure cfg
     | .error e => IO.eprintln e; return 2
@@ -338,9 +401,15 @@ unsafe def main (args : List String) : IO UInt32 := do
     IO.FS.writeFile out (report.pretty ++ "\n")
     IO.println s!"axiomsweep: wrote report to {out}"
   if cfg.update then
-    IO.FS.writeFile cfg.baseline ((toJson cur).pretty ++ "\n")
-    IO.println s!"axiomsweep: wrote baseline to {cfg.baseline}"
-    return 0
+    return (← runUpdate cur cfg.baseline)
   if cfg.check then
     return (← runCheck cur cfg.baseline)
   return 0
+
+open AxiomSweep in
+unsafe def main (args : List String) : IO UInt32 := do
+  try
+    run args
+  catch e =>
+    IO.eprintln s!"axiomsweep: internal error: {e}"
+    return 2

--- a/scripts/AxiomSweepTestFixtures/Clean.lean
+++ b/scripts/AxiomSweepTestFixtures/Clean.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+/-! # Clean executable fixture for axiomsweep -/
+
+public section
+
+namespace AxiomSweepTestFixtures.Clean
+
+def base : Nat := 7
+
+def transitive : Nat := base + 1
+
+end AxiomSweepTestFixtures.Clean

--- a/scripts/AxiomSweepTestFixtures/Tainted.lean
+++ b/scripts/AxiomSweepTestFixtures/Tainted.lean
@@ -1,0 +1,13 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+import AxiomSweepTestFixtures.Tainted.AxiomInType
+import AxiomSweepTestFixtures.Tainted.DirectSorry
+import AxiomSweepTestFixtures.Tainted.Mutual
+import AxiomSweepTestFixtures.Tainted.NativeNames
+
+/-! # Imported taint fixture root for axiomsweep -/

--- a/scripts/AxiomSweepTestFixtures/Tainted/AxiomInType.lean
+++ b/scripts/AxiomSweepTestFixtures/Tainted/AxiomInType.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+/-! # Axiom-in-type fixture for axiomsweep -/
+
+public section
+
+namespace AxiomSweepTestFixtures.Tainted
+
+axiom typeIndex : Nat
+
+axiom axiomInType : Fin (typeIndex + 1)
+
+end AxiomSweepTestFixtures.Tainted

--- a/scripts/AxiomSweepTestFixtures/Tainted/DirectSorry.lean
+++ b/scripts/AxiomSweepTestFixtures/Tainted/DirectSorry.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+/-! # Direct and transitive `sorryAx` fixtures for axiomsweep -/
+
+public section
+
+namespace AxiomSweepTestFixtures.Tainted
+
+opaque directSorry : Nat := sorryAx Nat true
+
+def transitiveSorry : Nat := directSorry
+
+end AxiomSweepTestFixtures.Tainted

--- a/scripts/AxiomSweepTestFixtures/Tainted/Mutual.lean
+++ b/scripts/AxiomSweepTestFixtures/Tainted/Mutual.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+/-! # Mutual-inductive fixpoint fixture for axiomsweep -/
+
+public section
+
+namespace AxiomSweepTestFixtures.Tainted
+
+axiom mutualAxiom : True
+
+mutual
+  inductive MutualLeft : Type where
+    | fromRight : MutualRight → MutualLeft
+    | tainted : True.intro = mutualAxiom → MutualLeft
+
+  inductive MutualRight : Type where
+    | fromLeft : MutualLeft → MutualRight
+end
+
+end AxiomSweepTestFixtures.Tainted

--- a/scripts/AxiomSweepTestFixtures/Tainted/NativeNames.lean
+++ b/scripts/AxiomSweepTestFixtures/Tainted/NativeNames.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+/-! # Native-axiom name-normalization fixtures for axiomsweep -/
+
+public section
+
+namespace AxiomSweepTestFixtures.Tainted.Generated._native.native_decide
+
+axiom ax_12_34 : True
+
+end AxiomSweepTestFixtures.Tainted.Generated._native.native_decide
+
+namespace AxiomSweepTestFixtures.Tainted.Collision._native.native_decide
+
+axiom ax_12_extra : True
+axiom ax_x_34 : True
+
+namespace ax_12_34
+
+axiom extra : True
+
+end ax_12_34
+
+end AxiomSweepTestFixtures.Tainted.Collision._native.native_decide
+
+namespace AxiomSweepTestFixtures.Tainted
+
+theorem generatedNativeUser : True := Generated._native.native_decide.ax_12_34
+
+theorem collisionUser : True := Collision._native.native_decide.ax_12_extra
+
+theorem collisionNondecimalUser : True := Collision._native.native_decide.ax_x_34
+
+theorem collisionExtraSegmentUser : True :=
+  Collision._native.native_decide.ax_12_34.extra
+
+end AxiomSweepTestFixtures.Tainted

--- a/scripts/AxiomSweepTestFixtures/Unimported.lean
+++ b/scripts/AxiomSweepTestFixtures/Unimported.lean
@@ -1,0 +1,16 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+/-! # Deliberately unimported `sorryAx` fixture for axiomsweep -/
+
+public section
+
+namespace AxiomSweepTestFixtures.Unimported
+
+opaque hiddenSorry : Nat := sorryAx Nat true
+
+end AxiomSweepTestFixtures.Unimported

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,9 @@ This directory contains various utility scripts for the ArkLib project.
 - **`check-warning-log.py`** - Fail on scoped warning classes found in a captured build log
 - **`AxiomSweep.lean`** (`lake exe axiomsweep`) - Kernel-level axiom/`sorry` accounting with a
   committed regression baseline (`axiom_baseline.json`); see "Axiom Sweep" below
+- **`test-axiomsweep.sh`** - Executable fixture matrix certifying the axiomsweep tool itself
+  (gate directions, native-trust floor, exit-code contract), against the synthetic-taint
+  fixtures in `AxiomSweepTestFixtures/`
 - **`ToyProblemRuntime.lean`** (`lake exe toyproblem-runtime`) - Compiled small-parameter checks
   for KoalaBear sextic arithmetic, executable interleaved-RS extraction, and the C6.9 virtual
   output-oracle and exact-extractor paths
@@ -134,8 +137,24 @@ lake exe axiomsweep --update-baseline
 ```
 
 The committed baseline makes the distinction the repo cares about mechanical:
-pre-existing `sorry` gaps are allowed, *new* ones fail `--check`. CI runs the check
-report-only; `./scripts/validate.sh --axioms` runs it enforcing.
+pre-existing `sorry` gaps are allowed, *new* ones fail `--check`. The baseline is an
+allowlist for `sorryAx` debt only; native-compiler trust (`Lean.ofReduceBool`,
+`Lean.trustCompiler`, and the per-declaration `…._native.<tactic>.ax_<n>_<n>` axioms
+minted by `native_decide`-style tactics) is never allowlistable — `--check` fails on it
+regardless of the baseline, and `--update-baseline` refuses to write while it is present.
+CI runs the library check report-only; `./scripts/validate.sh --axioms` runs it enforcing.
+
+The tool itself is certified by `./scripts/test-axiomsweep.sh`, which builds the isolated
+`AxiomSweepTestFixtures` library (deliberate synthetic taint of every shape the sweep
+reasons about: direct and transitive `sorry`, axiom-in-type, mutual-inductive inheritance,
+generated native-trust names and near-miss collisions, and an unimported file) and checks
+report determinism, every gate direction, and the exit-code contract (`1` = taint verdict,
+`2` = infrastructure failure). CI runs it as an enforcing step:
+
+```bash
+lake build AxiomSweepTestFixtures
+./scripts/test-axiomsweep.sh
+```
 
 ### `build_timing_report.sh`
 

--- a/scripts/test-axiomsweep.sh
+++ b/scripts/test-axiomsweep.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+# Execute falsifiable fixtures for the kernel-level axiom sweep.
+#
+# Ported from PolyFun's `scripts/test-axiomsweep.sh` via VCV-io, with the exit-code
+# matrix matching ArkLib's policy: the baseline is an allowlist for `sorryAx` debt
+# (PolyFun forbids a nonempty baseline outright; ArkLib carries genuine work in
+# progress), while native trust is held to the same zero-debt rule through
+# `neverAllowlistable`.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+FIXTURE_TMP="$(mktemp -d "${TMPDIR:-/tmp}/arklib-axiomsweep.XXXXXX")"
+trap 'rm -rf -- "$FIXTURE_TMP"' EXIT
+
+expect_status() {
+  local expected="$1"
+  local label="$2"
+  shift 2
+  local log="$FIXTURE_TMP/${label}.log"
+  local actual=0
+  "$@" >"$log" 2>&1 || actual=$?
+  if [[ "$actual" -ne "$expected" ]]; then
+    echo "ERROR: $label returned $actual; expected $expected" >&2
+    sed -n '1,160p' "$log" >&2
+    return 1
+  fi
+}
+
+EMPTY_BASELINE="$FIXTURE_TMP/empty.json"
+INVALID_BASELINE="$FIXTURE_TMP/invalid.json"
+MISSING_BASELINE="$FIXTURE_TMP/missing.json"
+COVERING_BASELINE="$FIXTURE_TMP/covering.json"
+CLEAN_REPORT="$FIXTURE_TMP/clean.json"
+TAINTED_REPORT="$FIXTURE_TMP/tainted.json"
+TAINTED_REPORT_2="$FIXTURE_TMP/tainted-2.json"
+UNIMPORTED_REPORT="$FIXTURE_TMP/unimported.json"
+
+printf '{"sorry": [], "nonstandard": []}\n' >"$EMPTY_BASELINE"
+printf '{not-json}\n' >"$INVALID_BASELINE"
+
+# VCVio's FFI C sources live in git submodules that Lake does not fetch, and every
+# root-package executable links them.
+if [ -e .lake/packages/VCVio/.git ]; then
+  git -C .lake/packages/VCVio submodule update --init --recursive
+fi
+
+lake build AxiomSweepTestFixtures
+lake exe axiomsweep --root AxiomSweepTestFixtures.Clean --out "$CLEAN_REPORT"
+lake exe axiomsweep --root AxiomSweepTestFixtures.Tainted --out "$TAINTED_REPORT"
+lake exe axiomsweep --root AxiomSweepTestFixtures.Tainted --out "$TAINTED_REPORT_2"
+lake exe axiomsweep --root AxiomSweepTestFixtures.Unimported --out "$UNIMPORTED_REPORT"
+
+# The sweep must be deterministic: same build, byte-identical report.
+cmp "$TAINTED_REPORT" "$TAINTED_REPORT_2"
+
+python3 - "$CLEAN_REPORT" "$TAINTED_REPORT" "$UNIMPORTED_REPORT" "$COVERING_BASELINE" <<'PY'
+import json
+import sys
+
+clean_path, tainted_path, unimported_path, covering_path = sys.argv[1:]
+
+with open(clean_path, encoding="utf-8") as stream:
+    clean = json.load(stream)
+with open(tainted_path, encoding="utf-8") as stream:
+    tainted = json.load(stream)
+with open(unimported_path, encoding="utf-8") as stream:
+    unimported = json.load(stream)
+
+clean_entries = {entry["name"]: entry for entry in clean["declarations"]}
+tainted_entries = {entry["name"]: entry for entry in tainted["declarations"]}
+unimported_entries = {entry["name"]: entry for entry in unimported["declarations"]}
+
+assert clean_entries
+assert all(not entry["axioms"] for entry in clean_entries.values())
+
+prefix = "AxiomSweepTestFixtures.Tainted."
+
+# `sorryAx` reached directly, and through an intervening definition.
+assert "sorryAx" in tainted_entries[prefix + "directSorry"]["axioms"]
+assert "sorryAx" in tainted_entries[prefix + "transitiveSorry"]["axioms"]
+
+# An axiom occurring only in a *type* still counts, matching Lean's `CollectAxioms`.
+assert prefix + "typeIndex" in tainted_entries[prefix + "axiomInType"]["axioms"]
+
+# The fixpoint repair pass: `MutualRight` never mentions the axiom itself, and inherits it
+# only across the mutual-inductive cycle. This is the witness for the `repair` phase.
+assert prefix + "mutualAxiom" in tainted_entries[prefix + "MutualRight"]["axioms"]
+
+all_axioms = {axiom for entry in tainted_entries.values() for axiom in entry["axioms"]}
+
+# A well-formed generated suffix collapses to its owning declaration...
+generated = prefix + "Generated._native.native_decide"
+assert generated in all_axioms
+assert generated + ".ax_12_34" not in all_axioms
+
+# ...and nothing else does. Collapsing these would let distinct axioms share one baseline
+# key, so real taint could hide behind an accepted entry.
+assert prefix + "Collision._native.native_decide.ax_12_extra" in all_axioms
+assert prefix + "Collision._native.native_decide.ax_x_34" in all_axioms
+assert prefix + "Collision._native.native_decide.ax_12_34.extra" in all_axioms
+
+# A file no root transitively imports is invisible to any environment-walking census.
+hidden = "AxiomSweepTestFixtures.Unimported.hiddenSorry"
+assert hidden not in tainted_entries
+assert hidden in unimported_entries
+assert "sorryAx" in unimported_entries[hidden]["axioms"]
+
+# A baseline that covers every tainted declaration of the fixture root, used below to
+# check that full coverage is accepted and that native trust is refused even so.
+covering = {
+    "sorry": sorted(n for n, e in tainted_entries.items() if "sorryAx" in e["axioms"]),
+    "nonstandard": [
+        {"name": n, "axioms": sorted(a for a in e["axioms"]
+                                     if a != "sorryAx"
+                                     and a not in ("propext", "Classical.choice", "Quot.sound"))}
+        for n, e in sorted(tainted_entries.items())
+        if any(a != "sorryAx" and a not in ("propext", "Classical.choice", "Quot.sound")
+               for a in e["axioms"])
+    ],
+}
+with open(covering_path, "w", encoding="utf-8") as stream:
+    json.dump(covering, stream)
+PY
+
+# --- gate directions -------------------------------------------------------------------
+
+expect_status 0 clean-check \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Clean \
+    --check --baseline "$EMPTY_BASELINE"
+expect_status 1 uncovered-taint \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Tainted \
+    --check --baseline "$EMPTY_BASELINE"
+
+# Full coverage still fails: the fixtures mint `._native.` axioms outside
+# `grandfatheredNativeTrust`, and no baseline edit may green those.
+expect_status 1 native-trust-floor \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Tainted \
+    --check --baseline "$COVERING_BASELINE"
+grep -q "never-allowlistable" "$FIXTURE_TMP/native-trust-floor.log"
+
+# --- infrastructure failures must never read as a taint verdict ------------------------
+
+expect_status 2 missing-baseline \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Clean \
+    --check --baseline "$MISSING_BASELINE"
+expect_status 2 invalid-baseline \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Clean \
+    --check --baseline "$INVALID_BASELINE"
+expect_status 2 conflicting-flags \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Clean \
+    --check --update-baseline --baseline "$EMPTY_BASELINE"
+expect_status 2 unknown-flag \
+  lake exe axiomsweep --bogus
+expect_status 2 bad-root \
+  lake exe axiomsweep --root NoSuchModule --check --baseline "$EMPTY_BASELINE"
+expect_status 2 unwritable-out \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Clean \
+    --out "$FIXTURE_TMP/no-such-dir/report.json"
+
+# --- baseline writing -------------------------------------------------------------------
+
+# Shrinking is allowed once the debt is gone.
+cp "$COVERING_BASELINE" "$FIXTURE_TMP/shrink.json"
+expect_status 0 shrink-baseline \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Clean \
+    --update-baseline --baseline "$FIXTURE_TMP/shrink.json"
+python3 -c "
+import json,sys
+b=json.load(open(sys.argv[1]))
+assert b['sorry'] == [] and b['nonstandard'] == [], b
+" "$FIXTURE_TMP/shrink.json"
+
+# Pre-authorizing native trust is not, and the file must be left untouched.
+cp "$EMPTY_BASELINE" "$FIXTURE_TMP/growth.json"
+cp "$FIXTURE_TMP/growth.json" "$FIXTURE_TMP/growth-before.json"
+expect_status 1 reject-native-trust-growth \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Tainted \
+    --update-baseline --baseline "$FIXTURE_TMP/growth.json"
+cmp "$FIXTURE_TMP/growth-before.json" "$FIXTURE_TMP/growth.json"
+
+echo "✓ Axiom sweep executable fixture matrix passed."

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -28,7 +28,7 @@ Optional checks:
   --lint    Run ./scripts/lint-style.sh
   --docs    Run DISABLE_EQUATIONS=1 lake build ArkLib:docs
   --site    Run ./scripts/build-web.sh (implies --docs)
-  --axioms  Run lake exe axiomsweep --check (axiom/sorry regression gate)
+  --axioms  Test the axiomsweep tool, then run the axiom/sorry regression gate
 EOF
 }
 
@@ -92,6 +92,9 @@ echo "# Checking knowledge base"
 python3 ./scripts/kb/lint.py
 
 if (( run_axioms )); then
+  echo ""
+  echo "# Testing the axiom sweep tool against its fixture matrix"
+  ./scripts/test-axiomsweep.sh
   echo ""
   echo "# Checking axiom/sorry regression baseline"
   # VCVio's FFI C sources live in git submodules that Lake does not fetch,


### PR DESCRIPTION
## What

Ports the newest shared axiomsweep tooling state (PolyFun #127 → VCV-io #513, head `77edbe29`) to ArkLib, as requested on the VCV-io PR. ArkLib already had the tool and baseline; this brings the tool fixes, the executable fixture matrix, and its test harness:

- **`scripts/AxiomSweep.lean`**: `isNativeTrust` now covers the per-declaration `Owner._native.<tactic>.ax_<n>_<n>` axioms that `native_decide`-style tactics mint on this toolchain (they do **not** route through `Lean.ofReduceBool`, so the previous floor was unreachable); explicit source-level `grandfatheredNativeTrust` list (empty for ArkLib — fail-closed); strict `normalizeAxiomName` suffix parsing (the loose form let two distinct axioms share one baseline key); `--update-baseline` extracted to `runUpdate` and refusing to write while never-allowlistable taint is present; `run`/`main` split with a top-level exception trap so the exit-code contract holds (`1` = taint verdict, anything else = infrastructure failure).
- **`scripts/AxiomSweepTestFixtures/`** (7 files, isolated `lean_lib`, not a default target): synthetic taint of every shape the sweep reasons about — direct/transitive `sorry`, axiom-in-type, mutual-inductive inheritance (the `repair`-phase witness), generated native-trust names plus three near-miss collisions, and an unimported file.
- **`scripts/test-axiomsweep.sh`**: report determinism, per-shape assertions, all gate directions (clean → 0, uncovered taint → 1, native-trust floor → 1 even under a fully-covering baseline), infrastructure cases → 2, baseline shrink allowed / native-trust growth refused with the file left untouched. Uses the allowlist-model matrix (ArkLib carries genuine `sorryAx` debt, like VCV-io; PolyFun's nonempty-baseline-forbidden cases don't apply).
- **Wiring**: `lakefile.toml` fixture lib; `validate.sh --axioms` runs the matrix before the regression gate; CI gains an enforcing "Test the axiom sweep tool" step (the library taint verdict itself stays report-only — flipping it after soak is a separate policy decision); docs synced (`AGENTS.md`, `docs/wiki/quickstart.md`, `scripts/README.md`, `docs/wiki/generated-files.md`).

Credit: the fixture matrix and tool upgrades are @quangvdao's PolyFun work, adapted by @alexanderlhicks for VCV-io in #513; this is the ArkLib leg of that port. CompPoly remains to be done (greenfield there).

## Why

Beyond keeping the three repos' shared tool in sync, two of the ported fixes are gate-soundness issues in ArkLib's current copy: the never-allowlistable floor was dead code for `native_decide`-backed proofs, and the loose axiom-name normalization could hide real taint behind an accepted baseline entry.

## Verification

- `lake build` + `lake build AxiomSweepTestFixtures`: clean (the fixture `sorry` warning is the fixture's purpose)
- `./scripts/test-axiomsweep.sh`: full matrix green
- `lake exe axiomsweep --check`: green with an identical census to before the port (9,658 declarations / 385 modules / 358 baseline `sorryAx` / 0 non-standard, at the current #754 head `99aebe90`)
- `scripts/axiom_baseline.json`: byte-unchanged
- `./scripts/validate.sh --axioms`: full run green (build, warning gate, toy-problem runtime, imports, docs integrity, KB lint, fixture matrix, regression gate)
- fixture files are mode 644, the test script 755 (style gate on executable bits unaffected)

## Base

Stacked on #754 (`alh/abf26-toyproblem`) since the fixtures use the v4.32.2 toolchain landed there; can be re-targeted to `main` once #754 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)