### PR TITLE
feat(coding-theory): threshold-form public faces for the proved bound catalog

### DIFF
--- a/ArkLib/Data/CodingTheory/Connections/ListDecodingAndCA/GCXK25.lean
+++ b/ArkLib/Data/CodingTheory/Connections/ListDecodingAndCA/GCXK25.lean
@@ -850,6 +850,24 @@ theorem linear_mcaError_le_of_Lambda_le (C : LinearCode ι F) (L : ℕ) (δ η :
   exact linear_mca_error_le_of_lambda_le_aux C L δ η _hδ_pos _hδ_lt
     _hδ_lt_dist _hη_pos _hη_lt _hΛ
 
+/-- Threshold form of `linear_mcaError_le_of_Lambda_le`: any target `ε_star` that the
+`(L²δn + 1/η)/|F|` budget clears at the instantiated parameters is a genuine affine-line MCA
+bound. Together with the list-size hypothesis `hΛ`, both numeric side conditions of the
+list-to-MCA conversion are discharged at the use site. -/
+theorem linear_mcaError_le_of_Lambda_le_of_budget (C : LinearCode ι F) (L : ℕ) (δ η : ℝ)
+    (hδ_pos : 0 < δ) (hδ_lt : δ < 1)
+    (hδ_lt_dist :
+        δ < (Code.minDist ((C : Set (ι → F))) : ℝ) / Fintype.card ι)
+    (hη_pos : 0 < η) (hη_lt : η < 1)
+    (hΛ : Lambda ((C : Set (ι → F))) δ ≤ (L : ℕ∞))
+    (ε_star : ℝ≥0)
+    (hbudget : ENNReal.ofReal
+        (((L : ℝ) ^ 2 * δ * Fintype.card ι + 1 / η) / Fintype.card F) ≤ (ε_star : ENNReal)) :
+    mcaError (AffineLineGenerator F) C
+        (1 - (1 - δ + η) ^ ((1 : ℝ) / 2)) ≤ (ε_star : ENNReal) :=
+  le_trans (linear_mcaError_le_of_Lambda_le C L δ η hδ_pos hδ_lt hδ_lt_dist
+    hη_pos hη_lt hΛ) hbudget
+
 end ListImpliesMCA
 
 end CodingTheory

--- a/ArkLib/Data/CodingTheory/JohnsonBound/Family.lean
+++ b/ArkLib/Data/CodingTheory/JohnsonBound/Family.lean
@@ -1028,5 +1028,109 @@ theorem frs_lambda_le_johnson_mds
   exact mds_johnson_lambda_le_of_rate_distance _ ρ η hρ_pos hρ_le1 hη_pos
     (ReedSolomon.Folded.frs_rate_distance_of_dvd hs hdvd dom ω hadm hω hk)
 
+/-! ## Threshold forms
+
+Target-shaped faces of the Johnson list bounds: the list-size target `L` is an argument and the
+numeric budget check `1/(2ηρ) ≤ L` is a hypothesis, so the contentful-range condition is
+discharged at the use site. The conclusions are stated on the bare `ℕ∞`-valued `Lambda`, the
+shape list-size consumers take. -/
+
+/-- Threshold form of `mds_johnson_lambda_le_of_rate_distance`. -/
+theorem mds_johnson_lambda_le_of_rate_distance_of_budget
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    {α : Type*} [Finite α] [DecidableEq α]
+    (C : Set (ι → α)) (ρ η : ℝ)
+    (hρ_pos : 0 < ρ) (hρ_le_one : ρ ≤ 1) (hη_pos : 0 < η)
+    (h_rate_distance : (Code.minDist C : ℝ) / Fintype.card ι =
+      1 - ρ + 1 / Fintype.card ι)
+    (L : ℕ) (hbudget : ENNReal.ofReal (1 / (2 * η * ρ)) ≤ (L : ENNReal)) :
+    Lambda C (1 - Real.sqrt ρ - η) ≤ (L : ℕ∞) := by
+  have h := (mds_johnson_lambda_le_of_rate_distance C ρ η hρ_pos hρ_le_one hη_pos
+    h_rate_distance).trans hbudget
+  exact ENat.toENNReal_le.mp (by simpa using h)
+
+/-- Threshold form of `mds_johnson_lambda_le`. -/
+theorem mds_johnson_lambda_le_of_budget
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    {F : Type*} [Field F] [Finite F] [DecidableEq F]
+    (C : LinearCode ι F) (η : ℝ) (hη_pos : 0 < η)
+    (h_mds : LinearCode.IsMDS C)
+    (L : ℕ)
+    (hbudget : ENNReal.ofReal
+        (1 / (2 * η * ((Module.finrank F C : ℝ) / Fintype.card ι))) ≤ (L : ENNReal)) :
+    Lambda ((C : Set (ι → F)))
+        (1 - Real.sqrt ((Module.finrank F C : ℝ) / Fintype.card ι) - η) ≤ (L : ℕ∞) := by
+  have h : (Lambda ((C : Set (ι → F)))
+        (1 - Real.sqrt ((Module.finrank F C : ℝ) / Fintype.card ι) - η) : ENNReal) ≤
+      ENNReal.ofReal (1 / (2 * η * ((Module.finrank F C : ℝ) / Fintype.card ι))) :=
+    mds_johnson_lambda_le C η hη_pos h_mds
+  exact ENat.toENNReal_le.mp (by simpa using h.trans hbudget)
+
+/-- Threshold form of `rs_lambda_le_johnson_mds`. -/
+theorem rs_lambda_le_johnson_mds_of_budget
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    {F : Type*} [Field F] [Finite F]
+    {n : ℕ} [NeZero n] (dom : ι ↪ F) (η : ℝ) (hη_pos : 0 < η)
+    (L : ℕ)
+    (hbudget : ENNReal.ofReal
+        (1 / (2 * η * ((Module.finrank F (ReedSolomon.code dom n) : ℝ) / Fintype.card ι)))
+      ≤ (L : ENNReal)) :
+    Lambda ((ReedSolomon.code dom n : Set (ι → F)))
+        (1 - Real.sqrt ((Module.finrank F (ReedSolomon.code dom n) : ℝ) / Fintype.card ι) - η)
+      ≤ (L : ℕ∞) := by
+  have h : (Lambda ((ReedSolomon.code dom n : Set (ι → F)))
+        (1 - Real.sqrt ((Module.finrank F (ReedSolomon.code dom n) : ℝ) / Fintype.card ι) - η) :
+          ENNReal) ≤
+      ENNReal.ofReal
+        (1 / (2 * η * ((Module.finrank F (ReedSolomon.code dom n) : ℝ) / Fintype.card ι))) :=
+    rs_lambda_le_johnson_mds dom η hη_pos
+  exact ENat.toENNReal_le.mp (by simpa using h.trans hbudget)
+
+/-- Threshold form of `irs_lambda_le_johnson_mds`. -/
+theorem irs_lambda_le_johnson_mds_of_budget
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    {F : Type*} [Field F] [Finite F]
+    (dom : ι ↪ F) (k s : ℕ) [NeZero s] (hks : 0 < k / s)
+    (η : ℝ) (hη_pos : 0 < η)
+    (L : ℕ)
+    (hbudget : ENNReal.ofReal
+        (1 / (2 * η * LinearCode.alphabetRate (ReedSolomon.Interleaved.irsCode dom k s)))
+      ≤ (L : ENNReal)) :
+    Lambda ((ReedSolomon.Interleaved.irsCode dom k s : Submodule F (ι → Fin s → F)) :
+        Set (ι → Fin s → F))
+        (1 - Real.sqrt (LinearCode.alphabetRate (ReedSolomon.Interleaved.irsCode dom k s)) - η)
+      ≤ (L : ℕ∞) := by
+  have h : (Lambda ((ReedSolomon.Interleaved.irsCode dom k s : Submodule F (ι → Fin s → F)) :
+        Set (ι → Fin s → F))
+        (1 - Real.sqrt (LinearCode.alphabetRate (ReedSolomon.Interleaved.irsCode dom k s)) - η) :
+          ENNReal) ≤
+      ENNReal.ofReal
+        (1 / (2 * η * LinearCode.alphabetRate (ReedSolomon.Interleaved.irsCode dom k s))) :=
+    irs_lambda_le_johnson_mds dom k s hks η hη_pos
+  exact ENat.toENNReal_le.mp (by simpa using h.trans hbudget)
+
+/-- Threshold form of `frs_lambda_le_johnson_mds`. -/
+theorem frs_lambda_le_johnson_mds_of_budget
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    {F : Type*} [Field F] [Finite F]
+    (dom : ι ↪ F) (k s : ℕ) [NeZero k] (ω : F) (hs : 0 < s) (hdvd : s ∣ k)
+    (hadm : ReedSolomon.Folded.Admissible (Finset.univ.map dom) s ω) (hω : ω ≠ 0)
+    (hk : k ≤ s * Fintype.card ι) (η : ℝ) (hη_pos : 0 < η)
+    (L : ℕ)
+    (hbudget : ENNReal.ofReal
+        (1 / (2 * η * LinearCode.alphabetRate (ReedSolomon.Folded.frsCode dom k s ω)))
+      ≤ (L : ENNReal)) :
+    Lambda ((ReedSolomon.Folded.frsCode dom k s ω : Submodule F (ι → Fin s → F)) :
+        Set (ι → Fin s → F))
+        (1 - Real.sqrt (LinearCode.alphabetRate (ReedSolomon.Folded.frsCode dom k s ω)) - η)
+      ≤ (L : ℕ∞) := by
+  have h : (Lambda ((ReedSolomon.Folded.frsCode dom k s ω : Submodule F (ι → Fin s → F)) :
+        Set (ι → Fin s → F))
+        (1 - Real.sqrt (LinearCode.alphabetRate (ReedSolomon.Folded.frsCode dom k s ω)) - η) :
+          ENNReal) ≤
+      ENNReal.ofReal
+        (1 / (2 * η * LinearCode.alphabetRate (ReedSolomon.Folded.frsCode dom k s ω))) :=
+    frs_lambda_le_johnson_mds dom k s ω hs hdvd hadm hω hk η hη_pos
+  exact ENat.toENNReal_le.mp (by simpa using h.trans hbudget)
 
 end CodingTheory

--- a/ArkLib/Data/CodingTheory/ListDecodability/Bounds/Linear.lean
+++ b/ArkLib/Data/CodingTheory/ListDecodability/Bounds/Linear.lean
@@ -882,6 +882,25 @@ theorem linear_card_le_generalized_singleton
     _ ≤ (q : ℝ) ^ ((n : ℝ) - (a : ℝ)) :=
       Real.rpow_le_rpow_of_exponent_le hq1R hexp
 
+/-- Threshold form of `linear_card_le_generalized_singleton`: any cardinality target `M` that
+the `q^(n - ⌊(ℓ+1)/ℓ·δn⌋)` budget clears at the instantiated parameters bounds the code size.
+Together with the list-size hypothesis `hΛ`, both numeric side conditions of the generalized
+Singleton bound are discharged at the use site. -/
+theorem linear_card_le_generalized_singleton_of_budget
+    (C : Submodule F (ι → F)) (ℓ : ℕ) (δ : ℝ)
+    (hℓ_pos : 0 < ℓ) (hℓ_lt : ℓ < Fintype.card F)
+    (hδ_pos : 0 < δ) (hδ_lt : δ < 1)
+    (hδn_int : ∃ e : ℕ, (e : ℝ) = δ * Fintype.card ι)
+    (hexp_nonneg : Nat.floor (((ℓ : ℝ) + 1) / ℓ * δ * Fintype.card ι) ≤ Fintype.card ι)
+    (hΛ : Lambda ((C : Set (ι → F))) δ ≤ (ℓ : ℕ∞))
+    (M : ℝ)
+    (hbudget : (Fintype.card F : ℝ) ^
+        ((Fintype.card ι : ℝ)
+          - (Nat.floor (((ℓ : ℝ) + 1) / ℓ * δ * Fintype.card ι) : ℝ)) ≤ M) :
+    (Set.ncard ((C : Set (ι → F))) : ℝ) ≤ M :=
+  le_trans (linear_card_le_generalized_singleton C ℓ δ hℓ_pos hℓ_lt hδ_pos hδ_lt
+    hδn_int hexp_nonneg hΛ) hbudget
+
 end LowerBounds_General
 
 section RandomLinear

--- a/ArkLib/Data/CodingTheory/ListDecodability/Bounds/SubspaceDesign.lean
+++ b/ArkLib/Data/CodingTheory/ListDecodability/Bounds/SubspaceDesign.lean
@@ -464,6 +464,71 @@ theorem um_lambda_le_capacity
     rw [hstep]
     exact div_le_div_of_nonneg_left hρs_nonneg hdenom_pos (by linarith)
 
+/-! ## Threshold forms
+
+Target-shaped faces of the subspace-design list bounds: the list-size target `L` is an argument
+and the numeric budget check is a hypothesis, so the contentful-range condition is discharged at
+the use site. Conclusions are stated on the bare `ℕ∞`-valued `Lambda`. -/
+
+/-- Threshold form of `subspaceDesign_lambda_le_of_profile_le`. -/
+theorem subspaceDesign_lambda_le_of_profile_le_of_budget
+    {ι : Type} [Fintype ι] [Nonempty ι] [DecidableEq ι]
+    {F : Type} [Field F] [Fintype F] [DecidableEq F]
+    (s : ℕ) (R : ℝ) (C : Submodule F (ι → Fin s → F))
+    (hR : (LinearCode.alphabetRate C : ℝ) = R)
+    (h : IsSubspaceDesign s
+      (fun r => if r ∈ Finset.Icc 1 s then
+        (s * R - 1 / Fintype.card ι) / (s - r + 1) else 1) C)
+    (η t : ℝ) (hη_pos : 0 < η) (ht_nonneg : 0 ≤ t)
+    (hτ_le : ∀ L : ℕ, 1 ≤ L → (L : ℝ) ≤ 1 / η → s * R / (s - L + 1) ≤ t)
+    (hs : 1 / η ≤ (s : ℝ))
+    (L : ℕ) (hbudget : ENNReal.ofReal ((1 - t) / η) ≤ (L : ENNReal)) :
+    Lambda ((C : Set (ι → Fin s → F))) (1 - t - η) ≤ (L : ℕ∞) := by
+  have hle := (subspaceDesign_lambda_le_of_profile_le s R C hR h η t hη_pos ht_nonneg
+    hτ_le hs).trans hbudget
+  exact ENat.toENNReal_le.mp (by simpa using hle)
+
+/-- Threshold form of `subspaceDesign_lambda_le_of_eta`. -/
+theorem subspaceDesign_lambda_le_of_eta_of_budget
+    {ι : Type} [Fintype ι] [Nonempty ι] [DecidableEq ι]
+    {F : Type} [Field F] [Fintype F] [DecidableEq F]
+    (s : ℕ) (R : ℝ) (C : Submodule F (ι → Fin s → F))
+    (hR : (LinearCode.alphabetRate C : ℝ) = R)
+    (h : IsSubspaceDesign s
+      (fun r => if r ∈ Finset.Icc 1 s then
+        (s * R - 1 / Fintype.card ι) / (s - r + 1) else 1) C)
+    (η : ℝ) (hη_pos : 0 < η) (hηs : 1 / η ≤ (s : ℝ))
+    (L : ℕ)
+    (hbudget : ENNReal.ofReal ((1 - s * R / ((s : ℝ) - 1 / η + 1)) / η) ≤ (L : ENNReal)) :
+    Lambda ((C : Set (ι → Fin s → F)))
+        (1 - s * R / ((s : ℝ) - 1 / η + 1) - η) ≤ (L : ℕ∞) := by
+  have hle := (subspaceDesign_lambda_le_of_eta s R C hR h η hη_pos hηs).trans hbudget
+  exact ENat.toENNReal_le.mp (by simpa using hle)
+
+/-- Threshold form of `um_lambda_le_capacity`. -/
+theorem um_lambda_le_capacity_of_budget
+    {ι : Type} [Fintype ι] [Nonempty ι] [DecidableEq ι]
+    {F : Type} [Field F] [Fintype F] [DecidableEq F]
+    (domain : ι ↪ F) (k s : ℕ)
+    (hs_pos : 0 < s)
+    (hchar : ringChar F = 0 ∨ k ≤ ringChar F)
+    (hk_le : k ≤ s * Fintype.card ι)
+    (η : ℝ) (hη_pos : 0 < η) (hη_lt_s : 1 / η < s)
+    (L : ℕ)
+    (hbudget : ENNReal.ofReal
+        ((s * (1 - (k : ℝ) / (s * (Fintype.card ι : ℝ))) + 1 - 1 / η)
+          / (η * (s + 1 - 1 / η))) ≤ (L : ENNReal)) :
+    Lambda ((ReedSolomon.Multiplicity.umCode domain k s : Set (ι → Fin s → F)))
+        (1 - ((k : ℝ) / (s * (Fintype.card ι : ℝ))) * s / (s - 1 / η + 1) - η)
+      ≤ (L : ℕ∞) := by
+  have h : (Lambda ((ReedSolomon.Multiplicity.umCode domain k s : Set (ι → Fin s → F)))
+        (1 - ((k : ℝ) / (s * (Fintype.card ι : ℝ))) * s / (s - 1 / η + 1) - η) : ENNReal) ≤
+      ENNReal.ofReal
+        ((s * (1 - (k : ℝ) / (s * (Fintype.card ι : ℝ))) + 1 - 1 / η)
+          / (η * (s + 1 - 1 / η))) :=
+    um_lambda_le_capacity domain k s hs_pos hchar hk_le η hη_pos hη_lt_s
+  exact ENat.toENNReal_le.mp (by simpa using h.trans hbudget)
+
 end SubspaceDesignUpperBounds
 
 end CodingTheory

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/EpsCa.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/EpsCa.lean
@@ -165,6 +165,33 @@ theorem rs_mcaError_le_of_le_relUDR {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥
       (two_mul_lt_dist_of_le_relUDR hδ_pos hδ))
     (rs_epsCa_le_of_le_relUDR hδ le_rfl)
 
+/-- Threshold form of `rs_epsCa_le_of_le_relUDR`: any target `ε_star` that `n/|F|` clears is a
+genuine CA bound in the unique-decoding range, with the numeric check discharged at the use
+site. -/
+theorem rs_epsCa_le_of_le_relUDR_of_budget {deg : ℕ} {domain : ι ↪ F} {δ_fld δ_int : ℝ≥0}
+    (hδ : δ_fld ≤ relativeUniqueDecodingRadius
+            (ι := ι) (F := F) (C := ReedSolomon.code domain deg))
+    (hle : δ_fld ≤ δ_int)
+    (ε_star : ℝ≥0)
+    (hbudget : ((Fintype.card ι / Fintype.card F : ℝ≥0) : ENNReal) ≤ (ε_star : ENNReal)) :
+    epsCa (F := F) (A := F) ((ReedSolomon.code domain deg : Set (ι → F))) δ_fld δ_int
+      ≤ (ε_star : ENNReal) :=
+  le_trans (rs_epsCa_le_of_le_relUDR hδ hle) hbudget
+
+/-- Threshold form of `rs_mcaError_le_of_le_relUDR`: any target `ε_star` that `n/|F|` clears is
+a genuine affine-line MCA bound in the unique-decoding range, with the numeric check discharged
+at the use site. This is the lemma-level counterpart of
+`GrandChallenges.McaLowerWitness.ofUniqueDecodingRange`. -/
+theorem rs_mcaError_le_of_le_relUDR_of_budget {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
+    (hδ_pos : 0 < δ)
+    (hδ : δ ≤ relativeUniqueDecodingRadius
+            (ι := ι) (F := F) (C := ReedSolomon.code domain deg))
+    (ε_star : ℝ≥0)
+    (hbudget : ((Fintype.card ι / Fintype.card F : ℝ≥0) : ENNReal) ≤ (ε_star : ENNReal)) :
+    mcaError (AffineLineGenerator F) (ReedSolomon.code domain deg) (δ : ℝ)
+      ≤ (ε_star : ENNReal) :=
+  le_trans (rs_mcaError_le_of_le_relUDR hδ_pos hδ) hbudget
+
 end UniqueDecodingRegime
 
 end ProximityGap

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds.lean
@@ -251,6 +251,35 @@ theorem exists_rs_epsCa_large_near_capacity
   sorry -- ABF26-T4.16; external admit [KKH26].
 
 
+/-- Threshold form of `rs_epsCa_le_of_no_radius_level_crossing`: any target `ε_star` that the
+two-branch no-grid-crossing budget clears at the instantiated parameters is a genuine CA bound.
+The numeric budget check is a hypothesis, so the contentful-range condition is discharged at
+the use site. -/
+theorem rs_epsCa_le_of_no_radius_level_crossing_of_budget
+    (domain : ι ↪ F) (k : ℕ) (δ_fld : ℝ≥0) (γ : ℝ≥0)
+    (h_ud : (δ_fld : ℝ) ≤ (1 - (k : ℝ) / Fintype.card ι) / 2 - 1 / Fintype.card ι)
+    (h_dmin : (Code.minDist ((ReedSolomon.code domain k : Set (ι → F))) : ℝ)
+                / Fintype.card ι / 3 ≤ δ_fld)
+    (hγ_pos : 0 < γ) (hγ_lt : (γ : ℝ) < 1)
+    (h_no_cross :
+        Nat.floor ((δ_fld + γ / (Fintype.card ι : ℝ≥0)) * (Fintype.card ι : ℝ≥0))
+          = Nat.floor ((δ_fld : ℝ≥0) * (Fintype.card ι : ℝ≥0)))
+    (ε_star : ℝ≥0)
+    (hbudget : ENNReal.ofReal
+        (max ((1 - (k : ℝ) / Fintype.card ι - δ_fld)
+                / (δ_fld * (1 - (k : ℝ) / Fintype.card ι - 2 * δ_fld) * Fintype.card F))
+             (((Fintype.card ι : ℝ) * δ_fld + γ) / (γ * Fintype.card F)))
+      ≤ (ε_star : ENNReal)) :
+    epsCa (F := F) (A := F) ((ReedSolomon.code domain k : Set (ι → F))) δ_fld δ_fld ≤
+      (ε_star : ENNReal) := by
+  have h : epsCa (F := F) (A := F) ((ReedSolomon.code domain k : Set (ι → F))) δ_fld δ_fld ≤
+      ENNReal.ofReal
+        (max ((1 - (k : ℝ) / Fintype.card ι - δ_fld)
+                / (δ_fld * (1 - (k : ℝ) / Fintype.card ι - 2 * δ_fld) * Fintype.card F))
+             (((Fintype.card ι : ℝ) * δ_fld + γ) / (γ * Fintype.card F))) :=
+    rs_epsCa_le_of_no_radius_level_crossing domain k δ_fld γ h_ud h_dmin hγ_pos hγ_lt h_no_cross
+  exact le_trans h hbudget
+
 end ReedSolomon
 
 section SubspaceDesignFRS

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/JohnsonCa.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/JohnsonCa.lean
@@ -1301,6 +1301,23 @@ theorem linear_epsCa_le_one_point_five_johnson
     C δ_min η δ_fld δ_src _h_δ_min _hη _hη_lt_third _hη_lt_δ_min
       _hδ_fld_pos _hδ_fld_lt _hδ_src
 
+/-- Threshold form of `linear_epsCa_le_one_point_five_johnson`: any target `ε_star` that the
+`2/(η²|F|)` budget clears at the instantiated parameters is a genuine CA bound. The numeric
+budget check is a hypothesis, so the contentful-range condition is discharged at the use
+site. -/
+theorem linear_epsCa_le_one_point_five_johnson_of_budget
+    (C : LinearCode ι F) (δ_min η δ_fld δ_src : ℝ≥0)
+    (h_δ_min : (δ_min : ℝ) = (Code.minDist (C : Set (ι → F)) : ℝ) / Fintype.card ι)
+    (hη : 0 < η) (hη_lt_third : (η : ℝ) < 1 / 3) (hη_lt_δ_min : η < δ_min)
+    (hδ_fld_pos : 0 < δ_fld) (hδ_fld_lt : δ_fld < δ_src)
+    (hδ_src : (δ_src : ℝ) <
+      1 - ((1 - (δ_min : ℝ) + (η : ℝ)) ^ ((1 : ℝ) / 3)))
+    (ε_star : ℝ≥0)
+    (hbudget : ENNReal.ofReal (2 / ((η : ℝ) ^ 2 * Fintype.card F)) ≤ (ε_star : ENNReal)) :
+    epsCa (F := F) (A := F) ((C : Set (ι → F))) δ_fld (δ_src + η) ≤ (ε_star : ENNReal) :=
+  le_trans (linear_epsCa_le_one_point_five_johnson C δ_min η δ_fld δ_src h_δ_min hη
+    hη_lt_third hη_lt_δ_min hδ_fld_pos hδ_fld_lt hδ_src) hbudget
+
 end General
 
 end CodingTheory

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/JohnsonLower.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/JohnsonLower.lean
@@ -8,6 +8,8 @@ import ArkLib.Data.CodingTheory.ListDecodability.Bounds.KKH26
 import Mathlib.Algebra.Algebra.ZMod
 import Mathlib.FieldTheory.Finite.Basic
 
+set_option linter.style.longFile 1800
+
 /-!
 # Reed--Solomon lower bound at the Johnson radius
 
@@ -1640,4 +1642,3 @@ end ReedSolomon
 
 end CodingTheory
 
-set_option linter.style.longFile 1800

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/JohnsonMca.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/JohnsonMca.lean
@@ -144,6 +144,27 @@ theorem linear_mcaError_le_one_point_five_johnson
       field_simp
       ring
 
+/-- Threshold form of `linear_mcaError_le_one_point_five_johnson`: any target `ε_star` that the
+explicit 1.5-Johnson budget clears at the instantiated parameters is a genuine affine-line MCA
+bound. The numeric budget check is a hypothesis, so the contentful-range condition is
+discharged at the use site. -/
+theorem linear_mcaError_le_one_point_five_johnson_of_budget
+    (C : LinearCode ι F) (δ_min η δ : ℝ≥0)
+    (h_δ_min : (δ_min : ℝ) = (Code.minDist (C : Set (ι → F)) : ℝ) / Fintype.card ι)
+    (hη : 0 < η) (hη_lt_δ_min : η < δ_min)
+    (hδ_pos : 0 < δ)
+    (hδ : (δ : ℝ) ≤ 1 - ((1 - (δ_min : ℝ) + (η : ℝ)) ^ ((1 : ℝ) / 3)))
+    (ε_star : ℝ≥0)
+    (hbudget : ENNReal.ofReal
+        ((((Fintype.card ι : ℝ) + 6) / η
+          + 2 / ((η : ℝ) *
+              ((1 - (δ_min : ℝ) + (η : ℝ)) ^ ((1 : ℝ) / 3)
+                - (1 - (δ_min : ℝ) + (η : ℝ)) ^ ((1 : ℝ) / 2)))
+         ) / (Fintype.card F : ℝ)) ≤ (ε_star : ENNReal)) :
+    mcaError (AffineLineGenerator F) C (δ : ℝ) ≤ (ε_star : ENNReal) :=
+  le_trans (linear_mcaError_le_one_point_five_johnson C δ_min η δ h_δ_min hη
+    hη_lt_δ_min hδ_pos hδ) hbudget
+
 end General
 
 end CodingTheory

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/Powers.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/Powers.lean
@@ -8,6 +8,8 @@ import ArkLib.Data.CodingTheory.ProximityGap.Errors
 import Mathlib.Combinatorics.Enumerative.DoubleCounting
 import Mathlib.LinearAlgebra.Matrix.Module
 
+set_option linter.style.longFile 2100
+
 /-!
 # MCA bounds for univariate powers
 
@@ -1914,6 +1916,35 @@ theorem linear_mcaError_powers_le
   · ring
   · apply congrArg₂ max <;> rw [div_div]
 
+/-- Threshold form of `linear_mcaError_powers_le`: any target `ε_star` that the explicit
+univariate-powers budget clears at the instantiated parameters is a genuine MCA bound for the
+powers generator. The numeric budget check is a hypothesis, so the contentful-range condition
+is discharged at the use site. -/
+theorem linear_mcaError_powers_le_of_budget
+    {ι : Type} [Fintype ι] [Nonempty ι]
+    {F : Type} [Field F] [Fintype F]
+    {A : Type} [Finite A] [DecidableEq A] [AddCommGroup A] [Module F A]
+    (C : ModuleCode ι F A) (k : ℕ) (δ_min η δ : ℝ≥0)
+    (hk : 1 ≤ k)
+    (hcard : k + 1 ≤ Fintype.card F)
+    (h_δ_min : (δ_min : ℝ) = (Code.minDist (C : Set (ι → A)) : ℝ) / Fintype.card ι)
+    (hη : 0 < η) (hη_lt_δ_min : η < δ_min)
+    (hδ : (δ : ℝ) ≤ 1 - (1 - (δ_min : ℝ) + (η : ℝ)) ^ ((1 : ℝ) / (k + 2)))
+    (ε_star : ℝ≥0)
+    (hbudget : ENNReal.ofReal
+        (((Fintype.card ι : ℝ)
+              * (1 - (1 - (δ_min : ℝ) + (η : ℝ)) ^ ((1 : ℝ) / (k + 1))) / η)
+            * ((k : ℝ) / Fintype.card F)
+          + max
+              (2 * (k : ℝ) /
+                ((η : ℝ)
+                  * ((1 - (δ_min : ℝ) + (η : ℝ)) ^ ((1 : ℝ) / (k + 2))
+                      - (1 - (δ_min : ℝ) + (η : ℝ)) ^ ((1 : ℝ) / (k + 1)))
+                  * Fintype.card F))
+              (((k : ℝ) + 1) * ((k : ℝ) + 2) / ((η : ℝ) * Fintype.card F)))
+      ≤ (ε_star : ENNReal)) :
+    mcaError (univariatePowersGenerator F k) C (δ : ℝ) ≤ (ε_star : ENNReal) :=
+  le_trans (linear_mcaError_powers_le C k δ_min η δ hk hcard h_δ_min hη hη_lt_δ_min hδ) hbudget
+
 end CodingTheory
 
-set_option linter.style.longFile 2100

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/Subfield.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/Subfield.lean
@@ -8,6 +8,8 @@ import ArkLib.Data.CodingTheory.ProximityGap.Errors
 import Mathlib.Analysis.SpecialFunctions.Stirling
 import Mathlib.FieldTheory.PrimitiveElement
 
+set_option linter.style.longFile 2700
+
 /-!
 # Subfield lower bound for Reed--Solomon correlated agreement
 
@@ -2537,4 +2539,3 @@ end ReedSolomon
 
 end CodingTheory
 
-set_option linter.style.longFile 2700

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/UniqueDecoding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/UniqueDecoding.lean
@@ -8,6 +8,8 @@ import ArkLib.Data.CodingTheory.ProximityGap.Errors
 import ArkLib.Data.CodingTheory.ProximityGap.BCIKS20.AffineLines.GoodCoeffs
 import Mathlib.Algebra.Order.Floor.Div
 
+set_option linter.style.longFile 1800
+
 /-!
 # Reed--Solomon CA in the unique-decoding range
 
@@ -1603,8 +1605,32 @@ theorem rs_epsCa_le_in_unique_decoding_range
     exact rs_fold_probability_le_bound_of_not_joint_proximity
       domain k δ_fld δ_int _h_ud _h_dmin _h_lt u hj
 
+/-- Threshold form of `rs_epsCa_le_in_unique_decoding_range`: any target `ε_star` that the
+two-branch unique-decoding budget clears at the instantiated parameters is a genuine CA bound.
+The numeric budget check is a hypothesis, so the contentful-range condition is discharged at
+the use site. -/
+theorem rs_epsCa_le_in_unique_decoding_range_of_budget
+    (domain : ι ↪ F) (k : ℕ) (δ_fld δ_int : ℝ≥0)
+    (h_ud : (δ_fld : ℝ) ≤ (1 - (k : ℝ) / Fintype.card ι) / 2 - 1 / Fintype.card ι)
+    (h_dmin : (Code.minDist ((ReedSolomon.code domain k : Set (ι → F))) : ℝ)
+                / Fintype.card ι / 3 ≤ δ_fld)
+    (h_lt : δ_fld < δ_int)
+    (ε_star : ℝ≥0)
+    (hbudget : ENNReal.ofReal
+        (max ((1 - (k : ℝ) / Fintype.card ι - δ_fld)
+                / (δ_fld * (1 - (k : ℝ) / Fintype.card ι - 2 * δ_fld) * Fintype.card F))
+             ((δ_int : ℝ) / ((δ_int - δ_fld) * Fintype.card F))) ≤ (ε_star : ENNReal)) :
+    epsCa (F := F) (A := F) ((ReedSolomon.code domain k : Set (ι → F))) δ_fld δ_int ≤
+      (ε_star : ENNReal) := by
+  have h : epsCa (F := F) (A := F) ((ReedSolomon.code domain k : Set (ι → F))) δ_fld δ_int ≤
+      ENNReal.ofReal
+        (max ((1 - (k : ℝ) / Fintype.card ι - δ_fld)
+                / (δ_fld * (1 - (k : ℝ) / Fintype.card ι - 2 * δ_fld) * Fintype.card F))
+             ((δ_int : ℝ) / ((δ_int - δ_fld) * Fintype.card F))) :=
+    rs_epsCa_le_in_unique_decoding_range domain k δ_fld δ_int h_ud h_dmin h_lt
+  exact le_trans h hbudget
+
 end ReedSolomon
 
 end CodingTheory
 
-set_option linter.style.longFile 1800

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -20,6 +20,9 @@ For reusable cross-cutting workflows that are not tied to one repo area, see
   `ArkLib/Data/CodingTheory/`.
 - [`proximity-error-conventions.md`](proximity-error-conventions.md) - the proximity-gap,
   correlated-agreement, and mutual-correlated-agreement APIs and their numeric types.
+- [`bound-statement-hygiene.md`](bound-statement-hygiene.md) - authoring rules for numeric
+  bound statements: source-native audit layer vs threshold-form consumption layer, ceiling
+  checks for lower-bound admits, and guard-satisfiability checks for existence statements.
 - [`probability-conventions.md`](probability-conventions.md) - namespace and export conventions
   for reusable helpers in `ArkLib/Data/Probability/`.
 - [`../kb/audits/open-problems-list-decoding-and-correlated-agreement.md`](../kb/audits/open-problems-list-decoding-and-correlated-agreement.md)

--- a/docs/wiki/bound-statement-hygiene.md
+++ b/docs/wiki/bound-statement-hygiene.md
@@ -1,0 +1,73 @@
+# Bound-Statement Hygiene
+
+Authoring rules for theorems whose content is a numeric bound on an error or list-size carrier
+(`epsCa`, `mcaError`, `Lambda`, and the protocol-level certificates built on them). The goal is
+that **no statement requires prose documentation to be used safely**: whether a bound is
+informative at given parameters must be checkable by the elaborator at the use site, never left
+as reader discipline.
+
+Adopted 2026-08-18 after the correlated-agreement discharge wave; the wrappers in
+`JohnsonBound/Family.lean`, `CapacityBounds/*.lean`, `BCIKS20/EpsCa.lean`,
+`Connections/ListDecodingAndCA/GCXK25.lean`, and `ListDecodability/Bounds/*.lean` are the
+reference implementations.
+
+## The two-layer rule
+
+Every numeric bound has two faces with different jobs:
+
+1. **Audit layer (source-native).** The statement exactly as printed in the source paper,
+   including its deliberately loose constants. This is the *only* acceptable form for an
+   **admitted** (`sorry`) statement: an admit is a trust liability, and pinning it verbatim to
+   the print is what makes it auditable. Never "improve" an admitted statement — a printed
+   theorem can be looser than its own proof supports (BCHKS25 Thm 4.6's multiplicity is the
+   canonical example), and tightening an admit silently strengthens what the library assumes.
+
+2. **Consumption layer (threshold form).** The public face consumers cite, added **in the same
+   PR that proves the statement**:
+
+   ```lean
+   theorem foo_le_of_budget … (ε_star : ℝ≥0)
+       (hbudget : ENNReal.ofReal (<the explicit formula>) ≤ (ε_star : ENNReal)) :
+       <carrier> ≤ (ε_star : ENNReal) :=
+     le_trans (foo_le …) hbudget
+   ```
+
+   The security target is an argument and the numeric budget check is a hypothesis, so a caller
+   *cannot* instantiate the theorem in a parameter range where the formula exceeds their target:
+   the use-site `norm_num`/`decide` obligation fails instead of a trivially-true bound leaking
+   into prose. Naming: `<name>_of_budget`. For `Lambda` bounds the target is `(L : ℕ)` and the
+   conclusion is on the bare `ℕ∞`-valued `Lambda` (the shape list-size consumers take), with
+   `ENat.toENNReal_le` closing the coercion gap.
+
+Wrappers add no logical strength — they are `le_trans` — and that is the point: they relocate
+the contentful-range check from documentation into types.
+
+## Checks before adding or accepting a bound statement
+
+- **Upper bounds** (`carrier ≤ formula`): always true-able, but content-free where the formula
+  meets the carrier's ceiling. Never clamp the statement (`min 1 formula` adds nothing); ship
+  the threshold form instead.
+- **Lower bounds** (`formula ≤ carrier`): if the hypotheses admit parameters where the formula
+  exceeds the carrier's ceiling (`epsCa`, `mcaError` ≤ 1 — `Lambda` is a count and has none),
+  the statement is **false there, hence unprovable**; for an admit this is a landmine. Verify
+  the guard arithmetic before accepting the admit (e.g. T4.16 self-guards via `β > c + 2`;
+  T5.4 via `ofReal (1 - 1/|F|)` plus an explicit `8 ≤ |F|`).
+- **Existence statements**: check the leading `∀`-guards are satisfiable (e.g. arbitrarily
+  large char-2 fields exist for `exists_rs_epsCa_large_at_johnson_radius`); an unsatisfiable
+  guard makes the theorem vacuously true and its proof meaningless.
+- **New predicates and structures**: surface non-degeneracy hypotheses explicitly with a
+  comment saying what breaks without them, rather than leaving degenerate instantiations
+  representable (`rs_epsCa_large_below_johnson_radius`'s `8 ≤ |F|` is the model).
+- **Attack-side results** (lower bounds intended as witnesses): route consumers through the
+  witness constructors in `ProximityGap/GrandChallenges.lean` (`McaLowerWitness.of…`,
+  `McaUpperWitness.of…`) rather than raw citation; the constructors carry the threshold
+  comparison in their fields.
+
+## What not to wrap
+
+- Transport lemmas whose right-hand side contains another carrier
+  (`lambda_interleaved_le_choose_mul_pow`, `rs_Lambda_extended_le_of_epsCa`): consumers must
+  bound the inner carrier first, at which point they chain directly.
+- Interface lemmas whose bound side is already a variable (`Lambda_le_iff_*`,
+  `isListDecodable_iff_*`, the `GrandChallenges` grid API): these are already target-shaped.
+- Monotonicity/comparison lemmas between carriers.


### PR DESCRIPTION
## Motivation

A numeric bound theorem stated as `carrier ≤ <explicit formula>` is true everywhere but
informative only where the formula clears the consumer's target — and nothing in such a
statement makes anyone check. Every consumption point in the tree had independently grown its
own guard (`McaLowerWitness.of…` hypotheses, `extractorCertificate_le_of_inputs`, the prize
repo's positive-score rule), which is the tell that the catalog statements were exporting an
unchecked numeric side condition.

This PR gives every **proved** formula-RHS bound in the CA/list-decoding catalog a
target-shaped public face, so the contentful-range check becomes a compile-time obligation at
the use site:

```lean
theorem foo_le_of_budget … (ε_star : ℝ≥0)
    (hbudget : ENNReal.ofReal (<formula>) ≤ (ε_star : ENNReal)) :
    <carrier> ≤ (ε_star : ENNReal) :=
  le_trans (foo_le …) hbudget
```

The wrappers are logically trivial (`le_trans`) by design: they relocate the check from reader
discipline into types. Statements themselves are untouched; admitted statements deliberately
get **no** wrapper until their discharge PR ships one (a wrapper over an admit is itself
sorryAx-tainted and grows the baseline for zero consumer value).

## What is added

**17 `_of_budget` wrappers** (joining the two shipped with #767):

| file | wrappers |
| --- | --- |
| `JohnsonBound/Family.lean` | `mds_johnson_lambda_le_of_rate_distance`, `mds_johnson_lambda_le`, `rs/irs/frs_lambda_le_johnson_mds` (5) |
| `CapacityBounds/JohnsonCa.lean` | `linear_epsCa_le_one_point_five_johnson` |
| `CapacityBounds/JohnsonMca.lean` | `linear_mcaError_le_one_point_five_johnson` |
| `CapacityBounds/Powers.lean` | `linear_mcaError_powers_le` |
| `CapacityBounds/UniqueDecoding.lean` | `rs_epsCa_le_in_unique_decoding_range` |
| `CapacityBounds.lean` | `rs_epsCa_le_of_no_radius_level_crossing` |
| `BCIKS20/EpsCa.lean` | `rs_epsCa_le_of_le_relUDR`, `rs_mcaError_le_of_le_relUDR` |
| `Connections/ListDecodingAndCA/GCXK25.lean` | `linear_mcaError_le_of_Lambda_le` |
| `ListDecodability/Bounds/SubspaceDesign.lean` | `subspaceDesign_lambda_le_of_profile_le`, `_of_eta`, `um_lambda_le_capacity` |
| `ListDecodability/Bounds/Linear.lean` | `linear_card_le_generalized_singleton` |

`Lambda` wrappers take a natural target `L : ℕ` and conclude on the bare `ℕ∞`-valued `Lambda`
(the shape list-size consumers use), via `ENat.toENNReal_le`.

**Deliberately not wrapped** (rationale in the new wiki page): transports whose RHS contains
another carrier (`rs_Lambda_extended_le_of_epsCa`, `lambda_interleaved_le_choose_mul_pow`),
already-target-shaped interface lemmas (`Lambda_le_iff_*`, the `GrandChallenges` grid API),
monotonicity lemmas, attack-side lower bounds (consumed via witness constructors), and the
remaining admits (T4.12, T4.16, T4.13, T5.4, and the list-decodability admits).

**`docs/wiki/bound-statement-hygiene.md`** — the authoring rule this PR instantiates:
source-native audit layer for admits, threshold-form consumption layer shipped on discharge,
ceiling checks for lower-bound admits (a lower bound whose RHS can pierce the probability
ceiling is unprovable as stated), guard-satisfiability checks for existence statements. Linked
from the wiki hub.

**Housekeeping:** the four `CapacityBounds/*` `longFile` opt-outs moved from the last line to
the conventional post-import position (caps unchanged; verified sufficient for the new
lengths).

## Verification

- Full `lake build` green; `lake exe axiomsweep --check` passes with **no baseline change**
  (all wrapped theorems are proved, so every wrapper is axiom-clean).
- No statement modified; every wrapper is `le_trans` of the existing theorem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
