### PR TITLE
feat(BCIKS20): prove Claim 5.4 in the high-rate regime

### DIFF
--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Guruswami.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Guruswami.lean
@@ -83,6 +83,145 @@ structure ModifiedGuruswami
   Q_D_YZ :
     D_YZ Q ≤ n * (m + 1/(2 : ℚ))^3 / (6 * Real.sqrt ((k + 1) / n))
 
+/-- The univariate polynomial `∏ i, (X - ωs i) ^ m`, which vanishes to order `m` at each of the
+`n` interpolation points. -/
+noncomputable def vanishingBase (ωs : Fin n ↪ F) (m : ℕ) : Polynomial F :=
+  ∏ i, (Polynomial.X - Polynomial.C (ωs i)) ^ m
+
+/-- The Guruswami-Sudan witness in the high-rate regime: `∏ i, (X - ωs i) ^ m`, viewed as a
+trivariate polynomial that is constant in both `Y` and `Z`. Since it does not involve `Y`, it
+vanishes to order `m` along the whole curve `(ωs i, u₀ i + Z * u₁ i)`, at the price of an
+`X`-degree of `n * m`. -/
+noncomputable def vanishingWitness (ωs : Fin n ↪ F) (m : ℕ) : F[Z][X][Y] :=
+  Polynomial.C ((vanishingBase ωs m).map (Polynomial.C : F →+* Polynomial F))
+
+omit [DecidableEq F] [DecidableEq (RatFunc F)] in
+/-- `vanishingBase` is monic, being a product of monic polynomials. -/
+lemma vanishingBase_monic (ωs : Fin n ↪ F) (m : ℕ) : (vanishingBase ωs m).Monic :=
+  Polynomial.monic_prod_of_monic _ _ fun i _ ↦ (Polynomial.monic_X_sub_C (ωs i)).pow m
+
+omit [DecidableEq F] [DecidableEq (RatFunc F)] in
+/-- `vanishingBase` has degree `n * m`. -/
+lemma natDegree_vanishingBase (ωs : Fin n ↪ F) (m : ℕ) :
+    (vanishingBase ωs m).natDegree = n * m := by
+  rw [vanishingBase,
+    Polynomial.natDegree_prod_of_monic _ _ fun i _ ↦ (Polynomial.monic_X_sub_C (ωs i)).pow m]
+  simp [Polynomial.natDegree_pow]
+
+omit [DecidableEq F] [DecidableEq (RatFunc F)] in
+/-- The coefficients of `vanishingWitness` are constant in `Z`, since it is the image of a
+univariate polynomial over `F`. -/
+lemma natDegree_coeff_vanishingWitness (ωs : Fin n ↪ F) (m i j : ℕ) :
+    (Polynomial.Bivariate.coeff (vanishingWitness ωs m) i j).natDegree = 0 := by
+  rcases eq_or_ne j 0 with rfl | hj
+  · simp [Polynomial.Bivariate.coeff, vanishingWitness, Polynomial.coeff_C]
+  · simp [Polynomial.Bivariate.coeff, vanishingWitness, Polynomial.coeff_C, hj]
+
+omit [DecidableEq F] [DecidableEq (RatFunc F)] in
+/-- `vanishingWitness` is non-zero. -/
+lemma vanishingWitness_ne_zero (ωs : Fin n ↪ F) (m : ℕ) : vanishingWitness ωs m ≠ 0 := by
+  simpa [vanishingWitness, Polynomial.C_eq_zero] using
+    ((vanishingBase_monic ωs m).map (Polynomial.C : F →+* Polynomial F)).ne_zero
+
+omit [DecidableEq F] [DecidableEq (RatFunc F)] in
+/-- `vanishingWitness` is supported on `Y ^ 0`. -/
+lemma support_vanishingWitness (ωs : Fin n ↪ F) (m : ℕ) :
+    (vanishingWitness ωs m).support = {0} :=
+  Polynomial.support_C (by
+    simpa [Polynomial.C_eq_zero] using
+      ((vanishingBase_monic ωs m).map (Polynomial.C : F →+* Polynomial F)).ne_zero)
+
+omit [DecidableEq F] [DecidableEq (RatFunc F)] in
+/-- Every weighted degree of `vanishingWitness` is carried by its `X`-degree `n * m`. -/
+lemma natWeightedDegree_vanishingWitness (ωs : Fin n ↪ F) (m u v : ℕ) :
+    Polynomial.Bivariate.natWeightedDegree (vanishingWitness ωs m) u v = u * (n * m) := by
+  rw [Polynomial.Bivariate.natWeightedDegree, support_vanishingWitness]
+  simp [vanishingWitness, (vanishingBase_monic ωs m).natDegree_map, natDegree_vanishingBase]
+
+omit [DecidableEq F] [DecidableEq (RatFunc F)] in
+/-- The `X`-degree of `vanishingWitness` is `n * m`. -/
+lemma degreeX_vanishingWitness (ωs : Fin n ↪ F) (m : ℕ) :
+    Polynomial.Bivariate.degreeX (vanishingWitness ωs m) = n * m := by
+  rw [Polynomial.Bivariate.degreeX_as_weighted_deg, natWeightedDegree_vanishingWitness, one_mul]
+
+omit [DecidableEq F] [DecidableEq (RatFunc F)] in
+/-- The `Y`-degree of `vanishingWitness` is zero. -/
+lemma D_Y_vanishingWitness (ωs : Fin n ↪ F) (m : ℕ) : D_Y (vanishingWitness ωs m) = 0 := by
+  simp [D_Y, Polynomial.Bivariate.natDegreeY, vanishingWitness]
+
+omit [DecidableEq F] [DecidableEq (RatFunc F)] in
+/-- The `YZ`-degree of `vanishingWitness` is zero: it is constant in both `Y` and `Z`. -/
+lemma D_YZ_vanishingWitness (ωs : Fin n ↪ F) (m : ℕ) : D_YZ (vanishingWitness ωs m) = 0 := by
+  have hmax : ∀ s : Finset ℕ, (∀ x ∈ s, x = 0) → Option.getD s.max 0 = 0 := by
+    intro s hs
+    rcases s.eq_empty_or_nonempty with rfl | hne
+    · rfl
+    · obtain ⟨a, ha⟩ := Finset.max_of_nonempty hne
+      rw [ha]
+      exact hs a (Finset.mem_of_max ha)
+  refine hmax _ fun x hx ↦ ?_
+  simp only [Finset.mem_image, support_vanishingWitness, Finset.mem_singleton] at hx
+  obtain ⟨j, rfl, rfl⟩ := hx
+  refine hmax _ fun y hy ↦ ?_
+  simp only [Finset.mem_image] at hy
+  obtain ⟨i, -, rfl⟩ := hy
+  simp [natDegree_coeff_vanishingWitness]
+
+omit [DecidableEq (RatFunc F)] in
+/-- `vanishingWitness` vanishes to order at least `m` at every point of the form `(ωs i, y)`,
+in particular along the curve `(ωs i, u₀ i + Z * u₁ i)`. -/
+lemma le_rootMultiplicity_vanishingWitness (ωs : Fin n ↪ F) (m : ℕ) (i : Fin n)
+    (y : Polynomial F) :
+    (m : Option ℕ) ≤ Polynomial.Bivariate.rootMultiplicity (vanishingWitness ωs m)
+      (Polynomial.C (ωs i)) y := by
+  set p := (vanishingBase ωs m).map (Polynomial.C : F →+* Polynomial F) with hp
+  have hshift : Polynomial.Bivariate.shift (vanishingWitness ωs m) (Polynomial.C (ωs i)) y
+      = Polynomial.C (p.comp (Polynomial.X + Polynomial.C (Polynomial.C (ωs i)))) := by
+    simp [Polynomial.Bivariate.shift, vanishingWitness, hp]
+  have hmap : ((Polynomial.X - Polynomial.C (ωs i)) ^ m).map (Polynomial.C : F →+* Polynomial F)
+      = (Polynomial.X - Polynomial.C (Polynomial.C (ωs i))) ^ m := by
+    rw [Polynomial.map_pow, Polynomial.map_sub, Polynomial.map_X, Polynomial.map_C]
+  have hfac : (Polynomial.X - Polynomial.C (Polynomial.C (ωs i))) ^ m ∣ p := by
+    rw [hp, vanishingBase, ← hmap]
+    exact Polynomial.map_dvd _ (Finset.dvd_prod_of_mem _ (Finset.mem_univ i))
+  have hcomp : ((Polynomial.X - Polynomial.C (Polynomial.C (ωs i))) ^ m).comp
+      (Polynomial.X + Polynomial.C (Polynomial.C (ωs i))) = Polynomial.X ^ m := by
+    rw [Polynomial.pow_comp, Polynomial.sub_comp, Polynomial.X_comp, Polynomial.C_comp,
+      add_sub_cancel_right]
+  have hXm : Polynomial.X ^ m ∣ p.comp (Polynomial.X + Polynomial.C (Polynomial.C (ωs i))) := by
+    rw [← hcomp]
+    exact map_dvd (Polynomial.compRingHom _) hfac
+  refine Polynomial.Bivariate.le_rootMultiplicity_of_coeff_shift_eq_zero ?_ ?_
+  · rw [hshift]
+    simpa [Polynomial.C_eq_zero] using
+      (((vanishingBase_monic ωs m).map (Polynomial.C : F →+* Polynomial F)).comp_X_add_C _).ne_zero
+  · intro s t hst
+    rw [hshift]
+    rcases eq_or_ne t 0 with rfl | ht
+    · simpa [Polynomial.Bivariate.coeff] using Polynomial.X_pow_dvd_iff.mp hXm s (by omega)
+    · simp [Polynomial.Bivariate.coeff, Polynomial.coeff_C, ht]
+
+omit [DecidableEq (RatFunc F)] in
+/-- Claim 5.4 from [BCIKS20] in the high-rate regime, where the degree budget `D_X` already
+accommodates a polynomial vanishing to order `m` at all `n` interpolation points: the explicit
+witness `∏ i, (X - ωs i) ^ m` solves the system.
+
+This is the branch of `modified_guruswami_has_a_solution` that an interpolation count cannot
+cover: when `n * m < D_X` the number of monomials below the weighted degree bound need not exceed
+the number of linear conditions. -/
+lemma exists_modifiedGuruswami_of_lt_D_X {m k : ℕ} (hk : 0 < k)
+    (hD : ((n * m : ℕ) : ℝ) < D_X ((k + 1) / (n : ℚ)) n m)
+    {ωs : Fin n ↪ F} {u₀ u₁ : Fin n → F} :
+    ∃ Q : F[Z][X][Y], ModifiedGuruswami m n k ωs Q u₀ u₁ := by
+  have hDX : 0 < D_X ((k + 1) / (n : ℚ)) n m := lt_of_le_of_lt (Nat.cast_nonneg _) hD
+  refine ⟨vanishingWitness ωs m, vanishingWitness_ne_zero ωs m, ?_,
+    fun i ↦ le_rootMultiplicity_vanishingWitness ωs m i _, ?_, ?_, ?_⟩
+  · simpa [natWeightedDegree_vanishingWitness] using hD
+  · simpa [degreeX_vanishingWitness] using hD
+  · simpa [D_Y_vanishingWitness] using div_pos hDX (by exact_mod_cast hk)
+  · simp only [D_YZ_vanishingWitness, Nat.cast_zero]
+    positivity
+
 omit [DecidableEq (RatFunc F)] in
 /-- The modified Guruswami-Sudan system is solvable: for every evaluation domain `ωs` and word
 pair `u₀ u₁`, some nonzero trivariate `Q` meets all the degree and multiplicity constraints of

