### PR TITLE
feat(coding-theory): generalize the GS counting bound, add the first-moment bound

### DIFF
--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
@@ -97,24 +97,29 @@ def weigthBoundIndices (k D : ℕ) : Finset (ℕ × ℕ) :=
 /-- The number of variables in the Guruswami-Sudan linear system. -/
 def numVars (k D : ℕ) : ℕ := (weigthBoundIndices k D).card
 
+/-- The index set of the Guruswami-Sudan system, with the range of the `Y`-degree already
+truncated to the values that can actually occur. -/
+lemma weigthBoundIndices_eq_filter_product (D : ℕ) (hk : 1 < k) :
+    weigthBoundIndices k D =
+      filter (fun p : ℕ × ℕ ↦ p.1 + (k - 1) * p.2 ≤ D)
+        ((range (D + 1)).product (range (D / (k - 1) + 1))) := by
+  ext ⟨i, j⟩
+  simp only [weigthBoundIndices, product_eq_sprod, mem_filter, mem_product, mem_range,
+    and_congr_left_iff, and_congr_right_iff]
+  exact fun _ _ ↦ iff_of_true (by
+    nlinarith [Nat.sub_pos_of_lt hk, D.div_add_mod (k - 1),
+      D.mod_lt (Nat.sub_pos_of_lt hk)])
+    (Nat.lt_succ_of_le (Nat.le_div_iff_mul_le (Nat.sub_pos_of_lt hk) |>.2
+    (by nlinarith [Nat.sub_pos_of_lt hk])))
+
 /-- The number of variables is the sum over j of the number of valid i's. -/
 lemma card_weigthBoundIndices_eq_sum (D : ℕ) (hk : 1 < k) :
     (weigthBoundIndices k D).card = ∑ j ∈ range (D / (k - 1) + 1), (D - (k - 1) * j + 1) := by
     have h_split : (weigthBoundIndices k D).card =
         ∑ j ∈ range (D / (k - 1) + 1),
           ∑ i ∈ range (D + 1), if i + (k - 1) * j ≤ D then 1 else 0 := by
-      rw [show weigthBoundIndices k D =
-        filter (fun p : ℕ × ℕ ↦ p.1 + (k - 1) * p.2 ≤ D)
-        ((range (D + 1)).product (range (D / (k - 1) + 1))) from ?_, card_filter]
-      · erw [sum_product, Finset.sum_comm]
-      · ext ⟨i, j⟩
-        simp only [weigthBoundIndices, product_eq_sprod, mem_filter, mem_product, mem_range,
-          and_congr_left_iff, and_congr_right_iff]
-        exact fun _ _ ↦ iff_of_true (by
-          nlinarith [Nat.sub_pos_of_lt hk, D.div_add_mod (k - 1),
-            D.mod_lt (Nat.sub_pos_of_lt hk)])
-          (Nat.lt_succ_of_le (Nat.le_div_iff_mul_le (Nat.sub_pos_of_lt hk) |>.2
-          (by nlinarith [Nat.sub_pos_of_lt hk])))
+      rw [weigthBoundIndices_eq_filter_product D hk, card_filter]
+      erw [sum_product, Finset.sum_comm]
     have h_inner : ∀ j ∈ range (D / (k - 1) + 1), ∑ i ∈ range (D + 1),
         (if i + (k - 1) * j ≤ D then 1 else 0) = (D - (k - 1) * j) + 1 := by
       intro j hj
@@ -203,6 +208,99 @@ lemma numVars_lower_bound_tight {D : ℕ} (hk : 1 < k) :
           simp_all [← even_iff_two_dvd, parity_simps]
         by_cases h : Even (D / (k + 1)) <;> simp_all [parity_simps]
 