--- a/ArkLib/Data/Polynomial/Bivariate.lean
+++ b/ArkLib/Data/Polynomial/Bivariate.lean
@@ -473,5 +473,33 @@ lemma evalX_mul {F : Type} [CommSemiring F] (x : F) (f g : F[X][Y]) :
     evalX x (f * g) = evalX x f * evalX x g := by
   simp [evalX_eq_map]
 
+section RootMultiplicity
+
+variable {R : Type} [CommSemiring R] [DecidableEq R]
+
+/-- A non-zero bivariate polynomial has a well-defined vanishing order at the origin. -/
+lemma rootMultiplicity₀_ne_none {g : R[X][Y]} (hg : g ≠ 0) : rootMultiplicity₀ g ≠ none := by
+  obtain ⟨i, j, hij⟩ : ∃ i j, coeff g i j ≠ 0 := by
+    by_contra h
+    simp only [not_exists, ne_eq, not_not] at h
+    exact hg (Polynomial.ext fun j ↦ Polynomial.ext fun i ↦ by simpa [coeff] using h i j)
+  exact fun hnone ↦
+    hij ((rootMultiplicity₀_ge_iff g (i + j + 1)).mpr (by simp [hnone]) i j (by omega))
+
+/-- The `(x, y)`-vanishing order of `g` is at least `m`, provided the shifted polynomial is
+non-zero and all of its coefficients of total degree less than `m` vanish.
+
+This is the ring-level counterpart of `rootMultiplicity₀_ge_iff`: it upgrades the vacuous
+`∀ r ∈ rootMultiplicity₀ _, m ≤ r` to an inequality in `Option ℕ`. -/
+lemma le_rootMultiplicity_of_coeff_shift_eq_zero {g : R[X][Y]} {x y : R} {m : ℕ}
+    (hg : shift g x y ≠ 0) (h : ∀ i j, i + j < m → coeff (shift g x y) i j = 0) :
+    (m : Option ℕ) ≤ rootMultiplicity g x y := by
+  obtain ⟨r, hr⟩ := Option.ne_none_iff_exists'.mp (rootMultiplicity₀_ne_none hg)
+  have hle : m ≤ r := (rootMultiplicity₀_ge_iff (shift g x y) m).mp h r (by rw [hr]; rfl)
+  rw [rootMultiplicity, hr]
+  exact Option.some_le_some.mpr hle
+
+end RootMultiplicity
+
 end
 end Polynomial.Bivariate