+/-- The exact first moment of `j ↦ j * (u - c * j)` over `range (J + 1)`, computed over `ℤ` so
+that the subtraction is not truncated. -/
+private lemma sum_range_mul_sub (u c J : ℕ) :
+    6 * (∑ j ∈ range (J + 1), (j : ℤ) * (u - c * j))
+      = 3 * u * J * (J + 1) - c * J * (J + 1) * (2 * J + 1) := by
+  induction J with
+  | zero => simp
+  | succ J ih =>
+      rw [Finset.sum_range_succ]
+      push_cast
+      linear_combination ih
+
+/-- Three-variable AM-GM, in the polynomial form needed for the first-moment bound.
+
+The three hints are the Schur-shaped products `a * (b - c) ^ 2` and its cyclic images, which
+already span the certificate. -/
+private lemma mul_mul_le_cube {a b c : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) :
+    27 * (a * b * c) ≤ (a + b + c) ^ 3 := by
+  nlinarith [mul_nonneg ha (sq_nonneg (b - c)), mul_nonneg hb (sq_nonneg (a - c)),
+    mul_nonneg hc (sq_nonneg (a - b))]
+
+/-- Summing the `Y`-degree over the index set, one `Y`-degree at a time. -/
+lemma sum_snd_weigthBoundIndices_eq (D : ℕ) (hk : 1 < k) :
+    (∑ p ∈ weigthBoundIndices k D, p.2)
+      = ∑ j ∈ range (D / (k - 1) + 1), j * (D - (k - 1) * j + 1) := by
+  rw [weigthBoundIndices_eq_filter_product D hk, Finset.sum_filter, product_eq_sprod,
+    Finset.sum_product, Finset.sum_comm]
+  refine Finset.sum_congr rfl fun j hj ↦ ?_
+  have hcj : (k - 1) * j ≤ D := by
+    have hj' : j ≤ D / (k - 1) := Nat.lt_succ_iff.mp (Finset.mem_range.mp hj)
+    calc (k - 1) * j ≤ (k - 1) * (D / (k - 1)) := by gcongr
+      _ ≤ D := Nat.mul_div_le D (k - 1)
+  have hfilter : filter (fun i ↦ i + (k - 1) * j ≤ D) (range (D + 1))
+      = range (D - (k - 1) * j + 1) := by
+    ext i
+    simp only [mem_filter, mem_range]
+    omega
+  rw [← Finset.sum_filter, hfilter, Finset.sum_const, card_range, smul_eq_mul, mul_comm]
+
+/-- The first-moment bound of [BCIKS20], Appendix B.1: the sum of the `Y`-degrees over the
+Guruswami-Sudan index set `{(i, j) : i + (k-1) * j ≤ D}` is at most `(D + 1) ^ 3 / (6 * (k-1) ^ 2)`.
+
+The paper calls this quantity `D_C`; it is what controls the total `Y, Z`-degree of the
+interpolation polynomial in the curve regime. The bound is essentially tight: for `k = 2` and
+`D = 4` the two sides are `120` and `125`. -/
+lemma sum_snd_weigthBoundIndices_le (D : ℕ) (hk : 1 < k) :
+    6 * (k - 1) ^ 2 * (∑ p ∈ weigthBoundIndices k D, p.2) ≤ (D + 1) ^ 3 := by
+  obtain ⟨κ, rfl⟩ : ∃ κ, k = κ + 1 := ⟨k - 1, by omega⟩
+  have hκ0 : 0 < κ := by omega
+  rw [sum_snd_weigthBoundIndices_eq D hk]
+  simp only [Nat.add_sub_cancel]
+  set J := D / κ with hJdef
+  set S := ∑ j ∈ range (J + 1), j * (D - κ * j + 1) with hSdef
+  have hcj : ∀ j ∈ range (J + 1), κ * j ≤ D := by
+    intro j hj
+    have hj' : j ≤ D / κ := Nat.lt_succ_iff.mp (Finset.mem_range.mp hj)
+    calc κ * j ≤ κ * (D / κ) := by gcongr
+      _ ≤ D := Nat.mul_div_le D κ
+  have hcast : (S : ℤ) = ∑ j ∈ range (J + 1), (j : ℤ) * ((D : ℤ) + 1 - κ * j) := by
+    rw [hSdef]
+    push_cast
+    refine Finset.sum_congr rfl fun j hj ↦ ?_
+    rw [Nat.cast_sub (hcj j hj)]
+    push_cast
+    ring
+  have hexact : 6 * (S : ℤ)
+      = 3 * ((D : ℤ) + 1) * J * (J + 1) - κ * J * (J + 1) * (2 * J + 1) := by
+    rw [hcast]
+    exact_mod_cast sum_range_mul_sub (D + 1) κ J
+  rcases Nat.eq_zero_or_pos J with hJ0 | hJ1
+  · have hS0 : (S : ℤ) = 0 := by rw [hJ0] at hexact; push_cast at hexact; linarith
+    have : S = 0 := by exact_mod_cast hS0
+    simp [this]
+  · have hτD : κ * J ≤ D := by
+      calc κ * J ≤ κ * (D / κ) := by gcongr
+        _ ≤ D := Nat.mul_div_le D κ
+    have hτ0 : (0 : ℤ) ≤ (κ : ℤ) * J := by positivity
+    have hτu : (κ : ℤ) * J ≤ (D : ℤ) := by exact_mod_cast hτD
+    have hκτ : (κ : ℤ) ≤ (κ : ℤ) * J := by
+      exact_mod_cast Nat.le_mul_of_pos_right κ hJ1
+    have hc0 : (0 : ℤ) ≤ 3 * ((D : ℤ) + 1) - 2 * ((κ : ℤ) * J) - κ := by linarith
+    have hkey : 6 * (κ : ℤ) ^ 2 * S
+        = ((κ : ℤ) * J) * ((κ : ℤ) * J + κ)
+          * (3 * ((D : ℤ) + 1) - 2 * ((κ : ℤ) * J) - κ) := by
+      linear_combination (κ : ℤ) ^ 2 * hexact
+    have hamgm := mul_mul_le_cube hτ0 (by linarith : (0 : ℤ) ≤ (κ : ℤ) * J + κ) hc0
+    have hsum : (κ : ℤ) * J + ((κ : ℤ) * J + κ)
+        + (3 * ((D : ℤ) + 1) - 2 * ((κ : ℤ) * J) - κ) = 3 * ((D : ℤ) + 1) := by ring
+    rw [hsum] at hamgm
+    have hfinal : 6 * (κ : ℤ) ^ 2 * S ≤ ((D : ℤ) + 1) ^ 3 := by
+      rw [hkey]; nlinarith [hamgm]
+    exact_mod_cast hfinal
+
 end numVars
 
 section numConstraints