### PR DESCRIPTION
Claim 5.4 of [BCIKS20] in the regime `n * m < D_X`, sorry-free. The `sorry` for the general
statement is untouched.

`vanishingWitness = ∏ i, (X - ωs i) ^ m`, constant in both `Y` and `Z`, satisfies every
`ModifiedGuruswami` field there. Defining it as the image of a polynomial over `F` makes every
coefficient constant in `Z`, so `D_YZ` vanishes.

This is the half of the parameter space the interpolation count cannot reach: that argument needs
`#{(i, j) : i + k * j ≤ D} > n * (m * (m + 1) / 2)`, which is false for `n` small relative to `k`.
The split is exhaustive — `n * m ≤ D` takes this witness, `D < n * m` feeds the counting argument,
since `n * m ≥ D_X` gives `n * m ^ 2 ≥ (m + 1/2) ^ 2 * (k + 1)`.

Also adds, in `Data/Polynomial/Bivariate.lean`, `rootMultiplicity₀_ne_none` and
`le_rootMultiplicity_of_coeff_shift_eq_zero` at `CommSemiring` generality, so they apply at the base
ring `F[Z]` where the multiplicity along the curve is taken. The latter upgrades CompPoly's
`rootMultiplicity₀_ge_iff` from a vacuous `∀ r ∈ _, m ≤ r` to an inequality in `Option ℕ`.

`lake build` green, 3386 jobs; `#print axioms` on all six new declarations gives
`[propext, Classical.choice, Quot.sound]`.