@@ -256,32 +354,44 @@ lemma proximity_gap_degree_bound_sq_gt (hn : n ≠ 0) :
       nlinarith [show 0 < (m + 1 / 2 : ℝ) * √((k + 1) * n) by
         positivity, Real.mul_self_sqrt (show 0 ≤ (k + 1 : ℝ) * n by positivity)]
 
+/-- The Guruswami-Sudan counting bound, stated for an arbitrary degree bound `D`: the system is
+underdetermined as soon as `D * (D + 2) > (k - 1) * n * m * (m + 1)`.
+
+This is the shared core of the counting arguments; a concrete degree bound only has to supply the
+displayed inequality, which for the usual choices follows from a lower bound on `(D + 1) ^ 2`. -/
+lemma numVars_gt_numConstraints_of_mul_lt {D : ℕ} (hk : 1 < k)
+    (h : ((k : ℝ) - 1) * n * m * (m + 1) < (D : ℝ) * (D + 2)) :
+    numVars k D > numConstraints n m := by
+  have h_ineq : 2 * (k - 1) * numVars k D > (k - 1) * n * m * (m + 1) := by
+    have h_lb : 2 * ((k : ℝ) - 1) * numVars k D ≥ (D : ℝ) * (D + 2) := by
+      convert numVars_lower_bound_tight hk using 1
+      · norm_cast
+        rw [Int.subNatNat_of_le] <;> norm_cast
+        linarith
+    have h_chain : ((k : ℝ) - 1) * n * m * (m + 1) < 2 * ((k : ℝ) - 1) * numVars k D :=
+      lt_of_lt_of_le h h_lb
+    norm_cast at h_chain
+    rw [Int.subNatNat_of_le hk.le] at h_chain
+    exact_mod_cast h_chain
+  have h_div : numVars k D > n * m * (m + 1) / 2 :=
+    Nat.div_lt_of_lt_mul <| by nlinarith [Nat.sub_pos_of_lt hk]
+  convert h_div using 1
+  convert congr_arg (fun x : ℕ ↦ n * x) (card_constraintIndices m) using 1
+  · rfl
+  · rw [← Nat.mul_div_assoc] <;> ring_nf
+    exact even_iff_two_dvd.mp (by simp [parity_simps])
+
 lemma numVars_gt_numConstraints_of_gt_one (hn : n ≠ 0) (hk : 1 < k) (hm : 1 ≤ m) :
     numVars k (proximity_gap_degree_bound k n m) > numConstraints n m := by
       set D := proximity_gap_degree_bound k n m
       have hD : ((D + 1)^2 : ℝ) > ((m : ℝ) + 1 / 2)^2 * (k + 1) * n := by
         convert proximity_gap_degree_bound_sq_gt hn using 1
-      have h_ineq : 2 * (k - 1) * numVars k D > (k - 1) * n * m * (m + 1) := by
-        have h_ineq : 2 * (k - 1) * numVars k D ≥ (D : ℝ) * (D + 2) := by
-          convert numVars_lower_bound_tight hk using 1
-          · norm_cast
-            rw [Int.subNatNat_of_le] <;> norm_cast
-            linarith
-        have h_ineq : (D : ℝ) * (D + 2) > (k - 1) * n * m * (m + 1) := by
-          nlinarith [show (k : ℝ) ≥ 2 by norm_cast, show (m : ℝ) ≥ 1 by
-            exact Nat.one_le_cast.mpr hm, show (n : ℝ) ≥ 1 by
-              exact Nat.one_le_cast.mpr (Nat.pos_of_ne_zero hn), mul_le_mul_of_nonneg_left
-                (show (m : ℝ) ≥ 1 by exact Nat.one_le_cast.mpr hm)
-                  (show (n : ℝ) ≥ 0 by positivity)]
-        norm_cast at *
-        rw [Int.subNatNat_of_le] at * <;> (norm_cast at *; linarith)
-      have h_div : numVars k D > n * m * (m + 1) / 2 := by
-        exact Nat.div_lt_of_lt_mul <| by nlinarith [Nat.sub_pos_of_lt hk]
-      convert h_div using 1
-      convert congr_arg (fun x : ℕ ↦ n * x) (card_constraintIndices m) using 1
-      · rfl
-      · rw [← Nat.mul_div_assoc] <;> ring_nf
-        exact even_iff_two_dvd.mp (by simp [parity_simps])
+      refine numVars_gt_numConstraints_of_mul_lt hk ?_
+      nlinarith [show (k : ℝ) ≥ 2 by norm_cast, show (m : ℝ) ≥ 1 by
+        exact Nat.one_le_cast.mpr hm, show (n : ℝ) ≥ 1 by
+          exact Nat.one_le_cast.mpr (Nat.pos_of_ne_zero hn), mul_le_mul_of_nonneg_left
+            (show (m : ℝ) ≥ 1 by exact Nat.one_le_cast.mpr hm)
+              (show (n : ℝ) ≥ 0 by positivity)]
 
 lemma numVars_gt_numConstraints (k n m : ℕ) :
     numVars k (proximity_gap_degree_bound k n m) > numConstraints n m := by
@@ -981,27 +1091,12 @@ lemma gs_numVars_gt_numConstraints_of_gt_one (hn : n ≠ 0) (hk : 1 < k) (hm : 1
   set D := gs_degree_bound k n m
   have hD : ((D + 1)^2 : ℝ) > ((m : ℝ) + 1 / 2)^2 * k * n := by
     convert gs_degree_bound_sq_gt hn (by omega : 0 < k) using 1
-  have h_ineq : 2 * (k - 1) * numVars k D > (k - 1) * n * m * (m + 1) := by
-    have h_ineq : 2 * (k - 1) * numVars k D ≥ (D : ℝ) * (D + 2) := by
-      convert numVars_lower_bound_tight hk using 1
-      · norm_cast
-        rw [Int.subNatNat_of_le] <;> norm_cast
-        linarith
-    have h_ineq : (D : ℝ) * (D + 2) > (k - 1) * n * m * (m + 1) := by
-      nlinarith [show (k : ℝ) ≥ 2 by norm_cast, show (m : ℝ) ≥ 1 by
-        exact Nat.one_le_cast.mpr hm, show (n : ℝ) ≥ 1 by
-          exact Nat.one_le_cast.mpr (Nat.pos_of_ne_zero hn), mul_le_mul_of_nonneg_left
-            (show (m : ℝ) ≥ 1 by exact Nat.one_le_cast.mpr hm)
-              (show (n : ℝ) ≥ 0 by positivity)]
-    norm_cast at *
-    rw [Int.subNatNat_of_le] at * <;> (norm_cast at *; linarith)
-  have h_div : numVars k D > n * m * (m + 1) / 2 := by
-    exact Nat.div_lt_of_lt_mul <| by nlinarith [Nat.sub_pos_of_lt hk]
-  convert h_div using 1
-  convert congr_arg (fun x : ℕ ↦ n * x) (card_constraintIndices m) using 1
-  · rfl
-  · rw [← Nat.mul_div_assoc] <;> ring_nf
-    exact even_iff_two_dvd.mp (by simp [parity_simps])
+  refine numVars_gt_numConstraints_of_mul_lt hk ?_
+  nlinarith [show (k : ℝ) ≥ 2 by norm_cast, show (m : ℝ) ≥ 1 by
+    exact Nat.one_le_cast.mpr hm, show (n : ℝ) ≥ 1 by
+      exact Nat.one_le_cast.mpr (Nat.pos_of_ne_zero hn), mul_le_mul_of_nonneg_left
+        (show (m : ℝ) ≥ 1 by exact Nat.one_le_cast.mpr hm)
+          (show (n : ℝ) ≥ 0 by positivity)]
 
 /-- The degree bound with ρ = k/n is strictly less than m times the number of
     agreement points, provided the distance is within the rate-corrected Johnson

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
@@ -13,7 +13,29 @@ import ArkLib.Data.CodingTheory.Basic.LinearCode
 import ArkLib.Data.CodingTheory.Basic.RelativeDistance
 import ArkLib.Data.CodingTheory.ReedSolomon
 import ArkLib.Data.Polynomial.Bivariate
-/-! # Guruswami-Sudan Basics -/
+/-! # Guruswami-Sudan Basics
+
+Degree bounds and variable/constraint counting for the Guruswami-Sudan interpolation system, in
+the parametrization used by the affine-line proximity-gap argument: the system asks for a nonzero
+bivariate polynomial with a `(1, k-1)`-weighted degree bound that vanishes with multiplicity `m`
+at `n` prescribed points, and it is solvable as soon as it has more variables than constraints.
+
+## Main definitions and results
+
+- `proximity_gap_degree_bound`, `gs_degree_bound` — the `D_X`-style weighted-degree bounds, with
+  reduced rate `(k+1)/n` and `k/n` respectively.
+- `weightBoundIndices`, `numVars`, `numConstraints` — the monomial index set of the system and
+  the two counts.
+- `numVars_gt_numConstraints_of_mul_lt` — the shared counting core: the system is
+  underdetermined as soon as `D * (D + 2) > (k - 1) * n * m * (m + 1)`.
+- `sum_snd_weightBoundIndices_le` — the first-moment bound `6 (k-1)² · Σ j ≤ (D + 1)³` on the
+  total `Y`-degree of the index set.
+
+## References
+
+- [BCIKS20] Ben-Sasson, Carmon, Ishai, Kopparty, Saraf, *Proximity Gaps for Reed–Solomon Codes*
+  (ePrint 2020/654): Lemma 5.3 for the degree bounds, Appendix B.1 for the first-moment bound.
+-/
 
 
 open Polynomial Polynomial.Bivariate Finsupp Finset
@@ -91,20 +113,20 @@ section numVars
 
 /-- Given a nonnegative integer `D`, it is the set of indices `(i,j)` such
     that `i + (k - 1) * j ≤ D`. -/
-def weigthBoundIndices (k D : ℕ) : Finset (ℕ × ℕ) :=
+def weightBoundIndices (k D : ℕ) : Finset (ℕ × ℕ) :=
   (range (D + 1)).product (range (D + 1)) |>.filter (fun x ↦ x.1 + (k - 1) * x.2 ≤ D)
 
 /-- The number of variables in the Guruswami-Sudan linear system. -/
-def numVars (k D : ℕ) : ℕ := (weigthBoundIndices k D).card
+def numVars (k D : ℕ) : ℕ := (weightBoundIndices k D).card
 
 /-- The index set of the Guruswami-Sudan system, with the range of the `Y`-degree already
 truncated to the values that can actually occur. -/
-lemma weigthBoundIndices_eq_filter_product (D : ℕ) (hk : 1 < k) :
-    weigthBoundIndices k D =
+lemma weightBoundIndices_eq_filter_product (D : ℕ) (hk : 1 < k) :
+    weightBoundIndices k D =
       filter (fun p : ℕ × ℕ ↦ p.1 + (k - 1) * p.2 ≤ D)
         ((range (D + 1)).product (range (D / (k - 1) + 1))) := by
   ext ⟨i, j⟩
-  simp only [weigthBoundIndices, product_eq_sprod, mem_filter, mem_product, mem_range,
+  simp only [weightBoundIndices, product_eq_sprod, mem_filter, mem_product, mem_range,
     and_congr_left_iff, and_congr_right_iff]
   exact fun _ _ ↦ iff_of_true (by
     nlinarith [Nat.sub_pos_of_lt hk, D.div_add_mod (k - 1),
@@ -113,12 +135,12 @@ lemma weigthBoundIndices_eq_filter_product (D : ℕ) (hk : 1 < k) :
     (by nlinarith [Nat.sub_pos_of_lt hk])))
 
 /-- The number of variables is the sum over j of the number of valid i's. -/
-lemma card_weigthBoundIndices_eq_sum (D : ℕ) (hk : 1 < k) :
-    (weigthBoundIndices k D).card = ∑ j ∈ range (D / (k - 1) + 1), (D - (k - 1) * j + 1) := by
-    have h_split : (weigthBoundIndices k D).card =
+lemma card_weightBoundIndices_eq_sum (D : ℕ) (hk : 1 < k) :
+    (weightBoundIndices k D).card = ∑ j ∈ range (D / (k - 1) + 1), (D - (k - 1) * j + 1) := by
+    have h_split : (weightBoundIndices k D).card =
         ∑ j ∈ range (D / (k - 1) + 1),
           ∑ i ∈ range (D + 1), if i + (k - 1) * j ≤ D then 1 else 0 := by
-      rw [weigthBoundIndices_eq_filter_product D hk, card_filter]
+      rw [weightBoundIndices_eq_filter_product D hk, card_filter]
       erw [sum_product, Finset.sum_comm]
     have h_inner : ∀ j ∈ range (D / (k - 1) + 1), ∑ i ∈ range (D + 1),
         (if i + (k - 1) * j ≤ D then 1 else 0) = (D - (k - 1) * j) + 1 := by
@@ -140,7 +162,7 @@ lemma card_weigthBoundIndices_eq_sum (D : ℕ) (hk : 1 < k) :
 /-- Closed form for the number of variables when k > 1. -/
 lemma numVars_eq_of_gt_one {D : ℕ} (hk : 1 < k) :
     numVars k D = let L := D / (k - 1); (L + 1) * (2 * D + 2 - (k - 1) * L) / 2 := by
-      convert card_weigthBoundIndices_eq_sum D hk using 1
+      convert card_weightBoundIndices_eq_sum D hk using 1
       · rfl
       next =>
       have h_simp : ∑ j ∈ range (D / (k - 1) + 1), (D - (k - 1) * j) =
@@ -181,7 +203,7 @@ lemma numVars_eq_of_gt_one {D : ℕ} (hk : 1 < k) :
 lemma numVars_eq_sq {k D : ℕ} (hk : k ≤ 1) : numVars k D = (D + 1) ^ 2 := by
   interval_cases k
   all_goals
-  simp only [numVars, weigthBoundIndices, tsub_self, zero_mul, add_zero, product_eq_sprod]
+  simp only [numVars, weightBoundIndices, tsub_self, zero_mul, add_zero, product_eq_sprod]
   norm_num
   rw [filter_true_of_mem fun x hx ↦ by linarith [mem_range.mp (mem_product.mp hx |>.1)]]
   norm_num [sq, card_product]
@@ -230,10 +252,10 @@ private lemma mul_mul_le_cube {a b c : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 
     mul_nonneg hc (sq_nonneg (a - b))]
 
 /-- Summing the `Y`-degree over the index set, one `Y`-degree at a time. -/
-lemma sum_snd_weigthBoundIndices_eq (D : ℕ) (hk : 1 < k) :
-    (∑ p ∈ weigthBoundIndices k D, p.2)
+lemma sum_snd_weightBoundIndices_eq (D : ℕ) (hk : 1 < k) :
+    (∑ p ∈ weightBoundIndices k D, p.2)
       = ∑ j ∈ range (D / (k - 1) + 1), j * (D - (k - 1) * j + 1) := by
-  rw [weigthBoundIndices_eq_filter_product D hk, Finset.sum_filter, product_eq_sprod,
+  rw [weightBoundIndices_eq_filter_product D hk, Finset.sum_filter, product_eq_sprod,
     Finset.sum_product, Finset.sum_comm]
   refine Finset.sum_congr rfl fun j hj ↦ ?_
   have hcj : (k - 1) * j ≤ D := by
@@ -247,17 +269,18 @@ lemma sum_snd_weigthBoundIndices_eq (D : ℕ) (hk : 1 < k) :
     omega
   rw [← Finset.sum_filter, hfilter, Finset.sum_const, card_range, smul_eq_mul, mul_comm]
 
-/-- The first-moment bound of [BCIKS20], Appendix B.1: the sum of the `Y`-degrees over the
-Guruswami-Sudan index set `{(i, j) : i + (k-1) * j ≤ D}` is at most `(D + 1) ^ 3 / (6 * (k-1) ^ 2)`.
+/-- The first-moment bound: the sum of the `Y`-degrees over the Guruswami-Sudan index set
+`{(i, j) : i + (k-1) * j ≤ D}` is at most `(D + 1) ^ 3 / (6 * (k-1) ^ 2)`, stated
+denominator-free.
 
-The paper calls this quantity `D_C`; it is what controls the total `Y, Z`-degree of the
-interpolation polynomial in the curve regime. The bound is essentially tight: for `k = 2` and
-`D = 4` the two sides are `120` and `125`. -/
-lemma sum_snd_weigthBoundIndices_le (D : ℕ) (hk : 1 < k) :
-    6 * (k - 1) ^ 2 * (∑ p ∈ weigthBoundIndices k D, p.2) ≤ (D + 1) ^ 3 := by
+This sum (called `D_C` in [BCIKS20]) controls the total `Y, Z`-degree of the interpolation
+polynomial in the curve regime. The bound is essentially tight: for `k = 2` and `D = 4` the two
+sides are `120` and `125`. -/
+lemma sum_snd_weightBoundIndices_le (D : ℕ) (hk : 1 < k) :
+    6 * (k - 1) ^ 2 * (∑ p ∈ weightBoundIndices k D, p.2) ≤ (D + 1) ^ 3 := by
   obtain ⟨κ, rfl⟩ : ∃ κ, k = κ + 1 := ⟨k - 1, by omega⟩
   have hκ0 : 0 < κ := by omega
-  rw [sum_snd_weigthBoundIndices_eq D hk]
+  rw [sum_snd_weightBoundIndices_eq D hk]
   simp only [Nat.add_sub_cancel]
   set J := D / κ with hJdef
   set S := ∑ j ∈ range (J + 1), j * (D - κ * j + 1) with hSdef
@@ -459,9 +482,9 @@ end numVars_gt_numConstraints
 section solution
 
 /-- The linear map from the space of coefficients to polynomials. -/
-noncomputable def coeffsToPoly (k D : ℕ) : ((weigthBoundIndices k D) → F) →ₗ[F] F[X][Y] :=
-  linearCombination F (fun p : weigthBoundIndices k D ↦ monomial p.1.1 p.1.2) ∘ₗ
-    (linearEquivFunOnFinite F F (weigthBoundIndices k D)).symm.toLinearMap
+noncomputable def coeffsToPoly (k D : ℕ) : ((weightBoundIndices k D) → F) →ₗ[F] F[X][Y] :=
+  linearCombination F (fun p : weightBoundIndices k D ↦ monomial p.1.1 p.1.2) ∘ₗ
+    (linearEquivFunOnFinite F F (weightBoundIndices k D)).symm.toLinearMap
 
 /-- The linear map evaluating the (s,t)-th derivative coefficient at (x,y). -/
 noncomputable def evalConstraint (x y : F) (s t : ℕ) : F[X][Y] →ₗ[F] F where
@@ -471,16 +494,16 @@ noncomputable def evalConstraint (x y : F) (s t : ℕ) : F[X][Y] →ₗ[F] F whe
 
 /-- The linear map representing the system of linear equations. -/
 noncomputable def constraintMap (k n m : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F) (D : ℕ) :
-  ((weigthBoundIndices k D) → F) →ₗ[F] (Fin n → constraintIndices m → F) where
+  ((weightBoundIndices k D) → F) →ₗ[F] (Fin n → constraintIndices m → F) where
   toFun c i st := evalConstraint (ωs i) (f i) st.1.1 st.1.2 (coeffsToPoly k D c)
   map_add' c d := by simp +zetaDelta at *; rfl
   map_smul' a c := by unfold evalConstraint coeffsToPoly; aesop
 
 /-- There exists a non-zero polynomial satisfying the conditions. -/
 lemma exists_nonzero_solution (k n m : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F) :
-    ∃ c : (weigthBoundIndices k (proximity_gap_degree_bound k n m)) → F,
+    ∃ c : (weightBoundIndices k (proximity_gap_degree_bound k n m)) → F,
     c ≠ 0 ∧ constraintMap k n m ωs f (proximity_gap_degree_bound k n m) c = 0 := by
-      have h_kernel_nontrivial : Module.finrank F ((weigthBoundIndices k
+      have h_kernel_nontrivial : Module.finrank F ((weightBoundIndices k
         (proximity_gap_degree_bound k n m)) → F) >
           Module.finrank F ((Fin n → constraintIndices m → F)) := by
         convert numVars_gt_numConstraints k n m using 1
@@ -500,9 +523,9 @@ lemma exists_nonzero_solution (k n m : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F
     given numVars k D > numConstraints n m. -/
 lemma exists_nonzero_solution_gen (k n m : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F) (D : ℕ)
     (hD : numVars k D > numConstraints n m) :
-    ∃ c : (weigthBoundIndices k D) → F,
+    ∃ c : (weightBoundIndices k D) → F,
     c ≠ 0 ∧ constraintMap k n m ωs f D c = 0 := by
-      have h_kernel_nontrivial : Module.finrank F ((weigthBoundIndices k D) → F) >
+      have h_kernel_nontrivial : Module.finrank F ((weightBoundIndices k D) → F) >
           Module.finrank F ((Fin n → constraintIndices m → F)) := by
         convert hD using 1
         · simp [numVars]
@@ -561,7 +584,7 @@ lemma polySol_ne_zero :
     have h_inj : Function.Injective (coeffsToPoly (F := F) k
     (proximity_gap_degree_bound k n m)) := by
       have : Function.Injective (linearCombination F
-        (fun p : weigthBoundIndices k (proximity_gap_degree_bound k n m) ↦
+        (fun p : weightBoundIndices k (proximity_gap_degree_bound k n m) ↦
           monomial (F := F) p.1.1 p.1.2)) :=
         linearIndependent_monomials.comp _ (fun p q h ↦ by aesop)
       exact this.comp (LinearEquiv.injective _)
@@ -633,22 +656,22 @@ lemma natWeightedDegree_smul_le {F : Type} [Semiring F] (a : F) (p : F[X][Y]) (u
         (show b ∈ p.support from by aesop))
 
 /-- The weighted degree of the polynomial constructed from coefficients is bounded by D. -/
-lemma natWeightedDegree_coeffsToPoly_le (k D : ℕ) (c : (weigthBoundIndices k D) → F) :
+lemma natWeightedDegree_coeffsToPoly_le (k D : ℕ) (c : (weightBoundIndices k D) → F) :
     natWeightedDegree (coeffsToPoly k D c) 1 (k - 1) ≤ D := by
   have h_comb : ∃ (s : Finset (ℕ × ℕ)) (f : ℕ × ℕ → F), (coeffsToPoly k D c) =
       ∑ p ∈ s, f p • (monomial (F := F) p.1 p.2) ∧ ∀ p ∈ s, p.1 + (k - 1) * p.2 ≤ D := by
     norm_num +zetaDelta at *
     refine ⟨univ.image
-      (fun p : { x // x ∈ weigthBoundIndices k D } ↦ (p.val.1, p.val.2)) , ?_, ?_ ⟩;
+      (fun p : { x // x ∈ weightBoundIndices k D } ↦ (p.val.1, p.val.2)) , ?_, ?_ ⟩;
     · use fun p ↦ if h : p ∈ univ.image
-          (fun p : { x // x ∈ weigthBoundIndices k D } ↦ (p.val.1, p.val.2))
+          (fun p : { x // x ∈ weightBoundIndices k D } ↦ (p.val.1, p.val.2))
         then c ⟨p, by aesop⟩ else 0
       unfold coeffsToPoly
       simp only [LinearMap.coe_comp, LinearEquiv.coe_coe, Function.comp_apply,
         linearCombination_apply, zero_smul, implies_true, sum_fintype, univ_eq_attach, Prod.mk.eta,
         attach_image_val, dite_smul]
       refine sum_bij (fun x hx ↦ x) ?_ ?_ ?_ ?_ <;> aesop
-    · unfold weigthBoundIndices at *; aesop
+    · unfold weightBoundIndices at *; aesop
   obtain ⟨s, f, h₁, h₂⟩ := h_comb
   rw [h₁]
   refine le_trans (natWeightedDegree_sum_le s _ _ _) ?_

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/GuruswamiSudan.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/GuruswamiSudan.lean
@@ -1001,7 +1001,7 @@ theorem gs_existence (k n : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F)
   · -- ne_zero
     have h_inj : Function.Injective (coeffsToPoly (F := F) k D) := by
       have : Function.Injective (linearCombination F
-        (fun p : weigthBoundIndices k D ↦ monomial (F := F) p.1.1 p.1.2)) :=
+        (fun p : weightBoundIndices k D ↦ monomial (F := F) p.1.1 p.1.2)) :=
         linearIndependent_monomials.comp _ (fun p q h ↦ by aesop)
       exact this.comp (LinearEquiv.injective _)
     exact fun h ↦ hc_ne <| h_inj <| by simpa using h
@@ -1021,7 +1021,7 @@ theorem gs_existence (k n : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F)
     apply rootMultiplicity_ge_of_shift_zero
     · have h_inj : Function.Injective (coeffsToPoly (F := F) k D) := by
         have : Function.Injective (linearCombination F
-          (fun p : weigthBoundIndices k D ↦ monomial (F := F) p.1.1 p.1.2)) :=
+          (fun p : weightBoundIndices k D ↦ monomial (F := F) p.1.1 p.1.2)) :=
           linearIndependent_monomials.comp _ (fun p q h ↦ by aesop)
         exact this.comp (LinearEquiv.injective _)
       exact fun h ↦ hc_ne <| h_inj <| by simpa using h


### PR DESCRIPTION
Two additions to the Guruswami-Sudan counting layer plus the deduplication they enable. No existing
statement changes; no `sorry` added or removed (0 before, 0 after).
Ground truth: [BCIKS20], ePrint 2020/654 v20210703, Appendix B.

## 1. The counting bound, for an arbitrary `D`

`numVars_gt_numConstraints_of_gt_one` and `gs_numVars_gt_numConstraints_of_gt_one` carried the same
proof twice: each establishes `(D + 1) ^ 2 > (m + 1/2) ^ 2 * _ * n` for its own degree bound, then
runs an identical chain through `numVars_lower_bound_tight` and `card_constraintIndices`. Only the
first step differs.

```lean
lemma numVars_gt_numConstraints_of_mul_lt {D : ℕ} (hk : 1 < k)
    (h : ((k : ℝ) - 1) * n * m * (m + 1) < (D : ℝ) * (D + 2)) :
    numVars k D > numConstraints n m
```

Both now derive from it, keeping only their own `nlinarith` — 27 lines to 12 each. Statements are
untouched, so no call site changes.

## 2. The first-moment bound (Appendix B.1)

```lean
lemma sum_snd_weigthBoundIndices_le (D : ℕ) (hk : 1 < k) :
    6 * (k - 1) ^ 2 * (∑ p ∈ weigthBoundIndices k D, p.2) ≤ (D + 1) ^ 3
```

The sum of the `Y`-degrees over `{(i, j) : i + (k-1) * j ≤ D}` — the paper's `D_C`, which bounds the
total `Y, Z`-degree of the interpolation polynomial in §5. The proof follows the paper rather than
estimating the sum: with `κ = k - 1`, `τ = κ * ⌊D / κ⌋`, `u = D + 1`,

```
6 * κ^2 * ∑ = τ * (τ + κ) * (3u - 2τ - κ)
```

three non-negative factors summing to `3u`, so AM-GM gives `≤ u ^ 3`. The `⌊D / κ⌋ = 0` case is
split off, since that is where the third factor could otherwise go negative.

Supporting, extracted rather than invented: `weigthBoundIndices_eq_filter_product` (was inline in
`card_weigthBoundIndices_eq_sum`, which now reuses it), `sum_snd_weigthBoundIndices_eq`, and two
`private` helpers — the exact moment identity over `ℤ`, and three-variable AM-GM.

## Verification

`./scripts/validate.sh` passed: 4300 jobs, `No ArkLib/Data non-sorry warnings found`. `lake env lean`
on the file: 0 errors, 0 warnings; downstream (`GuruswamiSudan.GuruswamiSudan`,
`BCIKS20.ListDecoding.Guruswami`, `BCIKS20.AffineSpaces`) green at 3448 jobs. `lintWhitespace.sh`,
`check-imports.sh` and `check-docs-integrity.py` all exit 0. `#print axioms` on all six new
declarations gives `[propext, Classical.choice, Quot.sound]`; `axiom_baseline.json` is keyed on
`sorry` / `nonstandard` entries and this adds neither. `lint-style.sh` (not in CI, cf. #561) reports
zero hits in this file.

I `#eval`-checked the statement before trusting the proof: `k = 2, D = 4` gives `120` against `125`,
and `k = 3, D = 7` gives `480` against `512` — tight rather than vacuously loose, which an
over-generous bound would typecheck just as happily. No trustworthy local timing: per-file numbers
here swing by ~±40s with import/cache variance (a control file with the same import and no
declarations timed *slower* than the real ones), so I defer to CI's timing report.

## Context

Infrastructure for the Claim 5.4 existence proof in `BCIKS20/ListDecoding/Guruswami.lean` (#718),
where this bound is what keeps the interpolation polynomial's `Y, Z`-degree inside `D_YZ`. It is
independent of that work, though — nothing here mentions the trivariate setting. It also stays clear
of #733 and #754: the former does not touch this file, and the latter's only edit to it is in
`degree_eval_le_weightedDegree`, well away from the counting section.
