### PR TITLE
fix(BCIKS20): repair separability, Claim A.2, and §5 hypotheses

### DIFF
--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Agreement.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Agreement.lean
@@ -24,6 +24,32 @@ variable {m : ℕ} (k : ℕ) {δ : ℚ} {x₀ : F} {u₀ u₁ : Fin n → F} {Q 
 
 open Trivariate in
 open Bivariate in
+/-- The technical inputs to Claim 5.7 that are not contained in `ModifiedGuruswami`.
+
+`regime` restores the standing §5 numerical assumptions.  `specializations_separable` says that
+the chosen `x₀` is good in the sense of Claim 5.6, at the fraction-field level actually used by
+Hensel lifting.  `positive_pair_for_every_z` is the content-factor bridge required by the present
+Claim 5.7 cardinality: every `z ∈ S` must be covered by a positive-`Y`-degree pair.  A future proof
+may instead remove the finite content-root exceptional set and weaken the cardinality conclusion;
+until that loss is quantified, keeping the bridge explicit is preferable to deriving it from the
+stronger and unintended ring-level `Polynomial.Separable` predicate. -/
+structure Claim57Assumptions (x₀ : F) (δ : ℚ)
+    (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) : Prop where
+  regime : Section5Regime m n k ωs Q u₀ u₁ δ h_gs
+  specializations_separable : ∀ R : F[Z][X][Y],
+    R ∈ pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
+      (u₀ := u₀) (u₁ := u₁) h_gs →
+    ((Bivariate.evalX (Polynomial.C x₀) R).map
+      (ToRatFunc.univPolyHom (F := F))).Separable
+  positive_pair_for_every_z :
+    ∀ z : coeffs_of_close_proximity (F := F) k ωs δ u₀ u₁,
+      ∃ R H,
+        (R, H) ∈ pg_positiveDegreePairs (m := m) (n := n) (k := k) (ωs := ωs)
+          (Q := Q) (u₀ := u₀) (u₁ := u₁) x₀ h_gs ∧
+        let P : F[X] := Pz (k := k) (ωs := ωs) (δ := δ) (u₀ := u₀) (u₁ := u₁) z.2
+        (pg_eval_on_Z (F := F) R z.1).eval P = 0 ∧
+          (Bivariate.evalX z.1 H).eval (P.eval x₀) = 0
+
 /-- Claim 5.7 of [BCIKS20].
 
 The separability conjunct is separability of `R(x₀,·,Z)` **over the fraction field** `F(Z)`, which
@@ -34,53 +60,71 @@ discriminant to be a unit, and it fails for genuine factors at legitimate Claim 
 `𝔽₅`, `R = Z·Y² + Z·Y + (Z + X)` at `x₀ = 0` gives `R(0, Y, Z) = Z·(Y² + Y + 1)`, which shares the
 factor `Z` with its `Y`-derivative.
 
-Claim 5.6 supplies the *unspecialized* condition `discY R (x₀) ≠ 0`; deriving this conjunct from it
-is the disc-commutes-with-specialization step, which needs the `Y`-leading coefficient of `R` to
-survive at `x₀`, and belongs to this claim's proof. -/
+The content-factor and good-specialization obligations are supplied explicitly by
+`Claim57Assumptions`; see its docstring. -/
 lemma exists_factors_with_large_common_root_set (δ : ℚ) (x₀ : F)
-  (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
-  ∃ R H, R ∈ (irreducible_factorization_of_gs_solution h_gs).choose_spec.choose ∧
-    Irreducible H ∧ 0 < H.natDegree ∧ H ∣ (Bivariate.evalX (Polynomial.C x₀) R) ∧
+  (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+  (h57 : Claim57Assumptions k x₀ δ h_gs) :
+  ∃ R H,
+    R ∈ pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
+      (u₀ := u₀) (u₁ := u₁) h_gs ∧
+    H ∈ pg_positiveDegreeFactors (Bivariate.evalX (Polynomial.C x₀) R) ∧
     ((Bivariate.evalX (Polynomial.C x₀) R).map
       (ToRatFunc.univPolyHom (F := F))).Separable ∧
-    #(@Set.toFinset _ { z : coeffs_of_close_proximity (F := F) k ωs δ u₀ u₁ |
+    (#(@Set.toFinset _ { z : coeffs_of_close_proximity (F := F) k ωs δ u₀ u₁ |
         letI Pz := Pz z.2
         (Trivariate.eval_on_Z R z.1).eval Pz = 0 ∧
-        (Bivariate.evalX z.1 H).eval (Pz.eval x₀) = 0} (Fintype.ofFinite _))
-    ≥ #(coeffs_of_close_proximity k ωs δ u₀ u₁) / (Bivariate.natDegreeY Q)
-    ∧ #(coeffs_of_close_proximity k ωs δ u₀ u₁) / (Bivariate.natDegreeY Q) >
-      2 * D_Y Q ^ 2 * (D_X ((k + 1 : ℚ) / n) n m) * D_YZ Q := by sorry
+        (Bivariate.evalX z.1 H).eval (Pz.eval x₀) = 0} (Fintype.ofFinite _)) : ℝ)
+      ≥ (#(coeffs_of_close_proximity k ωs δ u₀ u₁) : ℝ) / Bivariate.natDegreeY Q ∧
+    (#(coeffs_of_close_proximity k ωs δ u₀ u₁) : ℝ) / Bivariate.natDegreeY Q >
+      2 * D_Y Q * (D_Y Q + 1) * (D_X ((k + 1 : ℚ) / n) n m) * D_YZ Q := by sorry
 
-/-- Claim 5.7 establishes existens of a polynomial `R`. his is the extraction of this polynomial. -/
-noncomputable def R (δ : ℚ) (x₀ : F) (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) : F[Z][X][Y] :=
- (exists_factors_with_large_common_root_set k δ x₀ h_gs).choose
+/-- The polynomial `R` extracted from Claim 5.7. -/
+noncomputable def R (δ : ℚ) (x₀ : F) (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs) : F[Z][X][Y] :=
+ (exists_factors_with_large_common_root_set k δ x₀ h_gs h57).choose
 
-/-- Claim 5.7 establishes existens of a polynomial `H`. This is the extraction of this polynomial.
--/
-noncomputable def H (δ : ℚ) (x₀ : F) (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) : F[Z][X] :=
-(exists_factors_with_large_common_root_set k δ x₀ h_gs).choose_spec.choose
+/-- The polynomial `H` extracted from Claim 5.7. -/
+noncomputable def H (δ : ℚ) (x₀ : F) (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs) : F[Z][X] :=
+(exists_factors_with_large_common_root_set k δ x₀ h_gs h57).choose_spec.choose
 
 /-- An important property of the polynomial `H` extracted from Claim 5.7 is that it is irreducible.
 -/
-lemma irreducible_H (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) : Irreducible (H k δ x₀ h_gs) :=
-  (exists_factors_with_large_common_root_set k δ x₀ h_gs).choose_spec.choose_spec.2.1
+lemma irreducible_H (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs) : Irreducible (H k δ x₀ h_gs h57) := by
+  have hmem :=
+    (exists_factors_with_large_common_root_set k δ x₀ h_gs h57).choose_spec.choose_spec.2.1
+  simp only [pg_positiveDegreeFactors] at hmem
+  exact UniqueFactorizationMonoid.irreducible_of_normalized_factor
+    (a := Bivariate.evalX (Polynomial.C x₀) (R k δ x₀ h_gs h57))
+    (H k δ x₀ h_gs h57) (Multiset.mem_filter.mp hmem).1
 
 /-- The factor `H` extracted from Claim 5.7 has positive degree in the `Y` variable, matching the
 Appendix A hypotheses needed for the function field construction. -/
-lemma natDegree_H_pos (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
-    0 < (H k δ x₀ h_gs).natDegree :=
-  (exists_factors_with_large_common_root_set k δ x₀ h_gs).choose_spec.choose_spec.2.2.1
+lemma natDegree_H_pos (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs) :
+    0 < (H k δ x₀ h_gs h57).natDegree :=
+  pg_natDegree_pos_of_mem_positiveDegreeFactors
+    (exists_factors_with_large_common_root_set k δ x₀ h_gs h57).choose_spec.choose_spec.2.1
 
 /-- The extracted `H` divides `R(x₀, Y, Z)`, as required for the Hensel setup in Claim A.2. -/
-lemma H_dvd_evalX_R (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
-    H k δ x₀ h_gs ∣ Bivariate.evalX (Polynomial.C x₀) (R k δ x₀ h_gs) :=
-  (exists_factors_with_large_common_root_set k δ x₀ h_gs).choose_spec.choose_spec.2.2.2.1
+lemma H_dvd_evalX_R (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs) :
+    H k δ x₀ h_gs h57 ∣ Bivariate.evalX (Polynomial.C x₀) (R k δ x₀ h_gs h57) :=
+  by
+    apply UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors
+    have hmem :=
+      (exists_factors_with_large_common_root_set k δ x₀ h_gs h57).choose_spec.choose_spec.2.1
+    simp only [pg_positiveDegreeFactors] at hmem
+    exact (Multiset.mem_filter.mp hmem).1
 
 /-- The specialization `R(x₀, Y, Z)` is separable in `Y` over `F(Z)`, as required for Claim A.2. -/
-lemma evalX_R_separable_over_ratFunc (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
-    ((Bivariate.evalX (Polynomial.C x₀) (R k δ x₀ h_gs)).map
+lemma evalX_R_separable_over_ratFunc (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs) :
+    ((Bivariate.evalX (Polynomial.C x₀) (R k δ x₀ h_gs h57)).map
       (ToRatFunc.univPolyHom (F := F))).Separable :=
-  (exists_factors_with_large_common_root_set k δ x₀ h_gs).choose_spec.choose_spec.2.2.2.2.1
+  (exists_factors_with_large_common_root_set k δ x₀ h_gs h57).choose_spec.choose_spec.2.2.1
 
 open RationalFunctions.HenselNumerators in
 /-- The Claim A.2 hypotheses satisfied by the `R,H` pair extracted from Claim 5.7.
@@ -102,26 +146,36 @@ condition cannot be obtained from Claim 5.7:
 So §5 has to case-split on `deg_Y R`.  In the `= 1` branch the Hensel machinery is not needed at
 all: `R = R₁·Y + R₀` has the single rational root `γ = -R₀/R₁`, and Claim 5.9's conclusion should
 be reached directly.  The `≥ 2` branch is the one that consumes the weight bounds. -/
-lemma hensel_lift_hypotheses (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
-    Hypotheses x₀ (R k δ x₀ h_gs) (H k δ x₀ h_gs) :=
-  ⟨H_dvd_evalX_R k h_gs, evalX_R_separable_over_ratFunc k h_gs⟩
+lemma hensel_lift_hypotheses (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs) :
+    Hypotheses x₀ (R k δ x₀ h_gs h57) (H k δ x₀ h_gs h57) :=
+  ⟨H_dvd_evalX_R k h_gs h57, evalX_R_separable_over_ratFunc k h_gs h57⟩
 
 open RationalFunctions.HenselNumerators in
 /-- Claim 5.8 from [BCIKS20].
 States that the approximate solution is actually a solution. This version of the claim is stated in
-terms of coefficients. -/
+terms of coefficients.
+
+This is the branch of the §5 argument that genuinely needs the Appendix A weight machinery.  If
+the selected factor has `Y`-degree one, the desired rational root is available directly and this
+branch should be bypassed.  The two total-degree hypotheses record the factor bounds required by
+the weight lemmas; they are not consequences of `ModifiedGuruswami`'s interface alone. -/
 lemma approximate_solution_is_exact_solution_coeffs
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs)
+    (_hR_degree_at_least_two : 2 ≤ Bivariate.natDegreeY (R k δ x₀ h_gs h57))
+    (_hR_totalDegree_le : Bivariate.totalDegree (R k δ x₀ h_gs h57) ≤ D_YZ Q)
+    (_hH_totalDegree_le : Bivariate.totalDegree (H k δ x₀ h_gs h57) ≤ D_YZ Q)
     : ∀ t > k,
     alpha'
       x₀
-      (R k δ x₀ h_gs)
-      (irreducible_H k h_gs)
-      (natDegree_H_pos k h_gs)
-      (hensel_lift_hypotheses k h_gs)
+      (R k δ x₀ h_gs h57)
+      (irreducible_H k h_gs h57)
+      (natDegree_H_pos k h_gs h57)
+      (hensel_lift_hypotheses k h_gs h57)
       t
     =
-    (0 : RationalFunctions.𝕃 (H k δ x₀ h_gs))
+    (0 : RationalFunctions.𝕃 (H k δ x₀ h_gs h57))
     := by sorry
 
 open RationalFunctions.HenselNumerators in
@@ -131,19 +185,23 @@ This version is in terms of polynomials.
 -/
 lemma approximate_solution_is_exact_solution_coeffs'
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs)
+    (_hR_degree_at_least_two : 2 ≤ Bivariate.natDegreeY (R k δ x₀ h_gs h57))
+    (_hR_totalDegree_le : Bivariate.totalDegree (R k δ x₀ h_gs h57) ≤ D_YZ Q)
+    (_hH_totalDegree_le : Bivariate.totalDegree (H k δ x₀ h_gs h57) ≤ D_YZ Q)
     :
-    gamma' x₀ (R k δ x₀ h_gs) (irreducible_H k h_gs) (natDegree_H_pos k h_gs)
-        (hensel_lift_hypotheses k h_gs) =
+    gamma' x₀ (R k δ x₀ h_gs h57) (irreducible_H k h_gs h57)
+        (natDegree_H_pos k h_gs h57) (hensel_lift_hypotheses k h_gs h57) =
         PowerSeries.mk (fun t =>
           if t > k
-          then (0 : RationalFunctions.𝕃 (H k δ x₀ h_gs))
+          then (0 : RationalFunctions.𝕃 (H k δ x₀ h_gs h57))
           else PowerSeries.coeff t
             (gamma'
               x₀
-              (R k (x₀ := x₀) (δ := δ) h_gs)
-              (irreducible_H k h_gs)
-              (natDegree_H_pos k h_gs)
-              (hensel_lift_hypotheses k h_gs))) := by
+              (R k (x₀ := x₀) (δ := δ) h_gs h57)
+              (irreducible_H k h_gs h57)
+              (natDegree_H_pos k h_gs h57)
+              (hensel_lift_hypotheses k h_gs h57))) := by
    sorry
 
 open RationalFunctions.HenselNumerators in
@@ -151,22 +209,35 @@ open RationalFunctions.HenselNumerators in
 States that the solution `γ` is linear in the variable `Z`. -/
 lemma solution_gamma_is_linear_in_Z
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs)
+    (_hR_degree_at_least_two : 2 ≤ Bivariate.natDegreeY (R k δ x₀ h_gs h57))
+    (_hR_totalDegree_le : Bivariate.totalDegree (R k δ x₀ h_gs h57) ≤ D_YZ Q)
+    (_hH_totalDegree_le : Bivariate.totalDegree (H k δ x₀ h_gs h57) ≤ D_YZ Q)
     :
   ∃ (v₀ v₁ : F[X]),
-    gamma' x₀ (R k δ x₀ h_gs) (irreducible_H k (x₀ := x₀) (δ := δ) h_gs)
-      (natDegree_H_pos k (x₀ := x₀) (δ := δ) h_gs)
-      (hensel_lift_hypotheses k (x₀ := x₀) (δ := δ) h_gs) =
+    gamma' x₀ (R k δ x₀ h_gs h57)
+      (irreducible_H k (x₀ := x₀) (δ := δ) h_gs h57)
+      (natDegree_H_pos k (x₀ := x₀) (δ := δ) h_gs h57)
+      (hensel_lift_hypotheses k (x₀ := x₀) (δ := δ) h_gs h57) =
         RationalFunctions.polyToPowerSeries𝕃 _
           (
             (Polynomial.map Polynomial.C v₀) +
             (Polynomial.C Polynomial.X) * (Polynomial.map Polynomial.C v₁)
           ) := by sorry
 
-/-- The linear represenation of the solution `γ` extracted from Claim 5.9. -/
-noncomputable def P (δ : ℚ) (x₀ : F) (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) : F[Z][X] :=
-  let v₀ := Classical.choose (solution_gamma_is_linear_in_Z k (δ := δ) (x₀ := x₀) h_gs)
+/-- The linear representation of the solution `γ` extracted from Claim 5.9. -/
+noncomputable def P (δ : ℚ) (x₀ : F) (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs)
+    (hR_degree_at_least_two : 2 ≤ Bivariate.natDegreeY (R k δ x₀ h_gs h57))
+    (hR_totalDegree_le : Bivariate.totalDegree (R k δ x₀ h_gs h57) ≤ D_YZ Q)
+    (hH_totalDegree_le : Bivariate.totalDegree (H k δ x₀ h_gs h57) ≤ D_YZ Q) : F[Z][X] :=
+  let v₀ := Classical.choose
+    (solution_gamma_is_linear_in_Z k (δ := δ) (x₀ := x₀) h_gs h57
+      hR_degree_at_least_two hR_totalDegree_le hH_totalDegree_le)
   let v₁ := Classical.choose
-    (Classical.choose_spec <| solution_gamma_is_linear_in_Z k (δ := δ) (x₀ := x₀) h_gs)
+    (Classical.choose_spec <|
+      solution_gamma_is_linear_in_Z k (δ := δ) (x₀ := x₀) h_gs h57
+        hR_degree_at_least_two hR_totalDegree_le hH_totalDegree_le)
   (
     (Polynomial.map Polynomial.C v₀) +
     (Polynomial.C Polynomial.X) * (Polynomial.map Polynomial.C v₁)
@@ -174,51 +245,60 @@ noncomputable def P (δ : ℚ) (x₀ : F) (h_gs : ModifiedGuruswami m n k ωs Q 
 
 open RationalFunctions.HenselNumerators in
 /-- The extracted `P` from Claim 5.9 equals `γ`. -/
-lemma gamma_eq_P (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
-  gamma' x₀ (R k δ x₀ h_gs) (irreducible_H k (x₀ := x₀) (δ := δ) h_gs)
-    (natDegree_H_pos k (x₀ := x₀) (δ := δ) h_gs)
-    (hensel_lift_hypotheses k (x₀ := x₀) (δ := δ) h_gs) =
+lemma gamma_eq_P (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs)
+    (hR_degree_at_least_two : 2 ≤ Bivariate.natDegreeY (R k δ x₀ h_gs h57))
+    (hR_totalDegree_le : Bivariate.totalDegree (R k δ x₀ h_gs h57) ≤ D_YZ Q)
+    (hH_totalDegree_le : Bivariate.totalDegree (H k δ x₀ h_gs h57) ≤ D_YZ Q) :
+  gamma' x₀ (R k δ x₀ h_gs h57)
+    (irreducible_H k (x₀ := x₀) (δ := δ) h_gs h57)
+    (natDegree_H_pos k (x₀ := x₀) (δ := δ) h_gs h57)
+    (hensel_lift_hypotheses k (x₀ := x₀) (δ := δ) h_gs h57) =
   RationalFunctions.polyToPowerSeries𝕃 _
-    (P k δ x₀ h_gs) :=
+    (P k δ x₀ h_gs h57 hR_degree_at_least_two hR_totalDegree_le hH_totalDegree_le) :=
   Classical.choose_spec
-    (Classical.choose_spec (solution_gamma_is_linear_in_Z k (δ := δ) (x₀ := x₀) h_gs))
+    (Classical.choose_spec
+      (solution_gamma_is_linear_in_Z k (δ := δ) (x₀ := x₀) h_gs h57
+        hR_degree_at_least_two hR_totalDegree_le hH_totalDegree_le))
 
 /-- The set `S'_x` from [BCIKS20] (just before Claim 5.10). The set of all `z ∈ S'` such that
 `w(x,z)` matches `P_z(x)`. -/
 noncomputable def matching_set_at_x
     (δ : ℚ)
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
-    (hS : 0 < #(coeffs_of_close_proximity k ωs δ u₀ u₁))
+    (h57 : Claim57Assumptions k x₀ δ h_gs)
     (x : Fin n)
-    : Finset F := @Set.toFinset _ {z : F | ∃ h : z ∈ matching_set k ωs δ u₀ u₁ h_gs hS,
+    : Finset F := @Set.toFinset _ {z : F |
+      ∃ h : z ∈ matching_set k ωs δ u₀ u₁ h_gs h57.regime,
     u₀ x + z * u₁ x =
-      (Pz (matching_set_is_a_sub_of_coeffs_of_close_proximity k h_gs hS h)).eval (ωs x)}
+      (Pz (matching_set_is_a_sub_of_coeffs_of_close_proximity k h_gs h57.regime h)).eval (ωs x)}
     (Fintype.ofFinite _)
 
 /-- Claim 5.10 of [BCIKS20].
 Needed to prove Claim 5.9. This claim states that `γ(x) = w(x,Z)` if the cardinality `|S'_x|` is big
 enough.
 
-The threshold carries `dY + 1` where the paper writes `dY`.  It has to: the paper reaches
+The threshold carries `dY + 1` where the paper writes `dY`.  This is the conservative bound
+currently supplied by the repaired Appendix A estimate: the paper reaches
 `|S'_x| > (2k+1)·dH·dY·D ≥ dH·Λ(β̃(x))` from Claim A.2's `Λ(βₜ) ≤ (2t+1)·dY·D`, and that bound is
-short by the content charge — see `RationalFunctions.HenselNumerators.contentWeight`.  With the
-charge accounted for, the available bound is `(2t+1)·(dY+1)·D`
-(`numeratorShapeSharp_le_loose`), so the hypothesis has to be strengthened to match.  Concretely at
-`dY = 2`, `dH = 2`, `D = 100`, `k = 10` the paper's threshold is `4200` while the true weight can
-reach `4822`. -/
+short as a proof after adding the content charge.  The available proved bound is
+`(2t+1)·(dY+1)·D` (`numeratorShapeSharpContent_le_loose`).  This statement uses that sufficient
+threshold without asserting that the extra `+1` is mathematically necessary. -/
 lemma solution_gamma_matches_word_if_subset_large
     {ωs : Fin n ↪ F}
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (h57 : Claim57Assumptions k x₀ δ h_gs)
+    (hR_degree_at_least_two : 2 ≤ Bivariate.natDegreeY (R k δ x₀ h_gs h57))
+    (hR_totalDegree_le : Bivariate.totalDegree (R k δ x₀ h_gs h57) ≤ D_YZ Q)
+    (hH_totalDegree_le : Bivariate.totalDegree (H k δ x₀ h_gs h57) ≤ D_YZ Q)
     {x : Fin n}
-    {D : ℕ}
-    (hS : 0 < #(coeffs_of_close_proximity k ωs δ u₀ u₁))
-    (hD : D ≥ Bivariate.totalDegree (H k δ x₀ h_gs))
-    (hx : (matching_set_at_x k δ h_gs hS x).card >
+    (hx : (matching_set_at_x k δ h_gs h57 x).card >
       (2 * k + 1)
-        * (Bivariate.natDegreeY <| H k δ x₀ h_gs)
-        * (Bivariate.natDegreeY (R k δ x₀ h_gs) + 1)
-        * D)
-    : (P k δ x₀ h_gs).eval (Polynomial.C (ωs x)) =
+        * (Bivariate.natDegreeY <| H k δ x₀ h_gs h57)
+        * (Bivariate.natDegreeY (R k δ x₀ h_gs h57) + 1)
+        * D_YZ Q)
+    : (P k δ x₀ h_gs h57 hR_degree_at_least_two hR_totalDegree_le
+        hH_totalDegree_le).eval (Polynomial.C (ωs x)) =
       (Polynomial.C <| u₀ x) + u₁ x • Polynomial.X
     := by sorry
 
@@ -228,19 +308,18 @@ Claim 5.10. -/
 lemma exists_points_with_large_matching_subset
     {ωs : Fin n ↪ F}
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
-    {x : Fin n}
-    {D : ℕ}
-    (hS : 0 < #(coeffs_of_close_proximity k ωs δ u₀ u₁))
-    (hD : D ≥ Bivariate.totalDegree (H k δ x₀ h_gs))
-    :
+    (h57 : Claim57Assumptions k x₀ δ h_gs)
+    (_hR_degree_at_least_two : 2 ≤ Bivariate.natDegreeY (R k δ x₀ h_gs h57))
+    (_hR_totalDegree_le : Bivariate.totalDegree (R k δ x₀ h_gs h57) ≤ D_YZ Q)
+    (_hH_totalDegree_le : Bivariate.totalDegree (H k δ x₀ h_gs h57) ≤ D_YZ Q) :
   ∃ Dtop : Finset (Fin n),
     Dtop.card = k + 1 ∧
     ∀ x ∈ Dtop,
-      (matching_set_at_x k δ h_gs hS x).card >
+      (matching_set_at_x k δ h_gs h57 x).card >
         (2 * k + 1)
-        * (Bivariate.natDegreeY <| H k δ x₀ h_gs)
-        * (Bivariate.natDegreeY (R k δ x₀ h_gs) + 1)
-        * D := by sorry
+        * (Bivariate.natDegreeY <| H k δ x₀ h_gs h57)
+        * (Bivariate.natDegreeY (R k δ x₀ h_gs h57) + 1)
+        * D_YZ Q := by sorry
 
 end BCIKS20ProximityGapSection5
 

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Agreement.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Agreement.lean
@@ -24,12 +24,25 @@ variable {m : ℕ} (k : ℕ) {δ : ℚ} {x₀ : F} {u₀ u₁ : Fin n → F} {Q 
 
 open Trivariate in
 open Bivariate in
-/-- Claim 5.7 of [BCIKS20]. -/
+/-- Claim 5.7 of [BCIKS20].
+
+The separability conjunct is separability of `R(x₀,·,Z)` **over the fraction field** `F(Z)`, which
+is what the paper means by "separable in `Y`" and exactly what the Hensel setup consumes
+(`RationalFunctions.HenselNumerators.Hypotheses`).  It is not `Polynomial.Separable` over `F[Z]`:
+that is `IsCoprime f f.derivative` in the ambient ring, so over a non-field base it forces the
+discriminant to be a unit, and it fails for genuine factors at legitimate Claim 5.6 points — over
+`𝔽₅`, `R = Z·Y² + Z·Y + (Z + X)` at `x₀ = 0` gives `R(0, Y, Z) = Z·(Y² + Y + 1)`, which shares the
+factor `Z` with its `Y`-derivative.
+
+Claim 5.6 supplies the *unspecialized* condition `discY R (x₀) ≠ 0`; deriving this conjunct from it
+is the disc-commutes-with-specialization step, which needs the `Y`-leading coefficient of `R` to
+survive at `x₀`, and belongs to this claim's proof. -/
 lemma exists_factors_with_large_common_root_set (δ : ℚ) (x₀ : F)
   (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
   ∃ R H, R ∈ (irreducible_factorization_of_gs_solution h_gs).choose_spec.choose ∧
     Irreducible H ∧ 0 < H.natDegree ∧ H ∣ (Bivariate.evalX (Polynomial.C x₀) R) ∧
-    (Bivariate.evalX (Polynomial.C x₀) R).Separable ∧
+    ((Bivariate.evalX (Polynomial.C x₀) R).map
+      (ToRatFunc.univPolyHom (F := F))).Separable ∧
     #(@Set.toFinset _ { z : coeffs_of_close_proximity (F := F) k ωs δ u₀ u₁ |
         letI Pz := Pz z.2
         (Trivariate.eval_on_Z R z.1).eval Pz = 0 ∧
@@ -63,9 +76,10 @@ lemma H_dvd_evalX_R (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
     H k δ x₀ h_gs ∣ Bivariate.evalX (Polynomial.C x₀) (R k δ x₀ h_gs) :=
   (exists_factors_with_large_common_root_set k δ x₀ h_gs).choose_spec.choose_spec.2.2.2.1
 
-/-- The specialization `R(x₀, Y, Z)` is separable in `Y`, as required for Claim A.2. -/
-lemma evalX_R_separable (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
-    (Bivariate.evalX (Polynomial.C x₀) (R k δ x₀ h_gs)).Separable :=
+/-- The specialization `R(x₀, Y, Z)` is separable in `Y` over `F(Z)`, as required for Claim A.2. -/
+lemma evalX_R_separable_over_ratFunc (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
+    ((Bivariate.evalX (Polynomial.C x₀) (R k δ x₀ h_gs)).map
+      (ToRatFunc.univPolyHom (F := F))).Separable :=
   (exists_factors_with_large_common_root_set k δ x₀ h_gs).choose_spec.choose_spec.2.2.2.2.1
 
 open RationalFunctions.HenselNumerators in
@@ -90,7 +104,7 @@ all: `R = R₁·Y + R₀` has the single rational root `γ = -R₀/R₁`, and Cl
 be reached directly.  The `≥ 2` branch is the one that consumes the weight bounds. -/
 lemma hensel_lift_hypotheses (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
     Hypotheses x₀ (R k δ x₀ h_gs) (H k δ x₀ h_gs) :=
-  ⟨H_dvd_evalX_R k h_gs, evalX_R_separable k h_gs⟩
+  ⟨H_dvd_evalX_R k h_gs, evalX_R_separable_over_ratFunc k h_gs⟩
 
 open RationalFunctions.HenselNumerators in
 /-- Claim 5.8 from [BCIKS20].
@@ -174,25 +188,35 @@ lemma gamma_eq_P (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
 noncomputable def matching_set_at_x
     (δ : ℚ)
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (hS : 0 < #(coeffs_of_close_proximity k ωs δ u₀ u₁))
     (x : Fin n)
-    : Finset F := @Set.toFinset _ {z : F | ∃ h : z ∈ matching_set k ωs δ u₀ u₁ h_gs,
+    : Finset F := @Set.toFinset _ {z : F | ∃ h : z ∈ matching_set k ωs δ u₀ u₁ h_gs hS,
     u₀ x + z * u₁ x =
-      (Pz (matching_set_is_a_sub_of_coeffs_of_close_proximity k h_gs h)).eval (ωs x)}
+      (Pz (matching_set_is_a_sub_of_coeffs_of_close_proximity k h_gs hS h)).eval (ωs x)}
     (Fintype.ofFinite _)
 
 /-- Claim 5.10 of [BCIKS20].
 Needed to prove Claim 5.9. This claim states that `γ(x) = w(x,Z)` if the cardinality `|S'_x|` is big
-enough. -/
+enough.
+
+The threshold carries `dY + 1` where the paper writes `dY`.  It has to: the paper reaches
+`|S'_x| > (2k+1)·dH·dY·D ≥ dH·Λ(β̃(x))` from Claim A.2's `Λ(βₜ) ≤ (2t+1)·dY·D`, and that bound is
+short by the content charge — see `RationalFunctions.HenselNumerators.contentWeight`.  With the
+charge accounted for, the available bound is `(2t+1)·(dY+1)·D`
+(`numeratorShapeSharp_le_loose`), so the hypothesis has to be strengthened to match.  Concretely at
+`dY = 2`, `dH = 2`, `D = 100`, `k = 10` the paper's threshold is `4200` while the true weight can
+reach `4822`. -/
 lemma solution_gamma_matches_word_if_subset_large
     {ωs : Fin n ↪ F}
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
     {x : Fin n}
     {D : ℕ}
+    (hS : 0 < #(coeffs_of_close_proximity k ωs δ u₀ u₁))
     (hD : D ≥ Bivariate.totalDegree (H k δ x₀ h_gs))
-    (hx : (matching_set_at_x k δ h_gs x).card >
+    (hx : (matching_set_at_x k δ h_gs hS x).card >
       (2 * k + 1)
         * (Bivariate.natDegreeY <| H k δ x₀ h_gs)
-        * (Bivariate.natDegreeY <| R k δ x₀ h_gs)
+        * (Bivariate.natDegreeY (R k δ x₀ h_gs) + 1)
         * D)
     : (P k δ x₀ h_gs).eval (Polynomial.C (ωs x)) =
       (Polynomial.C <| u₀ x) + u₁ x • Polynomial.X
@@ -206,15 +230,16 @@ lemma exists_points_with_large_matching_subset
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
     {x : Fin n}
     {D : ℕ}
+    (hS : 0 < #(coeffs_of_close_proximity k ωs δ u₀ u₁))
     (hD : D ≥ Bivariate.totalDegree (H k δ x₀ h_gs))
     :
   ∃ Dtop : Finset (Fin n),
     Dtop.card = k + 1 ∧
     ∀ x ∈ Dtop,
-      (matching_set_at_x k δ h_gs x).card >
+      (matching_set_at_x k δ h_gs hS x).card >
         (2 * k + 1)
         * (Bivariate.natDegreeY <| H k δ x₀ h_gs)
-        * (Bivariate.natDegreeY <| R k δ x₀ h_gs)
+        * (Bivariate.natDegreeY (R k δ x₀ h_gs) + 1)
         * D := by sorry
 
 end BCIKS20ProximityGapSection5

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Extraction.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Extraction.lean
@@ -156,12 +156,6 @@ theorem pg_natDegree_pos_of_mem_positiveDegreeFactors {p : F[Z][X]} {H : F[Z][X]
   simpa [pg_positiveDegreeFactors] using (Multiset.of_mem_filter hH)
 
 omit [DecidableEq (RatFunc F)] [Finite F] in
-theorem pg_mem_normalizedFactors_of_mem_positiveDegreeFactors {p : F[Z][X]} {H : F[Z][X]}
-    (hH : H ∈ pg_positiveDegreeFactors p) :
-    H ∈ UniqueFactorizationMonoid.normalizedFactors p :=
-  Multiset.mem_of_mem_filter hH
-
-omit [DecidableEq (RatFunc F)] [Finite F] in
 /-- Every candidate pair has a second component of positive `Y`-degree.
 
 No separability hypothesis is needed now that `pg_candidatePairs` ranges over

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Extraction.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Extraction.lean
@@ -79,8 +79,15 @@ of the factorization (5.12), `discY(Rᵢ(X, Y, Z))(x₀) ≠ 0` **as an element 
 The specialisation is `X := x₀`. Since `Bivariate.discr_y R : F[Z][X]` carries `X` as its *outer*
 variable and `Z` as its inner one, this is `Polynomial.eval (Polynomial.C x₀)`, which leaves a
 polynomial in `Z`. (`Bivariate.evalX` evaluates the *inner* variable, so it would set `Z := x₀`
-here — the opposite of what the claim needs.) -/
-lemma discr_of_irred_components_nonzero (_h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
+here — the opposite of what the claim needs.)
+
+The degree hypothesis is the exact finite-field root-counting premise used by Claim 5.6.  In the
+paper it is derived from (5.3) and the formal discriminant-degree estimate; it cannot be obtained
+from `ModifiedGuruswami` alone. -/
+lemma discr_of_irred_components_nonzero (_h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (hdegree :
+      ((irreducible_factorization_of_gs_solution _h_gs).choose_spec.choose.map
+        Bivariate.discr_y).prod.natDegree < Nat.card F) :
     ∃ x₀ : F,
       ∀ R ∈ (irreducible_factorization_of_gs_solution _h_gs).choose_spec.choose,
       Polynomial.eval (Polynomial.C x₀) (Bivariate.discr_y R) ≠ 0 := by sorry
@@ -128,14 +135,14 @@ Claim 5.7's counting runs over these, since only they can serve as the `H` of th
 (`natDegree_H_pos`), and only for these is the count bounded by `natDegreeY Q` — see
 `pg_card_positiveDegreePairs_le_natDegreeY` and `pg_positiveDegreeFactors`.
 
-**Open obligation.**  `pg_exists_pair_for_z` produces a pair in `pg_candidatePairs`, not
+**Explicit bridge required downstream.**  `pg_exists_pair_for_z` produces a pair in
+`pg_candidatePairs`, not
 necessarily in this subset: a constant prime factor `C c` of `R(x₀,·,Z)` satisfies the vanishing
 condition exactly when `c(z) = 0`, which does happen.  Bridging the two therefore requires
 discarding the finitely many `z` annihilated by the content of `R(x₀,·,Z)`, which is part of Claim
-5.7's counting argument and is not available here.  Previously this bridge was obtained from
-ring-level `Polynomial.Separable` on the specialization, which excludes constant factors outright —
-but that hypothesis is unsatisfiable in the intended setting, so the obligation is recorded rather
-than discharged. -/
+5.7's counting argument.  `Claim57Assumptions.positive_pair_for_every_z` records this bridge until
+that finite exceptional-set argument is formalized.  Ring-level `Polynomial.Separable` would
+exclude constant factors, but is stronger than the source's fraction-field separability. -/
 noncomputable def pg_positiveDegreePairs
     (x₀ : F)
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
@@ -156,9 +163,37 @@ theorem pg_natDegree_pos_of_mem_positiveDegreeFactors {p : F[Z][X]} {H : F[Z][X]
   simpa [pg_positiveDegreeFactors] using (Multiset.of_mem_filter hH)
 
 omit [DecidableEq (RatFunc F)] [Finite F] in
-/-- Every candidate pair has a second component of positive `Y`-degree.
+/-- Under the stronger ring-level separability hypothesis, every normalized factor has positive
+degree.  This remains a useful general helper even though Claim 5.7 only supplies fraction-field
+separability and therefore uses the filtered variant above. -/
+theorem pg_natDegree_pos_of_mem_normalizedFactors_of_separable (p : F[Z][X])
+    (hp : p.Separable) {H : F[Z][X]}
+    (hH : H ∈ UniqueFactorizationMonoid.normalizedFactors p) :
+    0 < H.natDegree := by
+  have hH_irred : Irreducible H :=
+    UniqueFactorizationMonoid.irreducible_of_normalized_factor H hH
+  have hH_dvd : H ∣ p :=
+    UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hH
+  have hH_sep : H.Separable :=
+    Polynomial.Separable.of_dvd hp hH_dvd
+  by_contra hHdeg
+  have hHdeg0 : H.natDegree = 0 := Nat.eq_zero_of_not_pos hHdeg
+  have hconst : H = Polynomial.C (H.coeff 0) :=
+    Polynomial.eq_C_of_natDegree_eq_zero hHdeg0
+  have hsepC : (Polynomial.C (H.coeff 0) : F[Z][X]).Separable := by
+    exact hconst ▸ hH_sep
+  have hunitCoeff : IsUnit (H.coeff 0) :=
+    (Polynomial.separable_C (H.coeff 0)).1 hsepC
+  have hunitC : IsUnit (Polynomial.C (H.coeff 0) : F[Z][X]) :=
+    (Polynomial.isUnit_C).2 hunitCoeff
+  have hunit : IsUnit H := by
+    exact hconst.symm ▸ hunitC
+  exact hH_irred.not_isUnit hunit
 
-No separability hypothesis is needed now that `pg_candidatePairs` ranges over
+omit [DecidableEq (RatFunc F)] [Finite F] in
+/-- Every positive-degree candidate pair has a second component of positive `Y`-degree.
+
+No separability hypothesis is needed because `pg_positiveDegreePairs` ranges over
 `pg_positiveDegreeFactors`. -/
 theorem pg_positiveDegreePairs_snd_natDegree_pos (x₀ : F)
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
@@ -173,6 +208,30 @@ theorem pg_positiveDegreePairs_snd_natDegree_pos (x₀ : F)
         H ∈ pg_positiveDegreeFactors (Bivariate.evalX (Polynomial.C x₀) R) := by
     simpa [pg_positiveDegreePairs] using hmem
   exact pg_natDegree_pos_of_mem_positiveDegreeFactors h'.2
+
+omit [DecidableEq (RatFunc F)] [Finite F] in
+/-- The unfiltered candidate-pair API remains valid when callers really do have ring-level
+separability.  Claim 5.7 does not, so it uses `pg_positiveDegreePairs_snd_natDegree_pos`. -/
+theorem pg_candidatePairs_snd_natDegree_pos (x₀ : F)
+    (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (hsep : ∀ R : F[Z][X][Y],
+      R ∈ pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
+          (u₀ := u₀) (u₁ := u₁) h_gs →
+        (Bivariate.evalX (Polynomial.C x₀) R).Separable)
+    {R : F[Z][X][Y]} {H : F[Z][X]}
+    (hmem : (R, H) ∈ pg_candidatePairs (m := m) (n := n) (k := k) (ωs := ωs)
+      (Q := Q) (u₀ := u₀) (u₁ := u₁) x₀ h_gs) :
+    0 < H.natDegree := by
+  classical
+  have h' :
+      R ∈ pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
+          (u₀ := u₀) (u₁ := u₁) h_gs ∧
+        H ∈
+          UniqueFactorizationMonoid.normalizedFactors
+            (Bivariate.evalX (Polynomial.C x₀) R) := by
+    simpa [pg_candidatePairs] using hmem
+  exact pg_natDegree_pos_of_mem_normalizedFactors_of_separable
+    (Bivariate.evalX (Polynomial.C x₀) R) (hsep R h'.1) h'.2
 
 omit [DecidableEq (RatFunc F)] [Finite F] in
 /-- At most `p.natDegree` distinct factors of positive `Y`-degree.
@@ -222,6 +281,52 @@ theorem pg_card_positiveDegreeFactors_toFinset_le_natDegree (p : F[Z][X]) :
       Polynomial.natDegree_multiset_prod (t := s) hs0
     have hfin : #f.toFinset ≤ f.card := Multiset.toFinset_card_le (m := f)
     omega
+
+omit [DecidableEq (RatFunc F)] [Finite F] in
+/-- The corresponding unfiltered factor-count bound under ring-level separability.  Kept alongside
+the filtered theorem because the hypothesis is meaningful for other callers even though it is too
+strong for the BCIKS20 specialization. -/
+theorem pg_card_normalizedFactors_toFinset_le_natDegree (p : F[Z][X]) (hp : p.Separable) :
+    #((UniqueFactorizationMonoid.normalizedFactors p).toFinset) ≤ p.natDegree := by
+  classical
+  let s : Multiset (F[Z][X]) := UniqueFactorizationMonoid.normalizedFactors p
+  have hs0 : (0 : F[Z][X]) ∉ s := by
+    simpa [s] using (UniqueFactorizationMonoid.zero_notMem_normalizedFactors p)
+  have hp0 : p ≠ 0 := hp.ne_zero
+  have hpos : ∀ q ∈ s, 1 ≤ q.natDegree := by
+    intro q hq
+    have hq' : q ∈ UniqueFactorizationMonoid.normalizedFactors p := by
+      simpa [s] using hq
+    exact pg_natDegree_pos_of_mem_normalizedFactors_of_separable p hp hq'
+  have hcard_le_sum : s.card ≤ (s.map Polynomial.natDegree).sum := by
+    have : (∀ q ∈ s, 1 ≤ q.natDegree) → s.card ≤ (s.map Polynomial.natDegree).sum := by
+      refine Multiset.induction_on s ?_ ?_
+      · intro _
+        simp
+      · intro a t ih ht
+        have ha : 1 ≤ a.natDegree := ht a (by simp)
+        have ht' : ∀ q ∈ t, 1 ≤ q.natDegree := by
+          intro q hq
+          exact ht q (Multiset.mem_cons_of_mem hq)
+        have ih' : t.card ≤ (t.map Polynomial.natDegree).sum := ih ht'
+        have hstep : t.card + 1 ≤ (t.map Polynomial.natDegree).sum + a.natDegree :=
+          Nat.add_le_add ih' ha
+        simpa [Multiset.card_cons, Multiset.map_cons, Multiset.sum_cons, Nat.add_comm] using hstep
+    exact this hpos
+  have hassoc : Associated s.prod p := by
+    simpa [s] using (UniqueFactorizationMonoid.prod_normalizedFactors (a := p) hp0)
+  have hnatDegree_prod : s.prod.natDegree = p.natDegree := by
+    apply Polynomial.natDegree_eq_of_degree_eq
+    exact Polynomial.degree_eq_degree_of_associated hassoc
+  have hcard_le : s.card ≤ p.natDegree := by
+    have hnat : s.prod.natDegree = (s.map Polynomial.natDegree).sum :=
+      Polynomial.natDegree_multiset_prod (t := s) hs0
+    have h1 : s.card ≤ s.prod.natDegree := by
+      simpa [hnat.symm] using hcard_le_sum
+    simpa [hnatDegree_prod] using h1
+  have hfin : #s.toFinset ≤ p.natDegree :=
+    (Multiset.toFinset_card_le (m := s)).trans hcard_le
+  simpa [s] using hfin
 
 omit [DecidableEq F] [DecidableEq (RatFunc F)] [Finite F] in
 theorem pg_evalX_eq_map_evalRingHom (x₀ : F) (R : F[Z][X][Y]) :
@@ -538,7 +643,7 @@ omit [DecidableEq (RatFunc F)] [Finite F] in
 /-- The positive-degree candidate pairs number at most `natDegreeY Q`.
 
 No separability hypothesis: the bound now comes from filtering out the constant factors rather than
-from ring-level `Polynomial.Separable` on each specialization, which is unsatisfiable here — see
+from ring-level `Polynomial.Separable` on each specialization, which is too strong here — see
 `pg_positiveDegreeFactors` and `irreducible_factorization_of_gs_solution`. -/
 theorem pg_card_positiveDegreePairs_le_natDegreeY (x₀ : F)
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
@@ -608,6 +713,71 @@ theorem pg_card_positiveDegreePairs_le_natDegreeY (x₀ : F)
       (pg_sum_natDegreeY_Rset_le_natDegreeY_Q (m := m) (n := n) (k := k)
         (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs)
   -- Put everything together.
+  exact (hcard_biUnion.trans (hsum.trans hsum_Rset_le))
+
+omit [DecidableEq (RatFunc F)] [Finite F] in
+/-- The original unfiltered candidate-pair count under ring-level separability.  This theorem is
+valid and retained for callers that can supply its stronger hypothesis; the BCIKS20 path uses the
+filtered theorem above. -/
+theorem pg_card_candidatePairs_le_natDegreeY (x₀ : F) (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (hsep : ∀ R : F[Z][X][Y],
+    R ∈ pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs →
+      (Bivariate.evalX (Polynomial.C x₀) R).Separable) :
+  #(pg_candidatePairs (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
+      (u₀ := u₀) (u₁ := u₁) x₀ h_gs) ≤ Bivariate.natDegreeY Q := by
+  classical
+  set Rset : Finset F[Z][X][Y] :=
+    pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs with hRset
+  set t : F[Z][X][Y] → Finset (F[Z][X][Y] × F[Z][X]) := fun R ↦
+    (UniqueFactorizationMonoid.normalizedFactors
+        (Bivariate.evalX (Polynomial.C x₀) R)).toFinset.image (fun H ↦ (R, H)) with ht
+  have hcp :
+      pg_candidatePairs (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
+          (u₀ := u₀) (u₁ := u₁) x₀ h_gs = Rset.biUnion t := by
+    simp [pg_candidatePairs, pg_Rset, hRset, ht]
+  have hcard_biUnion :
+      #(pg_candidatePairs (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
+          (u₀ := u₀) (u₁ := u₁) x₀ h_gs) ≤ ∑ R ∈ Rset, #(t R) := by
+    simpa [hcp] using (Finset.card_biUnion_le (s := Rset) (t := t))
+  have hpoint : ∀ R : F[Z][X][Y], R ∈ Rset → #(t R) ≤ Bivariate.natDegreeY R := by
+    intro R hR
+    have hinj : Function.Injective (fun H : F[Z][X] ↦ (R, H)) := by
+      intro H1 H2 h
+      simpa using congrArg Prod.snd h
+    have hcard_image :
+        #(t R) =
+          #((UniqueFactorizationMonoid.normalizedFactors
+              (Bivariate.evalX (Polynomial.C x₀) R)).toFinset) := by
+      simpa [ht] using
+        (Finset.card_image_of_injective
+          (s := (UniqueFactorizationMonoid.normalizedFactors
+              (Bivariate.evalX (Polynomial.C x₀) R)).toFinset)
+          (f := fun H : F[Z][X] ↦ (R, H)) hinj)
+    have hR' : R ∈
+        pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs := by
+      simpa [hRset] using hR
+    have hcard_nf :
+        #((UniqueFactorizationMonoid.normalizedFactors
+            (Bivariate.evalX (Polynomial.C x₀) R)).toFinset)
+          ≤ (Bivariate.evalX (Polynomial.C x₀) R).natDegree :=
+      pg_card_normalizedFactors_toFinset_le_natDegree (F := F)
+        (p := (Bivariate.evalX (Polynomial.C x₀) R)) (hp := hsep R hR')
+    have hdeg : (Bivariate.evalX (Polynomial.C x₀) R).natDegree ≤ Bivariate.natDegreeY R :=
+      pg_natDegree_evalX_le_natDegreeY (F := F) x₀ R
+    calc
+      #(t R) =
+          #((UniqueFactorizationMonoid.normalizedFactors
+              (Bivariate.evalX (Polynomial.C x₀) R)).toFinset) := hcard_image
+      _ ≤ (Bivariate.evalX (Polynomial.C x₀) R).natDegree := hcard_nf
+      _ ≤ Bivariate.natDegreeY R := hdeg
+  have hsum : (∑ R ∈ Rset, #(t R)) ≤ ∑ R ∈ Rset, Bivariate.natDegreeY R := by
+    refine Finset.sum_le_sum ?_
+    intro R hR
+    exact hpoint R hR
+  have hsum_Rset_le : (∑ R ∈ Rset, Bivariate.natDegreeY R) ≤ Bivariate.natDegreeY Q := by
+    simpa [hRset] using
+      (pg_sum_natDegreeY_Rset_le_natDegreeY_Q (m := m) (n := n) (k := k)
+        (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs)
   exact (hcard_biUnion.trans (hsum.trans hsum_Rset_le))
 
 end BCIKS20ProximityGapSection5

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Extraction.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Extraction.lean
@@ -42,7 +42,16 @@ Considering `Q` as a polynomial in `Y` over `F[X, Z]`, it factors uniquely as
 `Q(X, Y, Z) = C(X, Z) * ∏ i, Rᵢ(X, Y ^ (p ^ fᵢ), Z) ^ eᵢ`
 
 where `p` is the characteristic of `F`, `fᵢ ≥ 0`, `eᵢ ≥ 1`, and each `Rᵢ` is irreducible and
-separable.
+separable in `Y`.
+
+Separability is recorded as `Bivariate.discr_y Rᵢ ≠ 0`, not as `Polynomial.Separable Rᵢ`.
+Mathlib's `Separable f` is `IsCoprime f f.derivative` in the ambient ring, so over the non-field
+base `F[Z][X]` it forces the discriminant to be a **unit** rather than nonzero — strictly stronger
+than
+[BCIKS20], which says only "this happens if `discY Ri (x0, Y, Z) ≠ 0`" (§5, after eq. 5.12), and
+false for genuine factors: over `𝔽₅` the irreducible `Rᵢ = Z·Y² + Z·Y + (Z + X)` has
+`discY Rᵢ = Z(-3Z - 4X)`, a non-unit.  Asking for `Polynomial.Separable` here would force every
+irreducible factor to have unit discriminant, which the paper never claims.
 
 The three lists are indexed *together*: the `i`-th factor pairs `R[i]` with its own exponents
 `f[i]` and `e[i]`. The product is therefore a single `List.zipWith` fold, not a product over
@@ -54,7 +63,7 @@ lemma irreducible_factorization_of_gs_solution
     R.length = f.length ∧
     f.length = e.length ∧
     (∀ eᵢ ∈ e, 1 ≤ eᵢ) ∧
-    (∀ Rᵢ ∈ R, Rᵢ.Separable) ∧
+    (∀ Rᵢ ∈ R, Bivariate.discr_y Rᵢ ≠ 0) ∧
     (∀ Rᵢ ∈ R, Irreducible Rᵢ) ∧
     Q = (Polynomial.C C) *
         (List.zipWith
@@ -93,6 +102,17 @@ theorem pg_Rset_irreducible (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
     simpa using hR
   exact UniqueFactorizationMonoid.irreducible_of_normalized_factor (a := Q) R hR'
 
+/-- The positive-`Y`-degree part of the factor multiset of `p`.
+
+[BCIKS20] eq. 5.12 splits the content off explicitly as the separate factor `C(X, Z)`, so the
+`Rᵢ` — and likewise the factors of the specialization that Claim 5.7 counts — are the factors of
+positive `Y`-degree.  Filtering is what makes `pg_card_positiveDegreeFactors_toFinset_le_natDegree`
+true: a constant prime such as `Z` is a legitimate normalized factor of `p : F[Z][X]` with
+`natDegree 0`, so an unfiltered count is not bounded by `p.natDegree` at all (take
+`p = Z · W · (Y + 1)` with `Z, W` distinct primes: three factors, `natDegree 1`). -/
+noncomputable def pg_positiveDegreeFactors (p : F[Z][X]) : Multiset F[Z][X] :=
+  (UniqueFactorizationMonoid.normalizedFactors p).filter (fun q => 0 < q.natDegree)
+
 noncomputable def pg_candidatePairs
     (x₀ : F)
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
@@ -102,97 +122,112 @@ noncomputable def pg_candidatePairs
     (UniqueFactorizationMonoid.normalizedFactors
         (Bivariate.evalX (Polynomial.C x₀) R)).toFinset.image (fun H => (R, H)))
 
-omit [DecidableEq (RatFunc F)] [Finite F] in
-theorem pg_natDegree_pos_of_mem_normalizedFactors_of_separable (p : F[Z][X])
-    (hp : p.Separable) {H : F[Z][X]}
-    (hH : H ∈ UniqueFactorizationMonoid.normalizedFactors p) :
-    0 < H.natDegree := by
-  have hH_irred : Irreducible H :=
-    UniqueFactorizationMonoid.irreducible_of_normalized_factor H hH
-  have hH_dvd : H ∣ p :=
-    UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hH
-  have hH_sep : H.Separable :=
-    Polynomial.Separable.of_dvd hp hH_dvd
-  by_contra hHdeg
-  have hHdeg0 : H.natDegree = 0 := Nat.eq_zero_of_not_pos hHdeg
-  have hconst : H = Polynomial.C (H.coeff 0) :=
-    Polynomial.eq_C_of_natDegree_eq_zero hHdeg0
-  have hsepC : (Polynomial.C (H.coeff 0) : F[Z][X]).Separable := by
-    exact hconst ▸ hH_sep
-  have hunitCoeff : IsUnit (H.coeff 0) :=
-    (Polynomial.separable_C (H.coeff 0)).1 hsepC
-  have hunitC : IsUnit (Polynomial.C (H.coeff 0) : F[Z][X]) :=
-    (Polynomial.isUnit_C).2 hunitCoeff
-  have hunit : IsUnit H := by
-    exact hconst.symm ▸ hunitC
-  exact hH_irred.not_isUnit hunit
+/-- The candidate pairs whose second component has positive `Y`-degree.
+
+Claim 5.7's counting runs over these, since only they can serve as the `H` of the Hensel setup
+(`natDegree_H_pos`), and only for these is the count bounded by `natDegreeY Q` — see
+`pg_card_positiveDegreePairs_le_natDegreeY` and `pg_positiveDegreeFactors`.
+
+**Open obligation.**  `pg_exists_pair_for_z` produces a pair in `pg_candidatePairs`, not
+necessarily in this subset: a constant prime factor `C c` of `R(x₀,·,Z)` satisfies the vanishing
+condition exactly when `c(z) = 0`, which does happen.  Bridging the two therefore requires
+discarding the finitely many `z` annihilated by the content of `R(x₀,·,Z)`, which is part of Claim
+5.7's counting argument and is not available here.  Previously this bridge was obtained from
+ring-level `Polynomial.Separable` on the specialization, which excludes constant factors outright —
+but that hypothesis is unsatisfiable in the intended setting, so the obligation is recorded rather
+than discharged. -/
+noncomputable def pg_positiveDegreePairs
+    (x₀ : F)
+    (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
+    Finset (F[Z][X][Y] × F[Z][X]) :=
+  let Rset := pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs
+  Rset.biUnion (fun R =>
+    (pg_positiveDegreeFactors
+        (Bivariate.evalX (Polynomial.C x₀) R)).toFinset.image (fun H => (R, H)))
 
 omit [DecidableEq (RatFunc F)] [Finite F] in
-theorem pg_candidatePairs_snd_natDegree_pos (x₀ : F)
+/-- Members of `pg_positiveDegreeFactors` have positive `Y`-degree, by construction.
+
+This replaces a derivation of the same conclusion from `Polynomial.Separable p`, which is not
+available: see `pg_positiveDegreeFactors` and `irreducible_factorization_of_gs_solution`. -/
+theorem pg_natDegree_pos_of_mem_positiveDegreeFactors {p : F[Z][X]} {H : F[Z][X]}
+    (hH : H ∈ pg_positiveDegreeFactors p) :
+    0 < H.natDegree := by
+  simpa [pg_positiveDegreeFactors] using (Multiset.of_mem_filter hH)
+
+omit [DecidableEq (RatFunc F)] [Finite F] in
+theorem pg_mem_normalizedFactors_of_mem_positiveDegreeFactors {p : F[Z][X]} {H : F[Z][X]}
+    (hH : H ∈ pg_positiveDegreeFactors p) :
+    H ∈ UniqueFactorizationMonoid.normalizedFactors p :=
+  Multiset.mem_of_mem_filter hH
+
+omit [DecidableEq (RatFunc F)] [Finite F] in
+/-- Every candidate pair has a second component of positive `Y`-degree.
+
+No separability hypothesis is needed now that `pg_candidatePairs` ranges over
+`pg_positiveDegreeFactors`. -/
+theorem pg_positiveDegreePairs_snd_natDegree_pos (x₀ : F)
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
-    (hsep : ∀ R : F[Z][X][Y],
-      R ∈ pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
-          (u₀ := u₀) (u₁ := u₁) h_gs →
-        (Bivariate.evalX (Polynomial.C x₀) R).Separable)
     {R : F[Z][X][Y]} {H : F[Z][X]}
-    (hmem : (R, H) ∈ pg_candidatePairs (m := m) (n := n) (k := k) (ωs := ωs)
+    (hmem : (R, H) ∈ pg_positiveDegreePairs (m := m) (n := n) (k := k) (ωs := ωs)
       (Q := Q) (u₀ := u₀) (u₁ := u₁) x₀ h_gs) :
     0 < H.natDegree := by
   classical
   have h' :
       R ∈ pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
           (u₀ := u₀) (u₁ := u₁) h_gs ∧
-        H ∈
-          UniqueFactorizationMonoid.normalizedFactors
-            (Bivariate.evalX (Polynomial.C x₀) R) := by
-    simpa [pg_candidatePairs] using hmem
-  exact pg_natDegree_pos_of_mem_normalizedFactors_of_separable
-    (Bivariate.evalX (Polynomial.C x₀) R) (hsep R h'.1) h'.2
+        H ∈ pg_positiveDegreeFactors (Bivariate.evalX (Polynomial.C x₀) R) := by
+    simpa [pg_positiveDegreePairs] using hmem
+  exact pg_natDegree_pos_of_mem_positiveDegreeFactors h'.2
 
 omit [DecidableEq (RatFunc F)] [Finite F] in
-theorem pg_card_normalizedFactors_toFinset_le_natDegree (p : F[Z][X]) (hp : p.Separable) :
-    #((UniqueFactorizationMonoid.normalizedFactors p).toFinset) ≤ p.natDegree := by
+/-- At most `p.natDegree` distinct factors of positive `Y`-degree.
+
+Stated over `pg_positiveDegreeFactors`, and with no hypothesis at all.  The unfiltered count is not
+bounded by `p.natDegree` (see `pg_positiveDegreeFactors`), and the ring-level `Polynomial.Separable`
+that would have excluded the constant factors is not available here — see
+`irreducible_factorization_of_gs_solution`. -/
+theorem pg_card_positiveDegreeFactors_toFinset_le_natDegree (p : F[Z][X]) :
+    #((pg_positiveDegreeFactors p).toFinset) ≤ p.natDegree := by
   classical
-  let s : Multiset (F[Z][X]) := UniqueFactorizationMonoid.normalizedFactors p
-  have hs0 : (0 : F[Z][X]) ∉ s := by
-    simpa [s] using (UniqueFactorizationMonoid.zero_notMem_normalizedFactors p)
-  have hp0 : p ≠ 0 := hp.ne_zero
-  have hpos : ∀ q ∈ s, 1 ≤ q.natDegree := by
-    intro q hq
-    have hq' : q ∈ UniqueFactorizationMonoid.normalizedFactors p := by
-      simpa [s] using hq
-    exact pg_natDegree_pos_of_mem_normalizedFactors_of_separable p hp hq'
-  have hcard_le_sum : s.card ≤ (s.map Polynomial.natDegree).sum := by
-    -- prove a general statement by induction
-    have : (∀ q ∈ s, 1 ≤ q.natDegree) → s.card ≤ (s.map Polynomial.natDegree).sum := by
-      refine Multiset.induction_on s ?_ ?_
-      · intro _
-        simp
-      · intro a t ih ht
-        have ha : 1 ≤ a.natDegree := ht a (by simp)
-        have ht' : ∀ q ∈ t, 1 ≤ q.natDegree := by
-          intro q hq
-          exact ht q (Multiset.mem_cons_of_mem hq)
-        have ih' : t.card ≤ (t.map Polynomial.natDegree).sum := ih ht'
-        have hstep : t.card + 1 ≤ (t.map Polynomial.natDegree).sum + a.natDegree :=
-          Nat.add_le_add ih' ha
-        -- rewrite goal
-        simpa [Multiset.card_cons, Multiset.map_cons, Multiset.sum_cons, Nat.add_comm] using hstep
-    exact this hpos
-  have hassoc : Associated s.prod p := by
-    simpa [s] using (UniqueFactorizationMonoid.prod_normalizedFactors (a := p) hp0)
-  have hnatDegree_prod : s.prod.natDegree = p.natDegree := by
-    apply Polynomial.natDegree_eq_of_degree_eq
-    exact Polynomial.degree_eq_degree_of_associated hassoc
-  have hcard_le : s.card ≤ p.natDegree := by
+  by_cases hp0 : p = 0
+  · simp [pg_positiveDegreeFactors, hp0]
+  · set s : Multiset (F[Z][X]) := UniqueFactorizationMonoid.normalizedFactors p with hs
+    set f : Multiset (F[Z][X]) := pg_positiveDegreeFactors p with hf
+    have hfs : f ≤ s := by
+      rw [hf, hs, pg_positiveDegreeFactors]; exact Multiset.filter_le _ _
+    have hs0 : (0 : F[Z][X]) ∉ s := by
+      simpa [hs] using (UniqueFactorizationMonoid.zero_notMem_normalizedFactors p)
+    have hpos : ∀ q ∈ f, 1 ≤ q.natDegree := by
+      intro q hq
+      exact pg_natDegree_pos_of_mem_positiveDegreeFactors (by rwa [hf] at hq)
+    have hcard_le_sum : f.card ≤ (f.map Polynomial.natDegree).sum := by
+      have hgen : ∀ m : Multiset (F[Z][X]),
+          (∀ q ∈ m, 1 ≤ q.natDegree) → m.card ≤ (m.map Polynomial.natDegree).sum := by
+        intro m
+        refine Multiset.induction_on m ?_ ?_
+        · intro _
+          simp
+        · intro a t ih ht
+          have ha : 1 ≤ a.natDegree := ht a (by simp)
+          have ht' : ∀ q ∈ t, 1 ≤ q.natDegree := fun q hq => ht q (Multiset.mem_cons_of_mem hq)
+          have hstep : t.card + 1 ≤ (t.map Polynomial.natDegree).sum + a.natDegree :=
+            Nat.add_le_add (ih ht') ha
+          simpa [Multiset.card_cons, Multiset.map_cons, Multiset.sum_cons, Nat.add_comm]
+            using hstep
+      exact hgen f hpos
+    have hsum_le : (f.map Polynomial.natDegree).sum ≤ (s.map Polynomial.natDegree).sum := by
+      obtain ⟨u, hu⟩ := Multiset.le_iff_exists_add.mp hfs
+      rw [hu, Multiset.map_add, Multiset.sum_add]
+      exact Nat.le_add_right _ _
+    have hassoc : Associated s.prod p := by
+      simpa [hs] using (UniqueFactorizationMonoid.prod_normalizedFactors (a := p) hp0)
+    have hnatDegree_prod : s.prod.natDegree = p.natDegree :=
+      Polynomial.natDegree_eq_of_degree_eq (Polynomial.degree_eq_degree_of_associated hassoc)
     have hnat : s.prod.natDegree = (s.map Polynomial.natDegree).sum :=
       Polynomial.natDegree_multiset_prod (t := s) hs0
-    have h1 : s.card ≤ s.prod.natDegree := by
-      simpa [hnat.symm] using hcard_le_sum
-    simpa [hnatDegree_prod] using h1
-  have hfin : #s.toFinset ≤ p.natDegree :=
-    (Multiset.toFinset_card_le (m := s)).trans hcard_le
-  simpa [s] using hfin
+    have hfin : #f.toFinset ≤ f.card := Multiset.toFinset_card_le (m := f)
+    omega
 
 omit [DecidableEq F] [DecidableEq (RatFunc F)] [Finite F] in
 theorem pg_evalX_eq_map_evalRingHom (x₀ : F) (R : F[Z][X][Y]) :
@@ -506,12 +541,14 @@ theorem pg_sum_natDegreeY_Rset_le_natDegreeY_Q (h_gs : ModifiedGuruswami m n k �
   simpa [hnatY_assoc] using hleft_le_prod
 
 omit [DecidableEq (RatFunc F)] [Finite F] in
-theorem pg_card_candidatePairs_le_natDegreeY (x₀ : F) (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
-    (hsep : ∀ R : F[Z][X][Y],
-    R ∈ pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs →
-      (Bivariate.evalX (Polynomial.C x₀) R).Separable)
-    :
-  #(pg_candidatePairs (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
+/-- The positive-degree candidate pairs number at most `natDegreeY Q`.
+
+No separability hypothesis: the bound now comes from filtering out the constant factors rather than
+from ring-level `Polynomial.Separable` on each specialization, which is unsatisfiable here — see
+`pg_positiveDegreeFactors` and `irreducible_factorization_of_gs_solution`. -/
+theorem pg_card_positiveDegreePairs_le_natDegreeY (x₀ : F)
+    (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
+  #(pg_positiveDegreePairs (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
       (u₀ := u₀) (u₁ := u₁) x₀ h_gs) ≤ Bivariate.natDegreeY Q := by
   classical
   -- Shorthands for the set of candidate polynomials `R` and the corresponding set of
@@ -519,17 +556,17 @@ theorem pg_card_candidatePairs_le_natDegreeY (x₀ : F) (h_gs : ModifiedGuruswam
   set Rset : Finset F[Z][X][Y] :=
     pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs with hRset
   set t : F[Z][X][Y] → Finset (F[Z][X][Y] × F[Z][X]) := fun R =>
-    (UniqueFactorizationMonoid.normalizedFactors
+    (pg_positiveDegreeFactors
         (Bivariate.evalX (Polynomial.C x₀) R)).toFinset.image (fun H => (R, H)) with ht
   -- Unfold `pg_candidatePairs` as a `biUnion` over `Rset`.
   have hcp :
-      pg_candidatePairs (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
+      pg_positiveDegreePairs (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
           (u₀ := u₀) (u₁ := u₁) x₀ h_gs
         = Rset.biUnion t := by
-    simp [pg_candidatePairs, pg_Rset, hRset, ht]
+    simp [pg_positiveDegreePairs, pg_Rset, hRset, ht]
   -- Cardinality bound for a `biUnion`.
   have hcard_biUnion :
-      #(pg_candidatePairs (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
+      #(pg_positiveDegreePairs (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
           (u₀ := u₀) (u₁ := u₁) x₀ h_gs)
         ≤ ∑ R ∈ Rset, #(t R) := by
     simpa [hcp] using (Finset.card_biUnion_le (s := Rset) (t := t))
@@ -542,28 +579,28 @@ theorem pg_card_candidatePairs_le_natDegreeY (x₀ : F) (h_gs : ModifiedGuruswam
       simpa using congrArg Prod.snd h
     have hcard_image :
         #(t R) =
-          #((UniqueFactorizationMonoid.normalizedFactors
+          #((pg_positiveDegreeFactors
               (Bivariate.evalX (Polynomial.C x₀) R)).toFinset) := by
       simpa [ht] using
         (Finset.card_image_of_injective
-          (s := (UniqueFactorizationMonoid.normalizedFactors
+          (s := (pg_positiveDegreeFactors
               (Bivariate.evalX (Polynomial.C x₀) R)).toFinset)
           (f := fun H : F[Z][X] => (R, H)) hinj)
     have hR' : R ∈
         pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs := by
       simpa [hRset] using hR
     have hcard_nf :
-        #((UniqueFactorizationMonoid.normalizedFactors
+        #((pg_positiveDegreeFactors
             (Bivariate.evalX (Polynomial.C x₀) R)).toFinset)
           ≤ (Bivariate.evalX (Polynomial.C x₀) R).natDegree :=
-      pg_card_normalizedFactors_toFinset_le_natDegree (F := F)
-        (p := (Bivariate.evalX (Polynomial.C x₀) R)) (hp := hsep R hR')
+      pg_card_positiveDegreeFactors_toFinset_le_natDegree (F := F)
+        (p := (Bivariate.evalX (Polynomial.C x₀) R))
     have hdeg : (Bivariate.evalX (Polynomial.C x₀) R).natDegree ≤ Bivariate.natDegreeY R :=
       pg_natDegree_evalX_le_natDegreeY (F := F) x₀ R
     -- Combine the bounds.
     calc
       #(t R) =
-          #((UniqueFactorizationMonoid.normalizedFactors
+          #((pg_positiveDegreeFactors
               (Bivariate.evalX (Polynomial.C x₀) R)).toFinset) := hcard_image
       _ ≤ (Bivariate.evalX (Polynomial.C x₀) R).natDegree := hcard_nf
       _ ≤ Bivariate.natDegreeY R := hdeg

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Guruswami.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Guruswami.lean
@@ -420,22 +420,8 @@ private theorem symbolicGSPolyMultiplicityBridge {F : Type} [Field F] [Decidable
       (Polynomial.C (ωs i))
       (Polynomial.C (u₀ i) + Polynomial.X * Polynomial.C (u₁ i)) := by
   intro i
-  let g := Polynomial.Bivariate.shift (symbolicGSPoly (F := F) A c)
-    (Polynomial.C (ωs i))
-    (Polynomial.C (u₀ i) + Polynomial.X * Polynomial.C (u₁ i))
-  have hg : ∀ s t, s + t < m → Polynomial.Bivariate.coeff g s t = 0 := by
-    intro s t hst
-    exact hvan i s t hst
-  have H := (Polynomial.Bivariate.rootMultiplicity₀_ge_iff g m).mp hg
-  have hgne : g ≠ 0 := Polynomial.Bivariate.shift_ne_zero _ _ _ hQ
-  have hroot : Polynomial.Bivariate.rootMultiplicity₀ g ≠ none :=
-    Polynomial.Bivariate.rootMultiplicity₀_ne_none g hgne
-  change (some m : Option ℕ) ≤ Polynomial.Bivariate.rootMultiplicity₀ g
-  cases hr : Polynomial.Bivariate.rootMultiplicity₀ g with
-  | none => exact False.elim (hroot hr)
-  | some r =>
-      have hmr : m ≤ r := H r (by simp only [hr, Option.mem_def])
-      simpa only [hr, Option.some_le_some] using hmr
+  exact Polynomial.Bivariate.le_rootMultiplicity_of_coeff_shift_eq_zero
+    (Polynomial.Bivariate.shift_ne_zero _ _ _ hQ) (fun s t hst => hvan i s t hst)
 
 open scoped BigOperators in
 private theorem symbolicGSPoly_eq_sum {F : Type} [Field F]
@@ -1131,12 +1117,18 @@ that set, with `degX P ≤ k` and `degZ P ≤ 1`.
 The three conjuncts are (5.9), (5.10) and (5.11) of [BCIKS20]. Note that (5.11) is *not* under the
 `∀ z ∈ S'` binder in the paper, and that (5.9) is a division of reals; both are reflected here.
 
-Still missing relative to the paper: the standing hypothesis on `#S` from Theorem 5.1 (eq. 5.3).
-Without it the statement is false whenever `coeffs_of_close_proximity = ∅` — then `S' ⊆ ∅` forces
-`#S' = 0`, while (5.9) demands `#S' > 0`. Separately, `ModifiedGuruswami` permits `D_Y Q = 0`, and
-there `2 * D_Y Q = 0` makes the right-hand side of (5.9) zero rather than the paper's `+∞`. -/
+`hS` is the residue of the standing hypothesis on `#S` that §5.2 inherits from Theorem 5.1
+(eq. 5.3): §5.2 runs under the assumption that correlated agreement has already failed, so `#S` is
+large.  The rendering dropped it, and without it the statement is false — at `δ < 0`, or for words
+far from the code, `coeffs_of_close_proximity` is empty, `S' ⊆ ∅` forces `#S' = 0`, and (5.9)
+demands `#S' > 0`.  Nonemptiness is the weakest form that restores provability, so that is what is
+assumed here rather than the paper's quantitative bound.
+
+`ModifiedGuruswami` still permits `D_Y Q = 0`; with real division the right-hand side of (5.9) is
+then `0` rather than the paper's `+∞`, which under `hS` is harmless. -/
 lemma exists_a_set_and_a_matching_polynomial
-    (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
+    (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (hS : 0 < #(coeffs_of_close_proximity k ωs δ u₀ u₁)) :
     ∃ S', ∃ (h_sub : S' ⊆ coeffs_of_close_proximity k ωs δ u₀ u₁), ∃ P : F[Z][X],
      (#S' : ℝ) > #(coeffs_of_close_proximity k ωs δ u₀ u₁) / (2 * D_Y Q) ∧
      (∀ z : S', Pz (h_sub z.2) = P.map (Polynomial.evalRingHom z.1)) ∧
@@ -1144,17 +1136,19 @@ lemma exists_a_set_and_a_matching_polynomial
      Bivariate.degreeX P ≤ 1 := by
     sorry
 
-/-- The subset `S'` extracted from Proprosition 5.5 [BCIKS20]. -/
+/-- The subset `S'` extracted from Proposition 5.5 [BCIKS20]. -/
 noncomputable def matching_set (ωs : Fin n ↪ F) (δ : ℚ) (u₀ u₁ : Fin n → F)
-  (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) : Finset F :=
-  (exists_a_set_and_a_matching_polynomial k h_gs (δ := δ)).choose
+  (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+  (hS : 0 < #(coeffs_of_close_proximity k ωs δ u₀ u₁)) : Finset F :=
+  (exists_a_set_and_a_matching_polynomial k h_gs hS (δ := δ)).choose
 
 omit [DecidableEq (RatFunc F)] in
 /-- `S'` is indeed a subset of `S` -/
 lemma matching_set_is_a_sub_of_coeffs_of_close_proximity
-    (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
-    matching_set k ωs δ u₀ u₁ h_gs ⊆ coeffs_of_close_proximity k ωs δ u₀ u₁ :=
-  (exists_a_set_and_a_matching_polynomial k h_gs (δ := δ)).choose_spec.choose
+    (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
+    (hS : 0 < #(coeffs_of_close_proximity k ωs δ u₀ u₁)) :
+    matching_set k ωs δ u₀ u₁ h_gs hS ⊆ coeffs_of_close_proximity k ωs δ u₀ u₁ :=
+  (exists_a_set_and_a_matching_polynomial k h_gs hS (δ := δ)).choose_spec.choose
 
 end BCIKS20ProximityGapSection5
 

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Guruswami.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Guruswami.lean
@@ -420,8 +420,22 @@ private theorem symbolicGSPolyMultiplicityBridge {F : Type} [Field F] [Decidable
       (Polynomial.C (ωs i))
       (Polynomial.C (u₀ i) + Polynomial.X * Polynomial.C (u₁ i)) := by
   intro i
-  exact Polynomial.Bivariate.le_rootMultiplicity_of_coeff_shift_eq_zero
-    (Polynomial.Bivariate.shift_ne_zero _ _ _ hQ) (fun s t hst => hvan i s t hst)
+  let g := Polynomial.Bivariate.shift (symbolicGSPoly (F := F) A c)
+    (Polynomial.C (ωs i))
+    (Polynomial.C (u₀ i) + Polynomial.X * Polynomial.C (u₁ i))
+  have hg : ∀ s t, s + t < m → Polynomial.Bivariate.coeff g s t = 0 := by
+    intro s t hst
+    exact hvan i s t hst
+  have H := (Polynomial.Bivariate.rootMultiplicity₀_ge_iff g m).mp hg
+  have hgne : g ≠ 0 := Polynomial.Bivariate.shift_ne_zero _ _ _ hQ
+  have hroot : Polynomial.Bivariate.rootMultiplicity₀ g ≠ none :=
+    Polynomial.Bivariate.rootMultiplicity₀_ne_none g hgne
+  change (some m : Option ℕ) ≤ Polynomial.Bivariate.rootMultiplicity₀ g
+  cases hr : Polynomial.Bivariate.rootMultiplicity₀ g with
+  | none => exact False.elim (hroot hr)
+  | some r =>
+      have hmr : m ≤ r := H r (by simp only [hr, Option.mem_def])
+      simpa only [hr, Option.some_le_some] using hmr
 
 open scoped BigOperators in
 private theorem symbolicGSPoly_eq_sum {F : Type} [Field F]
@@ -1081,6 +1095,30 @@ noncomputable instance {α : Type} (s : Set α) [inst : Finite s] : Fintype s :=
 noncomputable def coeffs_of_close_proximity (ωs : Fin n ↪ F) (δ : ℚ) (u₀ u₁ : Fin n → F)
     : Finset F := Set.toFinset { z | ∃ v : ReedSolomon.code ωs (k + 1), δᵣ(u₀ + z • u₁, v) ≤ δ}
 
+/-- The standing numerical hypotheses for [BCIKS20] §5.2.
+
+The paper works throughout with `m ≥ 3`, rate strictly below one, `δ` in the list-decoding
+radius, and the quantitative lower bound (5.8) on the set `S`.  Those assumptions were previously
+dropped from the individual Lean statements.  In particular, replacing (5.8) merely by `0 < #S`
+does not justify Claims 5.6, 5.7, or 5.11.
+
+The last field is a conservative, content-aware strengthening of (5.8): the paper has
+`2·D_Y³·D_X·D_YZ`, while the proved Appendix A bound currently costs
+`2·D_Y²·(D_Y+1)·D_X·D_YZ`.  This is sufficient for the repaired weight estimate; no claim is
+made that the extra `+1` is necessary. -/
+structure Section5Regime
+    (m n k : ℕ) (ωs : Fin n ↪ F) (Q : F[Z][X][Y]) (u₀ u₁ : Fin n → F) (δ : ℚ)
+    (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) : Prop where
+  m_ge_three : 3 ≤ m
+  rate_lt_one : k + 1 < n
+  delta_nonnegative : 0 ≤ δ
+  delta_le_radius : (δ : ℝ) ≤ _root_.proximity_gap_johnson (k + 1) n m
+  D_Y_pos : 0 < Trivariate.D_Y Q
+  S_large :
+    (#(coeffs_of_close_proximity k ωs δ u₀ u₁) : ℝ) >
+      2 * Trivariate.D_Y Q ^ 2 * (Trivariate.D_Y Q + 1) *
+        D_X ((k + 1 : ℚ) / n) n m * Trivariate.D_YZ Q
+
 open Polynomial
 
 omit [DecidableEq (RatFunc F)] in
@@ -1117,18 +1155,13 @@ that set, with `degX P ≤ k` and `degZ P ≤ 1`.
 The three conjuncts are (5.9), (5.10) and (5.11) of [BCIKS20]. Note that (5.11) is *not* under the
 `∀ z ∈ S'` binder in the paper, and that (5.9) is a division of reals; both are reflected here.
 
-`hS` is the residue of the standing hypothesis on `#S` that §5.2 inherits from Theorem 5.1
-(eq. 5.3): §5.2 runs under the assumption that correlated agreement has already failed, so `#S` is
-large.  The rendering dropped it, and without it the statement is false — at `δ < 0`, or for words
-far from the code, `coeffs_of_close_proximity` is empty, `S' ⊆ ∅` forces `#S' = 0`, and (5.9)
-demands `#S' > 0`.  Nonemptiness is the weakest form that restores provability, so that is what is
-assumed here rather than the paper's quantitative bound.
-
-`ModifiedGuruswami` still permits `D_Y Q = 0`; with real division the right-hand side of (5.9) is
-then `0` rather than the paper's `+∞`, which under `hS` is harmless. -/
+The `Section5Regime` argument restores the standing hypotheses that §5.2 inherits from Theorem
+5.1.  It is load-bearing: nonemptiness alone neither supplies the counting inequalities used later
+nor rules out `D_Y Q = 0`.  The latter case makes real division in (5.9) evaluate to zero and makes
+the downstream factor/Hensel argument collapse. -/
 lemma exists_a_set_and_a_matching_polynomial
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
-    (hS : 0 < #(coeffs_of_close_proximity k ωs δ u₀ u₁)) :
+    (hReg : Section5Regime m n k ωs Q u₀ u₁ δ h_gs) :
     ∃ S', ∃ (h_sub : S' ⊆ coeffs_of_close_proximity k ωs δ u₀ u₁), ∃ P : F[Z][X],
      (#S' : ℝ) > #(coeffs_of_close_proximity k ωs δ u₀ u₁) / (2 * D_Y Q) ∧
      (∀ z : S', Pz (h_sub z.2) = P.map (Polynomial.evalRingHom z.1)) ∧
@@ -1139,16 +1172,16 @@ lemma exists_a_set_and_a_matching_polynomial
 /-- The subset `S'` extracted from Proposition 5.5 [BCIKS20]. -/
 noncomputable def matching_set (ωs : Fin n ↪ F) (δ : ℚ) (u₀ u₁ : Fin n → F)
   (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
-  (hS : 0 < #(coeffs_of_close_proximity k ωs δ u₀ u₁)) : Finset F :=
-  (exists_a_set_and_a_matching_polynomial k h_gs hS (δ := δ)).choose
+  (hReg : Section5Regime m n k ωs Q u₀ u₁ δ h_gs) : Finset F :=
+  (exists_a_set_and_a_matching_polynomial k h_gs hReg (δ := δ)).choose
 
 omit [DecidableEq (RatFunc F)] in
 /-- `S'` is indeed a subset of `S` -/
 lemma matching_set_is_a_sub_of_coeffs_of_close_proximity
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
-    (hS : 0 < #(coeffs_of_close_proximity k ωs δ u₀ u₁)) :
-    matching_set k ωs δ u₀ u₁ h_gs hS ⊆ coeffs_of_close_proximity k ωs δ u₀ u₁ :=
-  (exists_a_set_and_a_matching_polynomial k h_gs hS (δ := δ)).choose_spec.choose
+    (hReg : Section5Regime m n k ωs Q u₀ u₁ δ h_gs) :
+    matching_set k ωs δ u₀ u₁ h_gs hReg ⊆ coeffs_of_close_proximity k ωs δ u₀ u₁ :=
+  (exists_a_set_and_a_matching_polynomial k h_gs hReg (δ := δ)).choose_spec.choose
 
 end BCIKS20ProximityGapSection5
 

--- a/ArkLib/Data/Polynomial/Bivariate.lean
+++ b/ArkLib/Data/Polynomial/Bivariate.lean
@@ -483,43 +483,41 @@ theorem shift_ne_zero {R : Type} [CommRing R]
     (Polynomial.map_eq_zero_iff hφ).mp hs
   exact hf (Polynomial.comp_X_add_C_eq_zero_iff.mp hcomp)
 
-/-- A nonzero bivariate polynomial has a well-defined multiplicity at the origin: some
-coefficient in the truncation grid is nonzero, so the defining `min?` is over a nonempty list. -/
+/-- A nonzero bivariate polynomial has a well-defined multiplicity at the origin.
+
+The argument runs `rootMultiplicity₀_ge_iff` backwards: were the multiplicity `none`, its
+right-hand side `∀ m ∈ none, r ≤ m` would hold vacuously for *every* `r`, forcing every
+coefficient to vanish. -/
 theorem rootMultiplicity₀_ne_none {R : Type} [CommSemiring R] [DecidableEq R]
     (g : Polynomial (Polynomial R)) (hg : g ≠ 0) :
     Polynomial.Bivariate.rootMultiplicity₀ g ≠ none := by
-  obtain ⟨t, ht⟩ : ∃ t, g.coeff t ≠ 0 := by
+  obtain ⟨i, j, hij⟩ : ∃ i j, Polynomial.Bivariate.coeff g i j ≠ 0 := by
     by_contra h
-    push Not at h
-    exact hg (Polynomial.ext h)
-  obtain ⟨s, hs⟩ : ∃ s, (g.coeff t).coeff s ≠ 0 := by
-    by_contra h
-    push Not at h
-    exact ht (Polynomial.ext h)
-  have htmem : t ∈ g.support := Polynomial.mem_support_iff.mpr ht
-  have hsle : s ≤ (g.coeff t).natDegree := Polynomial.le_natDegree_of_ne_zero hs
-  have htotal : (g.coeff t).natDegree + t ≤
-      Polynomial.Bivariate.natWeightedDegree g 1 1 := by
-    simpa only [Polynomial.Bivariate.natWeightedDegree, one_mul] using
-      (Finset.le_sup (f := fun j => (g.coeff j).natDegree + j) htmem)
-  have hslt : s < Polynomial.Bivariate.natWeightedDegree g 1 1 + 1 := by omega
-  have htlt : t < Polynomial.Bivariate.natWeightedDegree g 1 1 + 1 := by omega
-  intro hnone
-  simp only [Polynomial.Bivariate.rootMultiplicity₀,
-    Polynomial.Bivariate.weightedDegree_eq_natWeightedDegree] at hnone
-  have hempty := List.min?_eq_none_iff.mp hnone
-  have hmem : s + t ∈ List.filterMap
-      (fun p : ℕ × ℕ => if Polynomial.Bivariate.coeff g p.1 p.2 = 0
-        then none else some (p.1 + p.2))
-      (List.product
-        (List.range (Polynomial.Bivariate.natWeightedDegree g 1 1 + 1))
-        (List.range (Polynomial.Bivariate.natWeightedDegree g 1 1 + 1))) := by
-    rw [List.mem_filterMap]
-    refine ⟨(s,t), ?_, ?_⟩
-    · exact List.mem_product.mpr ⟨List.mem_range.mpr hslt, List.mem_range.mpr htlt⟩
-    · simp only [Polynomial.Bivariate.coeff, hs, if_false]
-  rw [hempty] at hmem
-  simp at hmem
+    simp only [not_exists, ne_eq, not_not] at h
+    exact hg (Polynomial.ext fun j ↦ Polynomial.ext fun i ↦ by
+      simpa [Polynomial.Bivariate.coeff] using h i j)
+  exact fun hnone ↦
+    hij ((Polynomial.Bivariate.rootMultiplicity₀_ge_iff g (i + j + 1)).mpr (by simp [hnone])
+      i j (by omega))
+
+/-- The `(x, y)`-vanishing order of `g` is at least `m`, provided the shifted polynomial is
+nonzero and each of its coefficients of total degree below `m` vanishes.
+
+`rootMultiplicity₀_ge_iff` on its own only yields `∀ r ∈ rootMultiplicity₀ _, m ≤ r`, which is
+vacuous exactly when the multiplicity is `none`; pairing it with `rootMultiplicity₀_ne_none`
+turns it into an inequality in `Option ℕ`. -/
+lemma le_rootMultiplicity_of_coeff_shift_eq_zero {R : Type} [CommSemiring R] [DecidableEq R]
+    {g : Polynomial (Polynomial R)} {x y : R} {m : ℕ}
+    (hg : Polynomial.Bivariate.shift g x y ≠ 0)
+    (h : ∀ i j, i + j < m →
+      Polynomial.Bivariate.coeff (Polynomial.Bivariate.shift g x y) i j = 0) :
+    (m : Option ℕ) ≤ Polynomial.Bivariate.rootMultiplicity g x y := by
+  obtain ⟨r, hr⟩ := Option.ne_none_iff_exists'.mp (rootMultiplicity₀_ne_none _ hg)
+  have hle : m ≤ r :=
+    (Polynomial.Bivariate.rootMultiplicity₀_ge_iff
+      (Polynomial.Bivariate.shift g x y) m).mp h r (by rw [hr]; rfl)
+  rw [Polynomial.Bivariate.rootMultiplicity, hr]
+  exact Option.some_le_some.mpr hle
 
 /-- The `Y`-degree is controlled by the `(1, k)`-weighted degree: each unit of `Y`-degree costs
 `k` units of weight. Stated natively over `ℕ`, with no division. -/

--- a/ArkLib/Data/Polynomial/Bivariate.lean
+++ b/ArkLib/Data/Polynomial/Bivariate.lean
@@ -483,41 +483,43 @@ theorem shift_ne_zero {R : Type} [CommRing R]
     (Polynomial.map_eq_zero_iff hφ).mp hs
   exact hf (Polynomial.comp_X_add_C_eq_zero_iff.mp hcomp)
 
-/-- A nonzero bivariate polynomial has a well-defined multiplicity at the origin.
-
-The argument runs `rootMultiplicity₀_ge_iff` backwards: were the multiplicity `none`, its
-right-hand side `∀ m ∈ none, r ≤ m` would hold vacuously for *every* `r`, forcing every
-coefficient to vanish. -/
+/-- A nonzero bivariate polynomial has a well-defined multiplicity at the origin: some
+coefficient in the truncation grid is nonzero, so the defining `min?` is over a nonempty list. -/
 theorem rootMultiplicity₀_ne_none {R : Type} [CommSemiring R] [DecidableEq R]
     (g : Polynomial (Polynomial R)) (hg : g ≠ 0) :
     Polynomial.Bivariate.rootMultiplicity₀ g ≠ none := by
-  obtain ⟨i, j, hij⟩ : ∃ i j, Polynomial.Bivariate.coeff g i j ≠ 0 := by
+  obtain ⟨t, ht⟩ : ∃ t, g.coeff t ≠ 0 := by
     by_contra h
-    simp only [not_exists, ne_eq, not_not] at h
-    exact hg (Polynomial.ext fun j ↦ Polynomial.ext fun i ↦ by
-      simpa [Polynomial.Bivariate.coeff] using h i j)
-  exact fun hnone ↦
-    hij ((Polynomial.Bivariate.rootMultiplicity₀_ge_iff g (i + j + 1)).mpr (by simp [hnone])
-      i j (by omega))
-
-/-- The `(x, y)`-vanishing order of `g` is at least `m`, provided the shifted polynomial is
-nonzero and each of its coefficients of total degree below `m` vanishes.
-
-`rootMultiplicity₀_ge_iff` on its own only yields `∀ r ∈ rootMultiplicity₀ _, m ≤ r`, which is
-vacuous exactly when the multiplicity is `none`; pairing it with `rootMultiplicity₀_ne_none`
-turns it into an inequality in `Option ℕ`. -/
-lemma le_rootMultiplicity_of_coeff_shift_eq_zero {R : Type} [CommSemiring R] [DecidableEq R]
-    {g : Polynomial (Polynomial R)} {x y : R} {m : ℕ}
-    (hg : Polynomial.Bivariate.shift g x y ≠ 0)
-    (h : ∀ i j, i + j < m →
-      Polynomial.Bivariate.coeff (Polynomial.Bivariate.shift g x y) i j = 0) :
-    (m : Option ℕ) ≤ Polynomial.Bivariate.rootMultiplicity g x y := by
-  obtain ⟨r, hr⟩ := Option.ne_none_iff_exists'.mp (rootMultiplicity₀_ne_none _ hg)
-  have hle : m ≤ r :=
-    (Polynomial.Bivariate.rootMultiplicity₀_ge_iff
-      (Polynomial.Bivariate.shift g x y) m).mp h r (by rw [hr]; rfl)
-  rw [Polynomial.Bivariate.rootMultiplicity, hr]
-  exact Option.some_le_some.mpr hle
+    push Not at h
+    exact hg (Polynomial.ext h)
+  obtain ⟨s, hs⟩ : ∃ s, (g.coeff t).coeff s ≠ 0 := by
+    by_contra h
+    push Not at h
+    exact ht (Polynomial.ext h)
+  have htmem : t ∈ g.support := Polynomial.mem_support_iff.mpr ht
+  have hsle : s ≤ (g.coeff t).natDegree := Polynomial.le_natDegree_of_ne_zero hs
+  have htotal : (g.coeff t).natDegree + t ≤
+      Polynomial.Bivariate.natWeightedDegree g 1 1 := by
+    simpa only [Polynomial.Bivariate.natWeightedDegree, one_mul] using
+      (Finset.le_sup (f := fun j => (g.coeff j).natDegree + j) htmem)
+  have hslt : s < Polynomial.Bivariate.natWeightedDegree g 1 1 + 1 := by omega
+  have htlt : t < Polynomial.Bivariate.natWeightedDegree g 1 1 + 1 := by omega
+  intro hnone
+  simp only [Polynomial.Bivariate.rootMultiplicity₀,
+    Polynomial.Bivariate.weightedDegree_eq_natWeightedDegree] at hnone
+  have hempty := List.min?_eq_none_iff.mp hnone
+  have hmem : s + t ∈ List.filterMap
+      (fun p : ℕ × ℕ => if Polynomial.Bivariate.coeff g p.1 p.2 = 0
+        then none else some (p.1 + p.2))
+      (List.product
+        (List.range (Polynomial.Bivariate.natWeightedDegree g 1 1 + 1))
+        (List.range (Polynomial.Bivariate.natWeightedDegree g 1 1 + 1))) := by
+    rw [List.mem_filterMap]
+    refine ⟨(s,t), ?_, ?_⟩
+    · exact List.mem_product.mpr ⟨List.mem_range.mpr hslt, List.mem_range.mpr htlt⟩
+    · simp only [Polynomial.Bivariate.coeff, hs, if_false]
+  rw [hempty] at hmem
+  simp at hmem
 
 /-- The `Y`-degree is controlled by the `(1, k)`-weighted degree: each unit of `Y`-degree costs
 `k` units of weight. Stated natively over `ℕ`, with no division. -/

--- a/ArkLib/Data/Polynomial/RationalFunctions.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions.lean
@@ -57,8 +57,8 @@ the specialization `R(x₀, Y, Z)`.
 * `HenselNumerators.IsHenselNumeratorSequence.unique` — uniqueness of the lift, which A.4 asserts
   and [BCIKS20] §5 invokes in Claim 5.9. It makes `betaSeq` canonical rather than an arbitrary
   choice.
-* `HenselNumerators.exists_hensel_numerators_with_weight_bounds` — Claim A.2 as the paper states
-  it: existence together with both weight bounds.
+* `HenselNumerators.exists_hensel_numerators_with_weight_bounds` — the corrected Claim A.2
+  package: existence together with the content-aware sharp and conservative loose bounds.
 
 Everything in this package is proved: no `sorry`, and no axioms beyond `propext`,
 `Classical.choice` and `Quot.sound`.
@@ -74,19 +74,22 @@ Everything in this package is proved: no `sorry`, and no axioms beyond `propext`
    a factor of `W` that the recursion *saves* is worth only `deg W` while one it *charges* costs
    the bound `D - dH`. See `numeratorShapeSharp`'s docstring for the full accounting.
 3. `xi_weight_le` carries a `contentWeight` summand that A.2's `Λ(ξ) ≤ (d-1)(D - dH + 1)` omits,
-   and consequently the loose bound is `(2t+1)·(d+1)·D` rather than the paper's `(2t+1)·d·D`.
+   and the proved uniform loose bound is consequently `(2t+1)·(d+1)·D` rather than the paper's
+   `(2t+1)·d·D`.
    This is the same disease as item 2 one level up: A.2's chain needs `Λ(W) = D - dH`, while the
    paper proves only `Λ(W) ≤ D - dH`, so the term of `ξ` whose `W`-power is negative can dominate.
    The gap is real, not an artefact of the formalization: over `𝔽₅` with
    `R = Z·Y² + Z·Y + (Z + X)`, `x₀ = 0`, `H = Y² + Y + 1`, `D = 3` — every A.4 hypothesis holds and
    `discY R = Z(-3Z - 4X)` makes `x₀ = 0` a legitimate Claim 5.6 point — the representative of `ξ`
    is `Z + 2Z·T`, of weight `3` against a stated bound of `2`. Consumers of the loose bound must
-   use the `d + 1` form; the affected §5 statements (`solution_gamma_matches_word_if_subset_large`,
-   `exists_points_with_large_matching_subset`) have been adjusted. See `contentWeight`.
+   currently use the proved `d + 1` form; this conservative weakening is not claimed to be optimal.
+   The affected §5 statements and their standing largeness assumption have been adjusted. See
+   `contentWeight`.
 
    Ring-level `Polynomial.Separable` in `Hypotheses` used to hide this, since it forces the
-   content of the specialization to be a unit; that hypothesis is unsatisfiable in the intended
-   application, so `Hypotheses` now asks for separability over `F(Z)`, the paper's actual meaning.
+   content of the specialization to be a unit.  That hypothesis is strictly stronger than the
+   intended application and excludes legitimate instances, so `Hypotheses` now asks for
+   separability over `F(Z)`, the paper's actual meaning.
 
 ## References
 

--- a/ArkLib/Data/Polynomial/RationalFunctions.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions.lean
@@ -72,8 +72,21 @@ Everything in this package is proved: no `sorry`, and no axioms beyond `propext`
    `Λ(ξ) = 1` against a claimed bound of `0`. Consumers must case-split on `deg_Y R`.
 2. `numeratorShapeSharp` carries a correction term relative to the inequality A.4 states, because
    a factor of `W` that the recursion *saves* is worth only `deg W` while one it *charges* costs
-   the bound `D - dH`. The loose bound `(2t+1)·d·D` is unaffected, so consumers of that bound see
-   no difference. See `numeratorShapeSharp`'s docstring for the full accounting.
+   the bound `D - dH`. See `numeratorShapeSharp`'s docstring for the full accounting.
+3. `xi_weight_le` carries a `contentWeight` summand that A.2's `Λ(ξ) ≤ (d-1)(D - dH + 1)` omits,
+   and consequently the loose bound is `(2t+1)·(d+1)·D` rather than the paper's `(2t+1)·d·D`.
+   This is the same disease as item 2 one level up: A.2's chain needs `Λ(W) = D - dH`, while the
+   paper proves only `Λ(W) ≤ D - dH`, so the term of `ξ` whose `W`-power is negative can dominate.
+   The gap is real, not an artefact of the formalization: over `𝔽₅` with
+   `R = Z·Y² + Z·Y + (Z + X)`, `x₀ = 0`, `H = Y² + Y + 1`, `D = 3` — every A.4 hypothesis holds and
+   `discY R = Z(-3Z - 4X)` makes `x₀ = 0` a legitimate Claim 5.6 point — the representative of `ξ`
+   is `Z + 2Z·T`, of weight `3` against a stated bound of `2`. Consumers of the loose bound must
+   use the `d + 1` form; the affected §5 statements (`solution_gamma_matches_word_if_subset_large`,
+   `exists_points_with_large_matching_subset`) have been adjusted. See `contentWeight`.
+
+   Ring-level `Polynomial.Separable` in `Hypotheses` used to hide this, since it forces the
+   content of the specialization to be a unit; that hypothesis is unsatisfiable in the intended
+   application, so `Hypotheses` now asks for separability over `F(Z)`, the paper's actual meaning.
 
 ## References
 

--- a/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Hensel.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Hensel.lean
@@ -745,8 +745,20 @@ theorem zeta_ne_zero_of_hypotheses (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
   have hderiv_evalX : Bivariate.evalX (Polynomial.C x₀) R.derivative = P.derivative := by
     ext i
     simp [P, derivative_evalX_coeff, Polynomial.coeff_derivative, Nat.cast_add, Nat.cast_one]
+  -- `liftToFunctionField` factors through `F(Z)`, so fraction-field separability is enough here.
+  set ψ : RatFunc F →+* 𝕃 H :=
+    (Ideal.Quotient.mk (Ideal.span {monicizeRatFunc H})).comp
+      (Polynomial.C : RatFunc F →+* Polynomial (RatFunc F)) with hψ
+  have hfactor : (liftToFunctionField (H := H)) = ψ.comp (univPolyHom (F := F)) :=
+    RingHom.ext fun c => by
+      simp only [hψ, RingHom.comp_apply, liftToFunctionField, coeffAsRatFunc,
+        ToRatFunc.bivPolyHom, Polynomial.coe_mapRingHom, Polynomial.map_C]
+  have hroot' : Polynomial.eval₂ ψ t (P.map (univPolyHom (F := F))) = 0 := by
+    rw [Polynomial.eval₂_map, ← hfactor]; exact hroot
   have hne : Polynomial.eval₂ (liftToFunctionField (H := H)) t P.derivative ≠ 0 := by
-    exact hHyp.separable_evalX.eval₂_derivative_ne_zero (liftToFunctionField (H := H)) hroot
+    have hsep := hHyp.separable_evalX.eval₂_derivative_ne_zero ψ hroot'
+    rw [Polynomial.derivative_map, Polynomial.eval₂_map, ← hfactor] at hsep
+    exact hsep
   simpa [zeta, P, t, hderiv_evalX] using hne
 
 /-- `formalHenselAlphaSequence` with its two hypotheses discharged from `Hypotheses`. -/

--- a/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Sequence.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Sequence.lean
@@ -268,7 +268,7 @@ lemma betaSeq_weight_sharp_le (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
         (WithBot.some (numeratorShapeSharpContent x₀ R H D t) : WithBot ℕ) :=
   hensel_numerator_weight_sharp_le x₀ R H hHyp hH hD_H hD_R hRdeg (betaSeq_spec x₀ R H hHyp)
 
-/-- The loose weight bound `Λ(βₜ) ≤ (2t+1)·dY·D` for the chosen numerator sequence. -/
+/-- The loose weight bound `Λ(βₜ) ≤ (2t+1)·(dY+1)·D` for the chosen numerator sequence. -/
 lemma betaSeq_weight_le (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     [φ : Fact (Irreducible H)] [H_natDegree_pos : Fact (0 < H.natDegree)]
     (hHyp : Hypotheses x₀ R H) (hH : 0 < H.natDegree)
@@ -294,7 +294,7 @@ lemma betaSeq_weight_sharp_le_defaultDegreeBound (x₀ : F) (R : F[X][X][Y]) (H 
   betaSeq_weight_sharp_le x₀ R H hHyp hH (defaultDegreeBound_ge_H R H)
     (fun _ hi => defaultDegreeBound_ge_R_coeff R H hi) hRdeg
 
-/-- The loose weight bound `Λ(βₜ) ≤ (2t+1)·dY·D` at the canonical degree bound. -/
+/-- The loose weight bound `Λ(βₜ) ≤ (2t+1)·(dY+1)·D` at the canonical degree bound. -/
 lemma betaSeq_weight_le_defaultDegreeBound (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     [φ : Fact (Irreducible H)] [H_natDegree_pos : Fact (0 < H.natDegree)]
     (hHyp : Hypotheses x₀ R H) (hH : 0 < H.natDegree)
@@ -310,10 +310,10 @@ lemma betaSeq_weight_le_defaultDegreeBound (x₀ : F) (R : F[X][X][Y]) (H : F[X]
 are regular `βₜ ∈ 𝒪` realizing the Hensel lift `αₜ = βₜ / (W^{t+1} ξ^{eₜ})`, with
 `eₜ = max(0, 2t-1)` and
 
-* `Λ(βₜ) ≤ 1 + (t+1)Λ(W) + eₜΛ(ξ)` (the sharp bound, the one that telescopes), and
-* `Λ(βₜ) ≤ (2t+1)·d·D` (the loose bound, which is what consumers usually want).
+* `Λ(βₜ) ≤ numeratorShapeSharpContent x₀ R H D t` (the corrected sharp bound), and
+* `Λ(βₜ) ≤ (2t+1)·(d+1)·D` (the conservative loose bound).
 
-The regularity of `ξ` and the bound `Λ(ξ) ≤ (d-1)(D - dH + 1)` are `xi_regular` and `xi_weight_le`.
+The regularity of `ξ` and its content-aware bound are `xi_regular` and `xi_weight_le`.
 Use `exists_hensel_numerator_sequence` (existence only) when defining data: this bundled form
 carries the weight conjuncts and hence their proof dependencies. -/
 theorem exists_hensel_numerators_with_weight_bounds (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])

--- a/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Sequence.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Sequence.lean
@@ -265,7 +265,7 @@ lemma betaSeq_weight_sharp_le (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     (hRdeg : 2 ≤ Bivariate.natDegreeY R) :
     ∀ t : ℕ,
       regularWeight hH ((betaSeq x₀ R H hHyp) t) D ≤
-        (WithBot.some (numeratorShapeSharp x₀ R H D t) : WithBot ℕ) :=
+        (WithBot.some (numeratorShapeSharpContent x₀ R H D t) : WithBot ℕ) :=
   hensel_numerator_weight_sharp_le x₀ R H hHyp hH hD_H hD_R hRdeg (betaSeq_spec x₀ R H hHyp)
 
 /-- The loose weight bound `Λ(βₜ) ≤ (2t+1)·dY·D` for the chosen numerator sequence. -/
@@ -290,7 +290,7 @@ lemma betaSeq_weight_sharp_le_defaultDegreeBound (x₀ : F) (R : F[X][X][Y]) (H 
     (hRdeg : 2 ≤ Bivariate.natDegreeY R) :
     ∀ t : ℕ,
       regularWeight hH ((betaSeq x₀ R H hHyp) t) (defaultDegreeBound R H) ≤
-        (WithBot.some (numeratorShapeSharp x₀ R H (defaultDegreeBound R H) t) : WithBot ℕ) :=
+        (WithBot.some (numeratorShapeSharpContent x₀ R H (defaultDegreeBound R H) t) : WithBot ℕ) :=
   betaSeq_weight_sharp_le x₀ R H hHyp hH (defaultDegreeBound_ge_H R H)
     (fun _ hi => defaultDegreeBound_ge_R_coeff R H hi) hRdeg
 
@@ -325,7 +325,7 @@ theorem exists_hensel_numerators_with_weight_bounds (x₀ : F) (R : F[X][X][Y]) 
     ∃ βseq : ℕ → 𝒪 H,
       IsHenselNumeratorSequence x₀ R H hHyp βseq ∧
       (∀ t : ℕ, regularWeight hH (βseq t) D ≤
-        (WithBot.some (numeratorShapeSharp x₀ R H D t) : WithBot ℕ)) ∧
+        (WithBot.some (numeratorShapeSharpContent x₀ R H D t) : WithBot ℕ)) ∧
       ∀ t : ℕ, regularWeight hH (βseq t) D ≤
         (WithBot.some ((2 * t + 1) * (Bivariate.natDegreeY R + 1) * D) : WithBot ℕ) :=
   ⟨betaSeq x₀ R H hHyp, betaSeq_spec x₀ R H hHyp,

--- a/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Sequence.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Sequence.lean
@@ -265,7 +265,7 @@ lemma betaSeq_weight_sharp_le (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     (hRdeg : 2 ≤ Bivariate.natDegreeY R) :
     ∀ t : ℕ,
       regularWeight hH ((betaSeq x₀ R H hHyp) t) D ≤
-        (WithBot.some (numeratorShapeSharp R H D t) : WithBot ℕ) :=
+        (WithBot.some (numeratorShapeSharp x₀ R H D t) : WithBot ℕ) :=
   hensel_numerator_weight_sharp_le x₀ R H hHyp hH hD_H hD_R hRdeg (betaSeq_spec x₀ R H hHyp)
 
 /-- The loose weight bound `Λ(βₜ) ≤ (2t+1)·dY·D` for the chosen numerator sequence. -/
@@ -277,7 +277,7 @@ lemma betaSeq_weight_le (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     (hRdeg : 2 ≤ Bivariate.natDegreeY R) :
     ∀ t : ℕ,
       regularWeight hH ((betaSeq x₀ R H hHyp) t) D ≤
-        (WithBot.some ((2 * t + 1) * Bivariate.natDegreeY R * D) : WithBot ℕ) :=
+        (WithBot.some ((2 * t + 1) * (Bivariate.natDegreeY R + 1) * D) : WithBot ℕ) :=
   hensel_numerator_weight_le x₀ R H hHyp hH hD_H hD_R hRdeg (betaSeq_spec x₀ R H hHyp)
 
 /-- The sharp weight bound at the canonical degree bound `defaultDegreeBound R H`,
@@ -290,7 +290,7 @@ lemma betaSeq_weight_sharp_le_defaultDegreeBound (x₀ : F) (R : F[X][X][Y]) (H 
     (hRdeg : 2 ≤ Bivariate.natDegreeY R) :
     ∀ t : ℕ,
       regularWeight hH ((betaSeq x₀ R H hHyp) t) (defaultDegreeBound R H) ≤
-        (WithBot.some (numeratorShapeSharp R H (defaultDegreeBound R H) t) : WithBot ℕ) :=
+        (WithBot.some (numeratorShapeSharp x₀ R H (defaultDegreeBound R H) t) : WithBot ℕ) :=
   betaSeq_weight_sharp_le x₀ R H hHyp hH (defaultDegreeBound_ge_H R H)
     (fun _ hi => defaultDegreeBound_ge_R_coeff R H hi) hRdeg
 
@@ -301,7 +301,7 @@ lemma betaSeq_weight_le_defaultDegreeBound (x₀ : F) (R : F[X][X][Y]) (H : F[X]
     (hRdeg : 2 ≤ Bivariate.natDegreeY R) :
     ∀ t : ℕ,
       regularWeight hH ((betaSeq x₀ R H hHyp) t) (defaultDegreeBound R H) ≤
-        (WithBot.some ((2 * t + 1) * Bivariate.natDegreeY R * defaultDegreeBound R H) :
+        (WithBot.some ((2 * t + 1) * (Bivariate.natDegreeY R + 1) * defaultDegreeBound R H) :
           WithBot ℕ) :=
   betaSeq_weight_le x₀ R H hHyp hH (defaultDegreeBound_ge_H R H)
     (fun _ hi => defaultDegreeBound_ge_R_coeff R H hi) hRdeg
@@ -325,9 +325,9 @@ theorem exists_hensel_numerators_with_weight_bounds (x₀ : F) (R : F[X][X][Y]) 
     ∃ βseq : ℕ → 𝒪 H,
       IsHenselNumeratorSequence x₀ R H hHyp βseq ∧
       (∀ t : ℕ, regularWeight hH (βseq t) D ≤
-        (WithBot.some (numeratorShapeSharp R H D t) : WithBot ℕ)) ∧
+        (WithBot.some (numeratorShapeSharp x₀ R H D t) : WithBot ℕ)) ∧
       ∀ t : ℕ, regularWeight hH (βseq t) D ≤
-        (WithBot.some ((2 * t + 1) * Bivariate.natDegreeY R * D) : WithBot ℕ) :=
+        (WithBot.some ((2 * t + 1) * (Bivariate.natDegreeY R + 1) * D) : WithBot ℕ) :=
   ⟨betaSeq x₀ R H hHyp, betaSeq_spec x₀ R H hHyp,
     betaSeq_weight_sharp_le x₀ R H hHyp hH hD_H hD_R hRdeg,
     betaSeq_weight_le x₀ R H hHyp hH hD_H hD_R hRdeg⟩

--- a/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Setup.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Setup.lean
@@ -46,10 +46,25 @@ variable {F : Type} [Field F] {R : F[X][X][Y]} {H : F[X][Y]}
 /-! ### Hypotheses and derivative setup -/
 
 /-- The algebraic hypotheses for the Hensel lift, after specializing
-`R` at `X = x₀`. -/
+`R` at `X = x₀`.
+
+`separable_evalX` is separability **over the fraction field** `F(Z)`, which is what [BCIKS20]
+means by "separable in `Y`": Appendix A.4 spells it out as having no double roots "not only \dots
+over the fields over which they are defined, but over any extension field as well", and §5 records
+the equivalent form "this happens if `discY Ri (x0, Y, Z) ≠ 0`".
+
+It is *not* `Polynomial.Separable` over the coefficient ring `F[Z]`.  Mathlib's `Separable f` is
+`IsCoprime f f.derivative` in the ambient ring, which over a non-field base forces the
+discriminant to be a **unit** rather than merely nonzero.  That is strictly stronger than the
+paper's hypothesis and unsatisfiable in the intended application: at a legitimate Claim 5.6 point
+the specialization may acquire a content factor, e.g. over `𝔽₅` the irreducible
+`R = Z·Y² + Z·Y + (Z + X)` has `discY R = Z(-3Z - 4X)`, so `x₀ = 0` is admissible, yet
+`R(0, Y, Z) = Z·(Y² + Y + 1)` shares the factor `Z` with its `Y`-derivative and is therefore not
+ring-`Separable`. -/
 structure Hypotheses (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y]) : Prop where
   dvd_evalX : H ∣ Bivariate.evalX (Polynomial.C x₀) R
-  separable_evalX : (Bivariate.evalX (Polynomial.C x₀) R).Separable
+  separable_evalX :
+    ((Bivariate.evalX (Polynomial.C x₀) R).map (univPolyHom (F := F))).Separable
 
 private lemma evalX_natDegree_le {K : Type} [CommSemiring K] (x : K) (P : K[X][Y]) :
     (Bivariate.evalX x P).natDegree ≤ P.natDegree := by
@@ -58,11 +73,12 @@ private lemma evalX_natDegree_le {K : Type} [CommSemiring K] (x : K) (P : K[X][Y
   have hcoeff : P.coeff n = 0 := Polynomial.coeff_eq_zero_of_natDegree_lt hn
   simp [Bivariate.evalX_eq_map, Polynomial.coeff_map, hcoeff]
 
-/-- `R(x₀,·,Z)` is nonzero, since it is separable by hypothesis. -/
+/-- `R(x₀,·,Z)` is nonzero, since its image over `F(Z)` is separable by hypothesis. -/
 lemma evalX_ne_zero_of_hypotheses {x₀ : F} {R : F[X][X][Y]} {H : F[X][Y]}
     (hHyp : Hypotheses x₀ R H) :
-    Bivariate.evalX (Polynomial.C x₀) R ≠ 0 :=
-  hHyp.separable_evalX.ne_zero
+    Bivariate.evalX (Polynomial.C x₀) R ≠ 0 := by
+  intro h
+  exact hHyp.separable_evalX.ne_zero (by rw [h, Polynomial.map_zero])
 
 /-- `dH ≤ d`: the factor `H` cannot have larger `Y`-degree than `R`, since it divides
 `R(x₀,·,Z)`. -/
@@ -619,85 +635,76 @@ noncomputable def xiPreTop (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y]) : F[X][Y] :
   let W : F[X] := H.leadingCoeff
   Polynomial.C (P.coeff (d - 1) / W) * Polynomial.X ^ (d - 1)
 
+/-- The `Z`-degree contributed by the top coefficient of the explicit representative of `ξ`.
+
+Writing `R(x₀,·,Z) = H · Q`, in the case `dH = d` this is `deg_Z (d · Q₀)`: the `Z`-degree of the
+**content** that specializing `X := x₀` leaves in front of `H`, over and above the `Λ(W)` already
+charged for `H`'s own leading coefficient.
+
+## Why the term is there
+
+[BCIKS20] Claim A.2 states `Λ(ξ) ≤ (D - 1) + (d - 2)Λ(W) ≤ (d - 1)(D - dH + 1)`, with no such
+summand.  That chain needs `Λ(W) = D - dH`.  With `Λ(T) = D + 1 - dH` fixed by the `Λ`-grading of
+Appendix A.2, passing from the `T ^ j` term of `ξ` to the `T ^ (j + 1)` term changes the estimate
+by `-1 + Λ(T) - Λ(W) ≥ 0`, with equality exactly when `Λ(W) = D - dH`.  The paper proves only
+`Λ(W) ≤ D - dH`, so the `j = d - 1` term — the one whose `W`-power is negative, freed by
+`leadingCoeff_dvd_evalX_derivative_coeff_pred` — can dominate, exceeding the stated bound by
+precisely this content degree.
+
+Over `𝔽₅` take `R = Z·Y² + Z·Y + (Z + X)`, `x₀ = 0`, `H = Y² + Y + 1`, `D = 3`.  Every hypothesis
+of A.4 holds: `R` is irreducible, `discY R = Z(-3Z - 4X)` is nonzero at `x₀ = 0` so the point is a
+legitimate Claim 5.6 choice, and `D` bounds both total `Y, Z`-degrees.  The representative of `ξ`
+is `Z + 2Z·T`, of weight `3`, against a stated bound of `2`.
+
+The same error one level down is already corrected by `numeratorShapeSharp`'s `(t - 1)(D - dY)`
+summand; see its docstring for the identical "a saved `W` is only worth its exact degree"
+accounting.  Ring-level `Polynomial.Separable` in `Hypotheses` used to mask this one, since it
+forces the content to be a unit — see that structure's docstring. -/
+noncomputable def contentWeight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y]) : ℕ :=
+  ((Bivariate.evalX (Polynomial.C x₀) R.derivative).coeff (R.natDegree - 1) /
+    H.leadingCoeff).natDegree
+
 omit H_irreducible H_natDegree_pos in
-/-- When `dH = d` the top coefficient `P_{d-1} / W` is a constant, so the top term contributes no
-`Z`-degree. -/
-theorem xiPreTop_coeff_natDegree_zero_of_H_natDegree_eq_R_natDegree (x₀ : F) (hH : 0 < H.natDegree)
-    (hHyp : Hypotheses x₀ R H)
-    (hRdeg : 2 ≤ R.natDegree) (heq : H.natDegree = R.natDegree) :
-    ((Bivariate.evalX (Polynomial.C x₀) R.derivative).coeff (R.natDegree - 1) /
-      H.leadingCoeff).natDegree = 0 := by
+/-- The content degree is bounded by `D - dY`.
+
+The top coefficient of `ξ` is `P_{d-1} / W` with `P_{d-1} = d · R_d` the `d`-th `Y`-coefficient of
+`R(x₀,·,Z)` scaled by `d`, so the total-degree bound on `R(x₀,·,Z)` caps its `Z`-degree at
+`D - dY`; dividing by `W` can only lower it. -/
+theorem contentWeight_le (x₀ : F) (hH : 0 < H.natDegree) (hHyp : Hypotheses x₀ R H)
+    (hRdeg : 2 ≤ R.natDegree) {D : ℕ}
+    (hD_Rx0 : Bivariate.totalDegree (Bivariate.evalX (Polynomial.C x₀) R) ≤ D) :
+    contentWeight x₀ R H ≤ D - R.natDegree := by
   classical
-  set P : F[X][Y] := Bivariate.evalX (Polynomial.C x₀) R with hP_def
-  rcases hHyp.dvd_evalX with ⟨Q, hQ⟩
-  have hP_ne : P ≠ 0 := by
-    rw [hP_def]
-    exact evalX_ne_zero_of_hypotheses hHyp
-  have hQ_ne : Q ≠ 0 := by
-    intro h0
-    apply hP_ne
-    rw [hP_def, hQ, h0, mul_zero]
-  have hH_ne : H ≠ 0 := Polynomial.ne_zero_of_natDegree_gt hH
-  have hdegP : P.natDegree ≤ R.natDegree := by
-    rw [hP_def]
-    exact evalX_natDegree_le (Polynomial.C x₀) R
-  have hQdeg : Q.natDegree = 0 := by
-    have hmuldeg : (H * Q).natDegree = H.natDegree + Q.natDegree := by
-      exact Polynomial.natDegree_mul hH_ne hQ_ne
-    have hPdeg_eq : P.natDegree = (H * Q).natDegree := by
-      rw [hP_def, hQ]
-    omega
-  let q : F[X] := Q.coeff 0
-  have hQ_C : Q = Polynomial.C q := by
-    exact Polynomial.eq_C_of_natDegree_le_zero (p := Q) (by omega)
-  have hsepHQ : (H * Polynomial.C q).Separable := by
-    rw [← hQ_C]
-    rw [← hQ, ← hP_def]
-    exact hHyp.separable_evalX
-  have hq_unit : IsUnit q := by
-    rw [Polynomial.separable_def'] at hsepHQ
-    rcases hsepHQ with ⟨A, B, hAB⟩
-    have hderiv : (H * Polynomial.C q).derivative = H.derivative * Polynomial.C q := by
-      simp [Polynomial.derivative_mul]
-    have hfactor : (A * H + B * H.derivative) * Polynomial.C q = (1 : F[X][Y]) := by
-      calc
-        (A * H + B * H.derivative) * Polynomial.C q
-            = A * (H * Polynomial.C q) + B * (H.derivative * Polynomial.C q) := by ring
-        _ = A * (H * Polynomial.C q) + B * (H * Polynomial.C q).derivative := by rw [hderiv]
-        _ = 1 := hAB
-    have hCunit : IsUnit (Polynomial.C q : F[X][Y]) := by
-      exact IsUnit.of_mul_eq_one (A * H + B * H.derivative) (by simpa [mul_comm] using hfactor)
-    exact (Polynomial.isUnit_C.mp hCunit)
   have hsucc : R.natDegree - 1 + 1 = R.natDegree := by omega
-  have hPtop : (Bivariate.evalX (Polynomial.C x₀) R).coeff R.natDegree = H.leadingCoeff * q := by
-    rw [hQ, hQ_C]
-    rw [← heq]
-    simp [Polynomial.coeff_natDegree]
-  have htop_coeff :
-      (Bivariate.evalX (Polynomial.C x₀) R.derivative).coeff (R.natDegree - 1) =
-        H.leadingCoeff * (q * (R.natDegree : F[X])) := by
-    rw [derivative_evalX_coeff, hsucc, hPtop]
-    ring
-  have hW_ne : H.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hH_ne
-  have hdiv : H.leadingCoeff ∣
-      (Bivariate.evalX (Polynomial.C x₀) R.derivative).coeff (R.natDegree - 1) :=
-    leadingCoeff_dvd_evalX_derivative_coeff_pred hHyp
-  have hquot :
-      (Bivariate.evalX (Polynomial.C x₀) R.derivative).coeff (R.natDegree - 1) /
-          H.leadingCoeff = q * (R.natDegree : F[X]) := by
-    exact (EuclideanDomain.div_eq_iff_eq_mul_of_dvd
-      ((Bivariate.evalX (Polynomial.C x₀) R.derivative).coeff (R.natDegree - 1))
-      H.leadingCoeff (q * (R.natDegree : F[X])) hW_ne hdiv).2 htop_coeff
-  rw [hquot]
-  have hqdeg0 : q.natDegree = 0 := Polynomial.natDegree_eq_zero_of_isUnit hq_unit
-  have hndeg0 : ((R.natDegree : F[X]).natDegree = 0) := by
+  have hcoeff : (Bivariate.evalX (Polynomial.C x₀) R.derivative).coeff (R.natDegree - 1) =
+      (Bivariate.evalX (Polynomial.C x₀) R).coeff R.natDegree * ((R.natDegree : ℕ) : F[X]) := by
+    rw [derivative_evalX_coeff, hsucc]
+  have htop : ((Bivariate.evalX (Polynomial.C x₀) R).coeff R.natDegree).natDegree
+      ≤ D - R.natDegree := by
+    by_cases hmem : R.natDegree ∈ (Bivariate.evalX (Polynomial.C x₀) R).support
+    · have hle := Bivariate.coeff_totalDegree_le (Bivariate.evalX (Polynomial.C x₀) R) hmem
+      omega
+    · rw [Polynomial.notMem_support_iff.mp hmem]
+      simp
+  have hcast : (((R.natDegree : ℕ) : F[X])).natDegree = 0 := by
     rw [← Polynomial.C_eq_natCast, Polynomial.natDegree_C]
-  have hle : (q * (R.natDegree : F[X])).natDegree ≤ 0 := by
-    calc
-      (q * (R.natDegree : F[X])).natDegree ≤ q.natDegree + ((R.natDegree : F[X]).natDegree) :=
-        Polynomial.natDegree_mul_le
-      _ = 0 := by rw [hqdeg0, hndeg0, Nat.zero_add]
-  omega
+  have hcdeg : ((Bivariate.evalX (Polynomial.C x₀) R.derivative).coeff
+      (R.natDegree - 1)).natDegree ≤ D - R.natDegree := by
+    rw [hcoeff]
+    refine le_trans Polynomial.natDegree_mul_le ?_
+    omega
+  unfold contentWeight
+  by_cases hc0 : (Bivariate.evalX (Polynomial.C x₀) R.derivative).coeff (R.natDegree - 1) = 0
+  · simp [hc0]
+  · have hH_ne : H ≠ 0 := Polynomial.ne_zero_of_natDegree_gt hH
+    have hW_ne : H.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hH_ne
+    have hdvd := leadingCoeff_dvd_evalX_derivative_coeff_pred (H := H) hHyp
+    have hmul := EuclideanDomain.mul_div_cancel' hW_ne hdvd
+    have hqdvd : ((Bivariate.evalX (Polynomial.C x₀) R.derivative).coeff (R.natDegree - 1) /
+        H.leadingCoeff) ∣
+        (Bivariate.evalX (Polynomial.C x₀) R.derivative).coeff (R.natDegree - 1) :=
+      Dvd.intro_left _ hmul
+    exact le_trans (Polynomial.natDegree_le_of_dvd hqdvd hc0) hcdeg
 
 omit H_irreducible H_natDegree_pos in
 /-- When `dH < d` the top term must be reduced modulo `H̃` before weighing, and the reduction obeys
@@ -864,42 +871,41 @@ theorem xiPreTop_weight_over_𝒪_le_of_H_natDegree_lt_R_natDegree (x₀ : F) (h
           rw [hsum]
 
 omit H_irreducible H_natDegree_pos in
-/-- The `𝒪`-weight of the top term, covering both `dH = d` and `dH < d`. -/
+/-- The `𝒪`-weight of the top term, covering both `dH = d` and `dH < d`.
+
+The `contentWeight` summand is charged only because the `dH = d` case needs it; see that
+definition's docstring.  In the `dH < d` case the reduction modulo `H̃` already absorbs the top
+term and the summand is pure slack. -/
 theorem xiPreTop_weight_over_𝒪_le (x₀ : F) (hH : 0 < H.natDegree) (hHyp : Hypotheses x₀ R H)
     (hRdeg : 2 ≤ R.natDegree)
     {D : ℕ} (hD_H : Bivariate.totalDegree H ≤ D)
     (hD_Rx0 : Bivariate.totalDegree (Bivariate.evalX (Polynomial.C x₀) R) ≤ D) :
     regularWeight hH
       (Ideal.Quotient.mk (Ideal.span {monicize H}) (xiPreTop x₀ R H) : 𝒪 H) D
-      ≤ WithBot.some ((R.natDegree - 1) * (D - H.natDegree + 1)) := by
+      ≤ WithBot.some ((R.natDegree - 1) * (D - H.natDegree + 1) + contentWeight x₀ R H) := by
   classical
   have hHleR : H.natDegree ≤ R.natDegree := natDegree_H_le_natDegree_R_of_hypotheses hHyp
   rcases lt_or_eq_of_le hHleR with hlt | heq
-  · exact xiPreTop_weight_over_𝒪_le_of_H_natDegree_lt_R_natDegree x₀ hH hHyp hRdeg hD_H hD_Rx0 hlt
+  · exact le_trans
+      (xiPreTop_weight_over_𝒪_le_of_H_natDegree_lt_R_natDegree x₀ hH hHyp hRdeg hD_H hD_Rx0 hlt)
+      (by exact_mod_cast Nat.le_add_right _ (contentWeight x₀ R H))
   · have hH_ne : H ≠ 0 := Polynomial.ne_zero_of_natDegree_gt hH
     have hH_in : H.natDegree ∈ H.support :=
       Polynomial.mem_support_iff.mpr (Polynomial.leadingCoeff_ne_zero.mpr hH_ne)
     have hHleD : H.natDegree ≤ D := by
       have hcoeff_total := Bivariate.coeff_totalDegree_le H hH_in
       omega
-    have hRleD : R.natDegree ≤ D := by omega
-    have hsub : D + 1 - R.natDegree = D - R.natDegree + 1 := by omega
+    have hEq : D + 1 - Bivariate.natDegreeY H = D - H.natDegree + 1 := by
+      rw [Bivariate.natDegreeY]; omega
     unfold xiPreTop
     let P : F[X][Y] := Bivariate.evalX (Polynomial.C x₀) R.derivative
     let d : ℕ := R.natDegree
     let W : F[X] := H.leadingCoeff
-    have hcoeff0 : (P.coeff (d - 1) / W).natDegree = 0 := by
-      dsimp [P, d, W]
-      exact xiPreTop_coeff_natDegree_zero_of_H_natDegree_eq_R_natDegree x₀ hH hHyp hRdeg heq
     refine le_trans (regularWeight_mk_le hD_H hH _) ?_
     refine le_trans (weight_C_mul_X_pow_le H D (P.coeff (d - 1) / W) (d - 1)) ?_
-    rw [WithBot.coe_le_coe]
-    dsimp [P, d, W]
-    rw [hcoeff0]
-    rw [Bivariate.natDegreeY]
-    rw [heq]
-    rw [hsub]
-    omega
+    rw [WithBot.coe_le_coe, hEq]
+    dsimp only [P, d, W, contentWeight]
+    exact le_rfl
 
 omit H_irreducible H_natDegree_pos in
 /-- The explicit representative of `ξ` splits as low part plus top term; this is how its weight
@@ -909,7 +915,11 @@ theorem xiPre_eq_lower_add_top (x₀ : F) (hRdeg : 2 ≤ R.natDegree) :
   simp only [xiPre, xiPreLower, xiPreTop, hRdeg, if_pos]
 
 
-/-- The weight bound `Λ(ξ) ≤ (dY - 1)·(D - dH + 1)`.
+/-- The weight bound `Λ(ξ) ≤ (dY - 1)·(D - dH + 1) + contentWeight`.
+
+[BCIKS20] Claim A.2 states this without the `contentWeight` summand; that form is false, and
+`contentWeight`'s docstring carries the counterexample and the reason the paper's chain needs
+`Λ(W) = D - dH` rather than the `Λ(W) ≤ D - dH` it proves.
 
 The explicit hypothesis `2 ≤ R.natDegree` is needed because the paper uses `W^(d-2)`, while
 Lean's natural-number exponent would otherwise totalize the low-degree cases by truncation. -/
@@ -918,7 +928,8 @@ lemma xi_weight_le (x₀ : F) (hH : 0 < H.natDegree) (hHyp : Hypotheses x₀ R H
     {D : ℕ} (hD_H : D ≥ Bivariate.totalDegree H)
     (hD_Rx0 : D ≥ Bivariate.totalDegree (Bivariate.evalX (Polynomial.C x₀) R)) :
     regularWeight hH (xi x₀ R H hHyp) D ≤
-    WithBot.some ((Bivariate.natDegreeY R - 1) * (D - Bivariate.natDegreeY H + 1)) := by
+    WithBot.some ((Bivariate.natDegreeY R - 1) * (D - Bivariate.natDegreeY H + 1) +
+      contentWeight x₀ R H) := by
   have hRdeg' : 2 ≤ R.natDegree := by
     simpa [Bivariate.natDegreeY] using hRdeg
   have hD_H' : Bivariate.totalDegree H ≤ D := hD_H
@@ -929,8 +940,11 @@ lemma xi_weight_le (x₀ : F) (hH : 0 < H.natDegree) (hHyp : Hypotheses x₀ R H
     (Ideal.Quotient.mk (Ideal.span {monicize H}) (xiPreLower x₀ R H) : 𝒪 H)
     (Ideal.Quotient.mk (Ideal.span {monicize H}) (xiPreTop x₀ R H) : 𝒪 H)).trans ?_
   apply max_le
-  · exact (regularWeight_mk_le hD_H' hH (xiPreLower x₀ R H)).trans
-      (by simpa [Bivariate.natDegreeY] using xiPreLower_weight_le x₀ hHyp hH hRdeg' hD_H' hD_Rx0')
+  · refine (regularWeight_mk_le hD_H' hH (xiPreLower x₀ R H)).trans ?_
+    refine (xiPreLower_weight_le x₀ hHyp hH hRdeg' hD_H' hD_Rx0').trans ?_
+    rw [WithBot.coe_le_coe, show Bivariate.natDegreeY R = R.natDegree from rfl,
+      show Bivariate.natDegreeY H = H.natDegree from rfl]
+    exact Nat.le_add_right _ _
   · simpa [Bivariate.natDegreeY] using
       (xiPreTop_weight_over_𝒪_le x₀ hH hHyp hRdeg' hD_H' hD_Rx0')
 

--- a/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Setup.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Setup.lean
@@ -56,7 +56,7 @@ the equivalent form "this happens if `discY Ri (x0, Y, Z) ≠ 0`".
 It is *not* `Polynomial.Separable` over the coefficient ring `F[Z]`.  Mathlib's `Separable f` is
 `IsCoprime f f.derivative` in the ambient ring, which over a non-field base forces the
 discriminant to be a **unit** rather than merely nonzero.  That is strictly stronger than the
-paper's hypothesis and unsatisfiable in the intended application: at a legitimate Claim 5.6 point
+paper's hypothesis and excludes legitimate inputs: at a Claim 5.6 point
 the specialization may acquire a content factor, e.g. over `𝔽₅` the irreducible
 `R = Z·Y² + Z·Y + (Z + X)` has `discY R = Z(-3Z - 4X)`, so `x₀ = 0` is admissible, yet
 `R(0, Y, Z) = Z·(Y² + Y + 1)` shares the factor `Z` with its `Y`-derivative and is therefore not

--- a/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Weight.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Weight.lean
@@ -334,19 +334,21 @@ The uncorrected bound would follow instead from `Λ(αₜ) ≤ Λ(T) - Λ(W)`, i
 on `𝕃` rather than on `𝒪`, giving `Λ(T) + t·deg W ≤ 1 + (t+1)(D - dH)`.  That route is not taken
 here: bounding the quotient `αₜ = -cₜ/ζ` needs a *lower* bound on `Λ(ζ)`, and only upper bounds are
 available. -/
-def numeratorShapeSharp (R : F[X][X][Y]) (H : F[X][Y]) (D t : ℕ) : ℕ :=
+def numeratorShapeSharp (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y]) (D t : ℕ) : ℕ :=
   1 + (t + 1) * (D - Bivariate.natDegreeY H) +
     henselDenominatorExponent t *
-      ((Bivariate.natDegreeY R - 1) * (D - Bivariate.natDegreeY H + 1)) +
+      ((Bivariate.natDegreeY R - 1) * (D - Bivariate.natDegreeY H + 1) +
+        contentWeight x₀ R H) +
     (t - 1) * (D - Bivariate.natDegreeY R)
 
 /-- The sharp bound weakens to the loose paper bound consumed by the final assembly:
 `sharp t ≤ (2t+1)·dY·D`.  Pure arithmetic, using `dH ≥ 1`, `dH ≤ dY`, `dH ≤ D`, and
 `eₜ ≤ 2t`. -/
 lemma numeratorShapeSharp_le_loose (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
-    (hHyp : Hypotheses x₀ R H) (hH : 0 < H.natDegree) {D : ℕ}
-    (hD_H : Bivariate.totalDegree H ≤ D) (t : ℕ) :
-    numeratorShapeSharp R H D t ≤ (2 * t + 1) * Bivariate.natDegreeY R * D := by
+    (hHyp : Hypotheses x₀ R H) (hH : 0 < H.natDegree) (hRdeg : 2 ≤ R.natDegree) {D : ℕ}
+    (hD_H : Bivariate.totalDegree H ≤ D)
+    (hD_Rx0 : Bivariate.totalDegree (Bivariate.evalX (Polynomial.C x₀) R) ≤ D) (t : ℕ) :
+    numeratorShapeSharp x₀ R H D t ≤ (2 * t + 1) * (Bivariate.natDegreeY R + 1) * D := by
   -- Translate the degree facts into the bare numeric hypotheses needed by the arithmetic.
   have hdH_dY : Bivariate.natDegreeY H ≤ Bivariate.natDegreeY R :=
     natDegree_H_le_natDegree_R_of_hypotheses hHyp
@@ -360,35 +362,44 @@ lemma numeratorShapeSharp_le_loose (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     rw [show Bivariate.natDegreeY H = H.natDegree from rfl]; omega
   have het : henselDenominatorExponent t ≤ 2 * t := by
     unfold henselDenominatorExponent; split <;> omega
+  have hcw : contentWeight x₀ R H ≤ D - Bivariate.natDegreeY R := by
+    rw [show Bivariate.natDegreeY R = R.natDegree from rfl]
+    exact contentWeight_le x₀ hH hHyp hRdeg hD_Rx0
   unfold numeratorShapeSharp
   set D' := D
   set dH := Bivariate.natDegreeY H with hdHdef
   set dY := Bivariate.natDegreeY R with hdYdef
   set et := henselDenominatorExponent t with hetdef
-  clear_value D' dH dY et
+  set cw := contentWeight x₀ R H with hcwdef
+  clear_value D' dH dY et cw
   obtain ⟨a, rfl⟩ : ∃ a, D' = dH + a := ⟨D' - dH, by omega⟩
   obtain ⟨b, rfl⟩ : ∃ b, dY = dH + b := ⟨dY - dH, by omega⟩
   obtain ⟨c, rfl⟩ : ∃ c, dH = c + 1 := ⟨dH - 1, by omega⟩
   simp only [Nat.add_sub_cancel_left] at *
   rw [show c + 1 + b - 1 = c + b by omega, show c + 1 + a - (c + 1 + b) = a - b by omega]
-  -- `P` is the `ξ`-charge; the correction contributes at most `t * a`
+  -- `P` is the `ξ`-charge proper; `cw` is the content charge, bounded by `a - b = D - dY`
   set P := (c + b) * (a + 1) with hPdef
-  have hA : et * P ≤ 2 * t * P := Nat.mul_le_mul_right _ (by omega)
+  have hcw' : cw ≤ a - b := by omega
+  have hA : et * (P + cw) ≤ 2 * t * (P + a) := Nat.mul_le_mul (by omega) (by omega)
   have hCorr : (t - 1) * (a - b) ≤ t * a := Nat.mul_le_mul (by omega) (by omega)
-  -- the right-hand side dominates `(2t+1)·(P + a + 1)`
-  have hRHSexp : P + a + 1 + ((c + b) * c + c) = (c + 1 + b) * (c + 1 + a) := by
+  -- the enlarged right-hand side dominates `(2t+1)·(P + 2a + c + 2)`
+  have hRHSexp : (c + 1 + b + 1) * (c + 1 + a) =
+      P + a + 1 + ((c + b) * c + c) + (c + 1 + a) := by
     rw [hPdef]; ring
-  have hRHS : (2 * t + 1) * (P + a + 1) ≤ (2 * t + 1) * ((c + 1 + b) * (c + 1 + a)) :=
+  have hRHS : (2 * t + 1) * (P + 2 * a + c + 2) ≤
+      (2 * t + 1) * ((c + 1 + b + 1) * (c + 1 + a)) :=
     Nat.mul_le_mul_left _ (by omega)
-  have hPle : 2 * t * P ≤ (2 * t + 1) * P := Nat.mul_le_mul_right _ (by omega)
-  calc 1 + (t + 1) * a + et * P + (t - 1) * (a - b)
-      ≤ 1 + (t + 1) * a + 2 * t * P + t * a :=
+  have h1 : 2 * t * P ≤ (2 * t + 1) * P := Nat.mul_le_mul_right _ (by omega)
+  have h2 : (4 * t + 1) * a ≤ (4 * t + 2) * a := Nat.mul_le_mul_right _ (by omega)
+  have h3 : 1 ≤ (2 * t + 1) * (c + 2) := Nat.one_le_iff_ne_zero.mpr (by positivity)
+  calc 1 + (t + 1) * a + et * (P + cw) + (t - 1) * (a - b)
+      ≤ 1 + (t + 1) * a + 2 * t * (P + a) + t * a :=
         Nat.add_le_add (Nat.add_le_add_left hA _) hCorr
-    _ = 1 + (2 * t + 1) * a + 2 * t * P := by ring
-    _ ≤ (2 * t + 1) * P + (2 * t + 1) * a + (2 * t + 1) := by omega
-    _ = (2 * t + 1) * (P + a + 1) := by ring
-    _ ≤ (2 * t + 1) * ((c + 1 + b) * (c + 1 + a)) := hRHS
-    _ = (2 * t + 1) * (c + 1 + b) * (c + 1 + a) := by ring
+    _ = 1 + (4 * t + 1) * a + 2 * t * P := by ring
+    _ ≤ (2 * t + 1) * P + (4 * t + 2) * a + (2 * t + 1) * (c + 2) := by omega
+    _ = (2 * t + 1) * (P + 2 * a + c + 2) := by ring
+    _ ≤ (2 * t + 1) * ((c + 1 + b + 1) * (c + 1 + a)) := hRHS
+    _ = (2 * t + 1) * (c + 1 + b + 1) * (c + 1 + a) := by ring
 
 omit H_irreducible H_natDegree_pos in
 /-- `RegularWeightLe`-version of the bridge from the embedded `𝒪`-witness back to the `𝒪`-weight:
@@ -459,7 +470,7 @@ set_option maxHeartbeats 2000000 in
 -- exhausted by the resulting `ring`/`omega` normalisations.
 /-- Weight-tracking per-degree clearing lemma: the `Λ`-graded analogue of
 `henselClearedTerm_regular`.  Each degree-`j` summand of the cleared `(t+1)`-st residual is
-regular with sharp `Λ`-weight at most `numeratorShapeSharp R H D (t+1)`.
+regular with sharp `Λ`-weight at most `numeratorShapeSharp x₀ R H D (t+1)`.
 
 The proof splits on the *boundary* summand `p.1 = 0`, `j = d ≥ 2`, `p.2 = t+1`, which is the one
 place where the `d` part-certificates want one more factor of `W` than the goal supplies.  There the
@@ -479,7 +490,7 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
       RegularWeightLe hH
         (αtrunc i * (liftToFunctionField (H := H) H.leadingCoeff ^ (i + 1) *
           (embeddingOf𝒪Into𝕃 H (xi x₀ R H hHyp)) ^ henselDenominatorExponent i))
-        D (numeratorShapeSharp R H D i))
+        D (numeratorShapeSharp x₀ R H D i))
     (hαzero : ∀ i, t < i → αtrunc i = 0)
     (j : ℕ) (hj : j ∈ Finset.range (R.natDegree + 1)) :
     RegularWeightLe hH
@@ -488,13 +499,14 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
         (liftToFunctionField (H := H) H.leadingCoeff ^ (t + 1 + 1) *
           (embeddingOf𝒪Into𝕃 H (xi x₀ R H hHyp)) ^ (henselDenominatorExponent (t + 1) - 1) *
           liftToFunctionField (H := H) H.leadingCoeff ^ (R.natDegree - 2)))
-      D (numeratorShapeSharp R H D (t + 1)) := by
+      D (numeratorShapeSharp x₀ R H D (t + 1)) := by
   classical
   set W : 𝕃 H := liftToFunctionField (H := H) H.leadingCoeff with hWdef
   set eta : 𝕃 H := embeddingOf𝒪Into𝕃 H (xi x₀ R H hHyp) with hetadef
   -- abbreviations for the sharp weight atoms
   set ΛW : ℕ := D - Bivariate.natDegreeY H with hΛWdef
-  set Λξ : ℕ := (Bivariate.natDegreeY R - 1) * (D - Bivariate.natDegreeY H + 1) with hΛξdef
+  set Λξ : ℕ := (Bivariate.natDegreeY R - 1) * (D - Bivariate.natDegreeY H + 1) +
+    contentWeight x₀ R H with hΛξdef
   -- base RegularWeightLe certificates for W and ξ at the SHARP weights
   have hRWLW : RegularWeightLe hH W D ΛW := by
     rw [hWdef, hΛWdef]
@@ -540,7 +552,7 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     have hPweq : Pw = p.2 + j := by rw [hPwdef, Finset.sum_add_distrib, hbsum]; simp
     have hprodW : RegularWeightLe hH
         ((∏ i ∈ Finset.range j, αtrunc (l i)) * (W ^ Pw * eta ^ Pe)) D
-        (∑ i ∈ Finset.range j, numeratorShapeSharp R H D (l i)) := by
+        (∑ i ∈ Finset.range j, numeratorShapeSharp x₀ R H D (l i)) := by
       rw [hPwdef, hPedef, ← Finset.prod_pow_eq_pow_sum, ← Finset.prod_pow_eq_pow_sum,
         ← Finset.prod_mul_distrib, ← Finset.prod_mul_distrib]
       refine RegularWeightLe.prod _ _ _ hD_H ?_
@@ -599,9 +611,9 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
           by_contra h; push Not at h; interval_cases S1 <;> omega
         omega
     -- sharp-sum identity: ∑ sharp(l i) = j + Pw*ΛW + Pe*Λξ + Pc*G
-    have hsharpSum : (∑ i ∈ Finset.range j, numeratorShapeSharp R H D (l i)) =
+    have hsharpSum : (∑ i ∈ Finset.range j, numeratorShapeSharp x₀ R H D (l i)) =
         j + Pw * ΛW + Pe * Λξ + Pc * G := by
-      have hexpand : ∀ i, numeratorShapeSharp R H D (l i) =
+      have hexpand : ∀ i, numeratorShapeSharp x₀ R H D (l i) =
           1 + (l i + 1) * ΛW + henselDenominatorExponent (l i) * Λξ + (l i - 1) * G := by
         intro i; rw [numeratorShapeSharp, hΛWdef, hΛξdef, hGdef]
       simp only [hexpand]
@@ -724,19 +736,20 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
           ((regularWeightLe_liftToFunctionField hD_H hH c).mono hc_deg) hprodW)
         (hRWLeta.pow hD_H _)).mono ?_
       rw [hsharpSum]
-      have hsharpSucc : numeratorShapeSharp R H D (t + 1) =
+      have hsharpSucc : numeratorShapeSharp x₀ R H D (t + 1) =
           1 + (t + 2) * ΛW + (2 * t + 1) * Λξ + t * G := by
         rw [numeratorShapeSharp, ← hΛWdef, ← hΛξdef, ← hGdef, henselDenominatorExponent_succ]
         rw [show 2 * (t + 1) - 1 = 2 * t + 1 by omega, show t + 1 + 1 = t + 2 by omega,
           show t + 1 - 1 = t by omega]
       rw [hsharpSucc]
       -- `Λξ = (dY-1)·(ΛW+1)` and `G = D - dY`, so the whole thing is linear arithmetic
-      have hΛξval : Λξ = (R.natDegree - 1) * (ΛW + 1) := by rw [hΛξdef, hΛWdef, hdY]
+      have hΛξval : Λξ = (R.natDegree - 1) * (ΛW + 1) + contentWeight x₀ R H := by
+        rw [hΛξdef, hΛWdef, hdY]
       have hGval : G = D - R.natDegree := by rw [hGdef, hdY]
       have hE1val : E1 = 2 * t := by rw [hE1def, henselDenominatorExponent_succ]; omega
       -- expand the two products so that only `ΛW`-linear atoms remain
       obtain ⟨dm, hdmeq⟩ : ∃ dm, R.natDegree = dm + 2 := ⟨R.natDegree - 2, by omega⟩
-      have hΛξexp : Λξ = dm * ΛW + dm + ΛW + 1 := by
+      have hΛξexp : Λξ = dm * ΛW + dm + ΛW + 1 + contentWeight x₀ R H := by
         rw [hΛξval, hdmeq, show dm + 2 - 1 = dm + 1 by omega]; ring
       have hPwexp : Pw * ΛW = (t + 1) * ΛW + dm * ΛW + 2 * ΛW := by
         rw [hPweq', hdmeq]; ring
@@ -751,7 +764,8 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
         _ = (j + Pw * ΛW + E1 * Λξ) + (G + Pc * G) := by
               rw [← Nat.add_mul, Nat.add_sub_cancel' hPe_le]
         _ ≤ (j + Pw * ΛW + E1 * Λξ) + t * G := Nat.add_le_add_left hPcG _
-        _ = 1 + (t + 2) * ΛW + (2 * t + 1) * Λξ + t * G := by
+        _ ≤ 1 + (t + 2) * ΛW + (2 * t + 1) * Λξ + t * G := by
+              refine Nat.le.intro (k := contentWeight x₀ R H) ?_
               rw [hjd', hPweq', hE1val, hΛξexp, hdmeq]; ring
     · -- NON-BOUNDARY: budget Pw ≤ (t+2)+(d-2) covers everything.
       have hbudget : Pw ≤ (t + 1 + 1) + (R.natDegree - 2) := by
@@ -789,7 +803,7 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
       -- weight: (D-j) + (j + Pw*ΛW + Pe*Λξ) + ((wb-Pw)*ΛW + (E1-Pe)*Λξ) ≤ sharp(t+1)
       rw [hsharpSum]
       -- sharp(t+1) expansion
-      have hsharpSucc : numeratorShapeSharp R H D (t + 1) =
+      have hsharpSucc : numeratorShapeSharp x₀ R H D (t + 1) =
           1 + (t + 2) * ΛW + (2 * t + 1) * Λξ + t * G := by
         rw [numeratorShapeSharp, ← hΛWdef, ← hΛξdef, ← hGdef, henselDenominatorExponent_succ]
         rw [show 2 * (t + 1) - 1 = 2 * t + 1 by omega, show t + 1 + 1 = t + 2 by omega,
@@ -810,7 +824,7 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
         rw [← Nat.add_mul]; congr 1; omega
       have hjDj : D - j + j = D := Nat.sub_add_cancel hjD
       -- Final: (D-j) + (j + Pw ΛW + Pe Λξ) + ((wb-Pw)ΛW + (E1-Pe)Λξ) = D + wb*ΛW + E1*Λξ
-      have hΛξval : Λξ = (R.natDegree - 1) * (ΛW + 1) := by
+      have hΛξval : Λξ = (R.natDegree - 1) * (ΛW + 1) + contentWeight x₀ R H := by
         rw [hΛξdef, hΛWdef, hdY]
       -- prove ≤
       have hfin0 : (D - j) + (j + Pw * ΛW + Pe * Λξ) +
@@ -832,7 +846,8 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
           · omega⟩
         rw [hdmeq] at hkey ⊢
         rw [show dm + 1 - 1 = dm by omega]
-        nlinarith [hkey, hwb_le, hgap, Nat.mul_le_mul_right ΛW hwb_le]
+        nlinarith [hkey, hwb_le, hgap, Nat.mul_le_mul_right ΛW hwb_le,
+          Nat.mul_le_mul_right (contentWeight x₀ R H) (show 2 * t ≤ 2 * t + 1 by omega)]
       -- the correction the parts consume is at most the `t·G` the target provides
       calc (D - j) + (j + Pw * ΛW + Pe * Λξ + Pc * G) +
             ((wb - Pw) * ΛW + (E1 - Pe) * Λξ)
@@ -846,8 +861,8 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
 
 /-- The cleared `(t+1)`-st Hensel residual `henselCoeffResidual · Ddiv` (with `Ddiv` the global
 clearing denominator `W^{t+2}·η^{E-1}·W^{d-2}`) is regular with sharp `Λ`-weight at most
-`numeratorShapeSharp R H D (t+1)`, given that every previous numerator `βseq s` (`s ≤ t`) has
-sharp weight `≤ numeratorShapeSharp R H D s`.
+`numeratorShapeSharp x₀ R H D (t+1)`, given that every previous numerator `βseq s` (`s ≤ t`) has
+sharp weight `≤ numeratorShapeSharp x₀ R H D s`.
 
 This is the quantitative (weight-tracking) heart of the argument: it is the `Λ`-graded
 analogue of `henselCoeffResidual_regular_after_clearing`, refining mere regularity to the sharp
@@ -866,13 +881,13 @@ lemma henselClearedResidual_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     (hshape : HasNumeratorShape x₀ R H hHyp αseq βseq)
     (t : ℕ)
     (ihAll : ∀ s ≤ t,
-      RegularWeightLe hH (embeddingOf𝒪Into𝕃 H (βseq s)) D (numeratorShapeSharp R H D s)) :
+      RegularWeightLe hH (embeddingOf𝒪Into𝕃 H (βseq s)) D (numeratorShapeSharp x₀ R H D s)) :
     RegularWeightLe hH
       (henselCoeffResidual x₀ R H αseq t *
         (liftToFunctionField (H := H) H.leadingCoeff ^ (t + 1 + 1) *
           (embeddingOf𝒪Into𝕃 H (xi x₀ R H hHyp)) ^ (henselDenominatorExponent (t + 1) - 1) *
           liftToFunctionField (H := H) H.leadingCoeff ^ (R.natDegree - 2)))
-      D (numeratorShapeSharp R H D (t + 1)) := by
+      D (numeratorShapeSharp x₀ R H D (t + 1)) := by
   classical
   set αtrunc : ℕ → 𝕃 H := fun i => if i ≤ t then αseq i else 0 with hαtrunc
   rw [henselCoeffResidual_eq_trunc x₀ R H αseq hα0 t]
@@ -897,7 +912,7 @@ lemma henselClearedResidual_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
       RegularWeightLe hH
         (αtrunc i * (liftToFunctionField (H := H) H.leadingCoeff ^ (i + 1) *
           (embeddingOf𝒪Into𝕃 H (xi x₀ R H hHyp)) ^ henselDenominatorExponent i))
-        D (numeratorShapeSharp R H D i) := by
+        D (numeratorShapeSharp x₀ R H D i) := by
     intro i hi
     have hW : liftToFunctionField (H := H) H.leadingCoeff ≠ 0 :=
       liftToFunctionField_leadingCoeff_ne_zero (H := H)
@@ -916,7 +931,7 @@ lemma henselClearedResidual_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
   intro j hj
   exact henselClearedTerm_weight x₀ R H hHyp hH hD_H hD_R hD_Rx0 hRdeg t αtrunc ihNum hαzero j hj
 
-/-- Sharp `Λ`-weight bound on every Hensel numerator: `Λ(βₜ) ≤ numeratorShapeSharp R H D t`,
+/-- Sharp `Λ`-weight bound on every Hensel numerator: `Λ(βₜ) ≤ numeratorShapeSharp x₀ R H D t`,
 i.e. `1 + (t+1)(D-dH) + eₜ(dY-1)(D-dH+1)` plus the correction term.  Proved by strong induction,
 the successor step being `henselClearedResidual_weight` together with the identity
 `embeddingOf𝒪Into𝕃 (βₜ₊₁) = -(henselCoeffResidual · Ddiv)`.
@@ -939,7 +954,7 @@ theorem numerator_shape_weight_sharp (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     (hroot : evalRAtPowerSeries x₀ H R (gammaFromAlpha H αseq) = 0)
     (hshape : HasNumeratorShape x₀ R H hHyp αseq βseq) :
     ∀ t : ℕ, RegularWeightLe hH (embeddingOf𝒪Into𝕃 H (βseq t)) D
-      (numeratorShapeSharp R H D t) := by
+      (numeratorShapeSharp x₀ R H D t) := by
   intro t
   induction t using Nat.strong_induction_on with
   | _ t ih =>
@@ -988,13 +1003,14 @@ theorem numerator_shape_weight_bound (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     (hshape : HasNumeratorShape x₀ R H hHyp αseq βseq) :
     ∀ t : ℕ,
       regularWeight hH (βseq t) D ≤
-        (WithBot.some ((2 * t + 1) * Bivariate.natDegreeY R * D) : WithBot ℕ) := by
+        (WithBot.some ((2 * t + 1) * (Bivariate.natDegreeY R + 1) * D) : WithBot ℕ) := by
   intro t
   have hsharp :=
     numerator_shape_weight_sharp x₀ R H hHyp hH hD_H hD_R hRdeg αseq βseq hα0 hroot hshape t
   refine (regularWeight_le_of_regularWeightLe (βseq t) hsharp).trans ?_
   rw [WithBot.coe_le_coe]
-  exact numeratorShapeSharp_le_loose x₀ R H hHyp hH hD_H t
+  exact numeratorShapeSharp_le_loose x₀ R H hHyp hH (by simpa [Bivariate.natDegreeY] using hRdeg)
+    hD_H (evalX_totalDegree_le_of_coeff_bound x₀ R hD_R) t
 
 /-- A sequence with the Hensel-lift semantics has the numerator shape witnessed by
 its own induced coefficients: `αₜ := βₜ / (W^{t+1} ξ^{eₜ})` is the tautological choice, so
@@ -1024,7 +1040,7 @@ theorem hensel_numerator_weight_sharp_le (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y
     {βseq : ℕ → 𝒪 H} (hβ : IsHenselNumeratorSequence x₀ R H hHyp βseq) :
     ∀ t : ℕ,
       regularWeight hH (βseq t) D ≤
-        (WithBot.some (numeratorShapeSharp R H D t) : WithBot ℕ) := by
+        (WithBot.some (numeratorShapeSharp x₀ R H D t) : WithBot ℕ) := by
   intro t
   exact regularWeight_le_of_regularWeightLe (βseq t)
     (numerator_shape_weight_sharp x₀ R H hHyp hH hD_H hD_R hRdeg
@@ -1042,11 +1058,12 @@ theorem hensel_numerator_weight_le (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     {βseq : ℕ → 𝒪 H} (hβ : IsHenselNumeratorSequence x₀ R H hHyp βseq) :
     ∀ t : ℕ,
       regularWeight hH (βseq t) D ≤
-        (WithBot.some ((2 * t + 1) * Bivariate.natDegreeY R * D) : WithBot ℕ) := by
+        (WithBot.some ((2 * t + 1) * (Bivariate.natDegreeY R + 1) * D) : WithBot ℕ) := by
   intro t
   refine (hensel_numerator_weight_sharp_le x₀ R H hHyp hH hD_H hD_R hRdeg hβ t).trans ?_
   rw [WithBot.coe_le_coe]
-  exact numeratorShapeSharp_le_loose x₀ R H hHyp hH hD_H t
+  exact numeratorShapeSharp_le_loose x₀ R H hHyp hH (by simpa [Bivariate.natDegreeY] using hRdeg)
+    hD_H (evalX_totalDegree_le_of_coeff_bound x₀ R hD_R) t
 
 
 end HenselNumerators

--- a/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Weight.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Weight.lean
@@ -25,10 +25,16 @@ certificate calculus on `𝕃 H`, the sharp per-step budget
 `numeratorShapeSharp = 1 + (t+1)Λ(W) + eₜΛ(ξ)`, its weakening to the paper's `(2t+1)·d·D`, and the
 induction transporting them along the cleared Hensel residual.
 
-Everything here is proved.  The one subtlety is that the bound `numeratorShapeSharp` carries a
-correction term relative to the inequality [BCIKS20] states, because a factor of `W` that the
-recursion *saves* is only worth `deg W` while one it *charges* costs the bound `D - dH`; see the
-docstring of `numeratorShapeSharp`.
+Everything here is proved.  Two places diverge from the inequalities [BCIKS20] states.
+
+`numeratorShapeSharp` carries a correction term, because a factor of `W` that the recursion
+*saves* is only worth `deg W` while one it *charges* costs the bound `D - dH`; see its own
+docstring.  It and `numeratorShapeSharp_le_loose` are exactly as the paper's accounting gives them.
+
+The numerators are then bounded not by `numeratorShapeSharp` but by
+`numeratorShapeSharpContent`, which adds `eₜ · contentWeight`, and the loose bound becomes
+`(2t+1)·(dY+1)·D` in place of `(2t+1)·dY·D`.  That is forced: A.2's `Λ(ξ)` bound omits a content
+charge and is false without it.  See `RationalFunctions.HenselNumerators.contentWeight`.
 
 ## References
 
@@ -334,21 +340,86 @@ The uncorrected bound would follow instead from `Λ(αₜ) ≤ Λ(T) - Λ(W)`, i
 on `𝕃` rather than on `𝒪`, giving `Λ(T) + t·deg W ≤ 1 + (t+1)(D - dH)`.  That route is not taken
 here: bounding the quotient `αₜ = -cₜ/ζ` needs a *lower* bound on `Λ(ζ)`, and only upper bounds are
 available. -/
-def numeratorShapeSharp (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y]) (D t : ℕ) : ℕ :=
+def numeratorShapeSharp (R : F[X][X][Y]) (H : F[X][Y]) (D t : ℕ) : ℕ :=
   1 + (t + 1) * (D - Bivariate.natDegreeY H) +
     henselDenominatorExponent t *
-      ((Bivariate.natDegreeY R - 1) * (D - Bivariate.natDegreeY H + 1) +
-        contentWeight x₀ R H) +
+      ((Bivariate.natDegreeY R - 1) * (D - Bivariate.natDegreeY H + 1)) +
     (t - 1) * (D - Bivariate.natDegreeY R)
 
 /-- The sharp bound weakens to the loose paper bound consumed by the final assembly:
 `sharp t ≤ (2t+1)·dY·D`.  Pure arithmetic, using `dH ≥ 1`, `dH ≤ dY`, `dH ≤ D`, and
 `eₜ ≤ 2t`. -/
 lemma numeratorShapeSharp_le_loose (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
+    (hHyp : Hypotheses x₀ R H) (hH : 0 < H.natDegree) {D : ℕ}
+    (hD_H : Bivariate.totalDegree H ≤ D) (t : ℕ) :
+    numeratorShapeSharp R H D t ≤ (2 * t + 1) * Bivariate.natDegreeY R * D := by
+  -- Translate the degree facts into the bare numeric hypotheses needed by the arithmetic.
+  have hdH_dY : Bivariate.natDegreeY H ≤ Bivariate.natDegreeY R :=
+    natDegree_H_le_natDegree_R_of_hypotheses hHyp
+  have hdH_pos : 1 ≤ Bivariate.natDegreeY H := hH
+  have hdH_D : Bivariate.natDegreeY H ≤ D := by
+    have hH_in : H.natDegree ∈ H.support :=
+      Polynomial.mem_support_iff.mpr (Polynomial.leadingCoeff_ne_zero.mpr
+        (by rintro rfl; simp at hH))
+    have h1 : (H.coeff H.natDegree).natDegree + H.natDegree ≤ Bivariate.totalDegree H :=
+      Bivariate.coeff_totalDegree_le H hH_in
+    rw [show Bivariate.natDegreeY H = H.natDegree from rfl]; omega
+  have het : henselDenominatorExponent t ≤ 2 * t := by
+    unfold henselDenominatorExponent; split <;> omega
+  unfold numeratorShapeSharp
+  set D' := D
+  set dH := Bivariate.natDegreeY H with hdHdef
+  set dY := Bivariate.natDegreeY R with hdYdef
+  set et := henselDenominatorExponent t with hetdef
+  clear_value D' dH dY et
+  obtain ⟨a, rfl⟩ : ∃ a, D' = dH + a := ⟨D' - dH, by omega⟩
+  obtain ⟨b, rfl⟩ : ∃ b, dY = dH + b := ⟨dY - dH, by omega⟩
+  obtain ⟨c, rfl⟩ : ∃ c, dH = c + 1 := ⟨dH - 1, by omega⟩
+  simp only [Nat.add_sub_cancel_left] at *
+  rw [show c + 1 + b - 1 = c + b by omega, show c + 1 + a - (c + 1 + b) = a - b by omega]
+  -- `P` is the `ξ`-charge; the correction contributes at most `t * a`
+  set P := (c + b) * (a + 1) with hPdef
+  have hA : et * P ≤ 2 * t * P := Nat.mul_le_mul_right _ (by omega)
+  have hCorr : (t - 1) * (a - b) ≤ t * a := Nat.mul_le_mul (by omega) (by omega)
+  -- the right-hand side dominates `(2t+1)·(P + a + 1)`
+  have hRHSexp : P + a + 1 + ((c + b) * c + c) = (c + 1 + b) * (c + 1 + a) := by
+    rw [hPdef]; ring
+  have hRHS : (2 * t + 1) * (P + a + 1) ≤ (2 * t + 1) * ((c + 1 + b) * (c + 1 + a)) :=
+    Nat.mul_le_mul_left _ (by omega)
+  have hPle : 2 * t * P ≤ (2 * t + 1) * P := Nat.mul_le_mul_right _ (by omega)
+  calc 1 + (t + 1) * a + et * P + (t - 1) * (a - b)
+      ≤ 1 + (t + 1) * a + 2 * t * P + t * a :=
+        Nat.add_le_add (Nat.add_le_add_left hA _) hCorr
+    _ = 1 + (2 * t + 1) * a + 2 * t * P := by ring
+    _ ≤ (2 * t + 1) * P + (2 * t + 1) * a + (2 * t + 1) := by omega
+    _ = (2 * t + 1) * (P + a + 1) := by ring
+    _ ≤ (2 * t + 1) * ((c + 1 + b) * (c + 1 + a)) := hRHS
+    _ = (2 * t + 1) * (c + 1 + b) * (c + 1 + a) := by ring
+
+/-- The content-charged sharp bound: `numeratorShapeSharp` plus `eₜ · contentWeight`.
+
+`numeratorShapeSharp` itself is untouched, and `numeratorShapeSharp_le_loose` still holds of it —
+that lemma is arithmetic about a defined quantity, and nothing about it was defective.  What is
+defective is the claim that `Λ(βₜ)` is bounded by it: that needs the content charge, because
+[BCIKS20] Claim A.2's `Λ(ξ)` bound does.  See `contentWeight`. -/
+def numeratorShapeSharpContent (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y]) (D t : ℕ) : ℕ :=
+  1 + (t + 1) * (D - Bivariate.natDegreeY H) +
+    henselDenominatorExponent t *
+      ((Bivariate.natDegreeY R - 1) * (D - Bivariate.natDegreeY H + 1) +
+        contentWeight x₀ R H) +
+    (t - 1) * (D - Bivariate.natDegreeY R)
+
+/-- The content-charged sharp bound weakens to `(2t+1)·(dY+1)·D`, in place of the paper's
+`(2t+1)·dY·D`.  Arithmetic, using `dH ≥ 1`, `dH ≤ dY`, `dH ≤ D`, `eₜ ≤ 2t` and
+`contentWeight ≤ D - dY`.
+
+The `dY + 1` is necessary, not slack: at `dY = 2`, `dH = 2`, `D = 100`, `t = 10` the paper's bound
+is `4200` while the charged quantity reaches `5704`. -/
+lemma numeratorShapeSharpContent_le_loose (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     (hHyp : Hypotheses x₀ R H) (hH : 0 < H.natDegree) (hRdeg : 2 ≤ R.natDegree) {D : ℕ}
     (hD_H : Bivariate.totalDegree H ≤ D)
     (hD_Rx0 : Bivariate.totalDegree (Bivariate.evalX (Polynomial.C x₀) R) ≤ D) (t : ℕ) :
-    numeratorShapeSharp x₀ R H D t ≤ (2 * t + 1) * (Bivariate.natDegreeY R + 1) * D := by
+    numeratorShapeSharpContent x₀ R H D t ≤ (2 * t + 1) * (Bivariate.natDegreeY R + 1) * D := by
   -- Translate the degree facts into the bare numeric hypotheses needed by the arithmetic.
   have hdH_dY : Bivariate.natDegreeY H ≤ Bivariate.natDegreeY R :=
     natDegree_H_le_natDegree_R_of_hypotheses hHyp
@@ -365,7 +436,7 @@ lemma numeratorShapeSharp_le_loose (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
   have hcw : contentWeight x₀ R H ≤ D - Bivariate.natDegreeY R := by
     rw [show Bivariate.natDegreeY R = R.natDegree from rfl]
     exact contentWeight_le x₀ hH hHyp hRdeg hD_Rx0
-  unfold numeratorShapeSharp
+  unfold numeratorShapeSharpContent
   set D' := D
   set dH := Bivariate.natDegreeY H with hdHdef
   set dY := Bivariate.natDegreeY R with hdYdef
@@ -470,7 +541,7 @@ set_option maxHeartbeats 2000000 in
 -- exhausted by the resulting `ring`/`omega` normalisations.
 /-- Weight-tracking per-degree clearing lemma: the `Λ`-graded analogue of
 `henselClearedTerm_regular`.  Each degree-`j` summand of the cleared `(t+1)`-st residual is
-regular with sharp `Λ`-weight at most `numeratorShapeSharp x₀ R H D (t+1)`.
+regular with sharp `Λ`-weight at most `numeratorShapeSharpContent x₀ R H D (t+1)`.
 
 The proof splits on the *boundary* summand `p.1 = 0`, `j = d ≥ 2`, `p.2 = t+1`, which is the one
 place where the `d` part-certificates want one more factor of `W` than the goal supplies.  There the
@@ -490,7 +561,7 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
       RegularWeightLe hH
         (αtrunc i * (liftToFunctionField (H := H) H.leadingCoeff ^ (i + 1) *
           (embeddingOf𝒪Into𝕃 H (xi x₀ R H hHyp)) ^ henselDenominatorExponent i))
-        D (numeratorShapeSharp x₀ R H D i))
+        D (numeratorShapeSharpContent x₀ R H D i))
     (hαzero : ∀ i, t < i → αtrunc i = 0)
     (j : ℕ) (hj : j ∈ Finset.range (R.natDegree + 1)) :
     RegularWeightLe hH
@@ -499,7 +570,7 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
         (liftToFunctionField (H := H) H.leadingCoeff ^ (t + 1 + 1) *
           (embeddingOf𝒪Into𝕃 H (xi x₀ R H hHyp)) ^ (henselDenominatorExponent (t + 1) - 1) *
           liftToFunctionField (H := H) H.leadingCoeff ^ (R.natDegree - 2)))
-      D (numeratorShapeSharp x₀ R H D (t + 1)) := by
+      D (numeratorShapeSharpContent x₀ R H D (t + 1)) := by
   classical
   set W : 𝕃 H := liftToFunctionField (H := H) H.leadingCoeff with hWdef
   set eta : 𝕃 H := embeddingOf𝒪Into𝕃 H (xi x₀ R H hHyp) with hetadef
@@ -552,7 +623,7 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     have hPweq : Pw = p.2 + j := by rw [hPwdef, Finset.sum_add_distrib, hbsum]; simp
     have hprodW : RegularWeightLe hH
         ((∏ i ∈ Finset.range j, αtrunc (l i)) * (W ^ Pw * eta ^ Pe)) D
-        (∑ i ∈ Finset.range j, numeratorShapeSharp x₀ R H D (l i)) := by
+        (∑ i ∈ Finset.range j, numeratorShapeSharpContent x₀ R H D (l i)) := by
       rw [hPwdef, hPedef, ← Finset.prod_pow_eq_pow_sum, ← Finset.prod_pow_eq_pow_sum,
         ← Finset.prod_mul_distrib, ← Finset.prod_mul_distrib]
       refine RegularWeightLe.prod _ _ _ hD_H ?_
@@ -611,11 +682,11 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
           by_contra h; push Not at h; interval_cases S1 <;> omega
         omega
     -- sharp-sum identity: ∑ sharp(l i) = j + Pw*ΛW + Pe*Λξ + Pc*G
-    have hsharpSum : (∑ i ∈ Finset.range j, numeratorShapeSharp x₀ R H D (l i)) =
+    have hsharpSum : (∑ i ∈ Finset.range j, numeratorShapeSharpContent x₀ R H D (l i)) =
         j + Pw * ΛW + Pe * Λξ + Pc * G := by
-      have hexpand : ∀ i, numeratorShapeSharp x₀ R H D (l i) =
+      have hexpand : ∀ i, numeratorShapeSharpContent x₀ R H D (l i) =
           1 + (l i + 1) * ΛW + henselDenominatorExponent (l i) * Λξ + (l i - 1) * G := by
-        intro i; rw [numeratorShapeSharp, hΛWdef, hΛξdef, hGdef]
+        intro i; rw [numeratorShapeSharpContent, hΛWdef, hΛξdef, hGdef]
       simp only [hexpand]
       rw [Finset.sum_add_distrib, Finset.sum_add_distrib, Finset.sum_add_distrib]
       rw [Finset.sum_const, Finset.card_range, smul_eq_mul, Nat.mul_one]
@@ -736,9 +807,9 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
           ((regularWeightLe_liftToFunctionField hD_H hH c).mono hc_deg) hprodW)
         (hRWLeta.pow hD_H _)).mono ?_
       rw [hsharpSum]
-      have hsharpSucc : numeratorShapeSharp x₀ R H D (t + 1) =
+      have hsharpSucc : numeratorShapeSharpContent x₀ R H D (t + 1) =
           1 + (t + 2) * ΛW + (2 * t + 1) * Λξ + t * G := by
-        rw [numeratorShapeSharp, ← hΛWdef, ← hΛξdef, ← hGdef, henselDenominatorExponent_succ]
+        rw [numeratorShapeSharpContent, ← hΛWdef, ← hΛξdef, ← hGdef, henselDenominatorExponent_succ]
         rw [show 2 * (t + 1) - 1 = 2 * t + 1 by omega, show t + 1 + 1 = t + 2 by omega,
           show t + 1 - 1 = t by omega]
       rw [hsharpSucc]
@@ -803,9 +874,9 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
       -- weight: (D-j) + (j + Pw*ΛW + Pe*Λξ) + ((wb-Pw)*ΛW + (E1-Pe)*Λξ) ≤ sharp(t+1)
       rw [hsharpSum]
       -- sharp(t+1) expansion
-      have hsharpSucc : numeratorShapeSharp x₀ R H D (t + 1) =
+      have hsharpSucc : numeratorShapeSharpContent x₀ R H D (t + 1) =
           1 + (t + 2) * ΛW + (2 * t + 1) * Λξ + t * G := by
-        rw [numeratorShapeSharp, ← hΛWdef, ← hΛξdef, ← hGdef, henselDenominatorExponent_succ]
+        rw [numeratorShapeSharpContent, ← hΛWdef, ← hΛξdef, ← hGdef, henselDenominatorExponent_succ]
         rw [show 2 * (t + 1) - 1 = 2 * t + 1 by omega, show t + 1 + 1 = t + 2 by omega,
           show t + 1 - 1 = t by omega]
       rw [hsharpSucc]
@@ -861,8 +932,9 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
 
 /-- The cleared `(t+1)`-st Hensel residual `henselCoeffResidual · Ddiv` (with `Ddiv` the global
 clearing denominator `W^{t+2}·η^{E-1}·W^{d-2}`) is regular with sharp `Λ`-weight at most
-`numeratorShapeSharp x₀ R H D (t+1)`, given that every previous numerator `βseq s` (`s ≤ t`) has
-sharp weight `≤ numeratorShapeSharp x₀ R H D s`.
+`numeratorShapeSharpContent x₀ R H D (t+1)`, given that every previous numerator `βseq s`
+(`s ≤ t`) has
+sharp weight `≤ numeratorShapeSharpContent x₀ R H D s`.
 
 This is the quantitative (weight-tracking) heart of the argument: it is the `Λ`-graded
 analogue of `henselCoeffResidual_regular_after_clearing`, refining mere regularity to the sharp
@@ -881,13 +953,13 @@ lemma henselClearedResidual_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     (hshape : HasNumeratorShape x₀ R H hHyp αseq βseq)
     (t : ℕ)
     (ihAll : ∀ s ≤ t,
-      RegularWeightLe hH (embeddingOf𝒪Into𝕃 H (βseq s)) D (numeratorShapeSharp x₀ R H D s)) :
+      RegularWeightLe hH (embeddingOf𝒪Into𝕃 H (βseq s)) D (numeratorShapeSharpContent x₀ R H D s)) :
     RegularWeightLe hH
       (henselCoeffResidual x₀ R H αseq t *
         (liftToFunctionField (H := H) H.leadingCoeff ^ (t + 1 + 1) *
           (embeddingOf𝒪Into𝕃 H (xi x₀ R H hHyp)) ^ (henselDenominatorExponent (t + 1) - 1) *
           liftToFunctionField (H := H) H.leadingCoeff ^ (R.natDegree - 2)))
-      D (numeratorShapeSharp x₀ R H D (t + 1)) := by
+      D (numeratorShapeSharpContent x₀ R H D (t + 1)) := by
   classical
   set αtrunc : ℕ → 𝕃 H := fun i => if i ≤ t then αseq i else 0 with hαtrunc
   rw [henselCoeffResidual_eq_trunc x₀ R H αseq hα0 t]
@@ -912,7 +984,7 @@ lemma henselClearedResidual_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
       RegularWeightLe hH
         (αtrunc i * (liftToFunctionField (H := H) H.leadingCoeff ^ (i + 1) *
           (embeddingOf𝒪Into𝕃 H (xi x₀ R H hHyp)) ^ henselDenominatorExponent i))
-        D (numeratorShapeSharp x₀ R H D i) := by
+        D (numeratorShapeSharpContent x₀ R H D i) := by
     intro i hi
     have hW : liftToFunctionField (H := H) H.leadingCoeff ≠ 0 :=
       liftToFunctionField_leadingCoeff_ne_zero (H := H)
@@ -931,7 +1003,8 @@ lemma henselClearedResidual_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
   intro j hj
   exact henselClearedTerm_weight x₀ R H hHyp hH hD_H hD_R hD_Rx0 hRdeg t αtrunc ihNum hαzero j hj
 
-/-- Sharp `Λ`-weight bound on every Hensel numerator: `Λ(βₜ) ≤ numeratorShapeSharp x₀ R H D t`,
+/-- Sharp `Λ`-weight bound on every Hensel numerator:
+`Λ(βₜ) ≤ numeratorShapeSharpContent x₀ R H D t`,
 i.e. `1 + (t+1)(D-dH) + eₜ(dY-1)(D-dH+1)` plus the correction term.  Proved by strong induction,
 the successor step being `henselClearedResidual_weight` together with the identity
 `embeddingOf𝒪Into𝕃 (βₜ₊₁) = -(henselCoeffResidual · Ddiv)`.
@@ -940,7 +1013,8 @@ The hypothesis `2 ≤ dY` is the standing assumption under which `ξ = W^{dY-2}�
 for `dY < 2` that expression carries a negative power of `W`.  It is load-bearing rather than
 cosmetic.  Truncated subtraction silently reads `W^{dY-2}` as `1` for `dY ≤ 2`, so dropping the
 hypothesis would make this statement *false*: with `dY = dH = 1` one has `ξ = ζ`, of weight up to
-`D - 1 > 0`, while the factor `(dY-1) = 0` erases the `ξ`-contribution from `numeratorShapeSharp`.
+`D - 1 > 0`, while the factor `(dY-1) = 0` erases the `ξ`-contribution from
+`numeratorShapeSharpContent`.
 A witness is `R = (1+Z)Y + 1 + ZX`, `x₀ = 0`, `H = (1+Z)Y + 1`, where `D = 2` and `Λ(ξ) = 1` against
 a bound of `0`.  Accordingly `xi_weight_le` assumes `2 ≤ dY` as well. -/
 theorem numerator_shape_weight_sharp (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
@@ -954,7 +1028,7 @@ theorem numerator_shape_weight_sharp (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     (hroot : evalRAtPowerSeries x₀ H R (gammaFromAlpha H αseq) = 0)
     (hshape : HasNumeratorShape x₀ R H hHyp αseq βseq) :
     ∀ t : ℕ, RegularWeightLe hH (embeddingOf𝒪Into𝕃 H (βseq t)) D
-      (numeratorShapeSharp x₀ R H D t) := by
+      (numeratorShapeSharpContent x₀ R H D t) := by
   intro t
   induction t using Nat.strong_induction_on with
   | _ t ih =>
@@ -970,7 +1044,7 @@ theorem numerator_shape_weight_sharp (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
           simpa only [pow_one, one_mul] using (weight_X_pow_le (H := H) (D := D) (k := 1))
         refine hX.trans ?_
         rw [WithBot.coe_le_coe]
-        unfold numeratorShapeSharp
+        unfold numeratorShapeSharpContent
         rw [henselDenominatorExponent_zero]
         omega
     | succ t =>
@@ -989,7 +1063,8 @@ theorem numerator_shape_weight_sharp (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
           hroot hshape t (fun s hs => ih s (Nat.lt_succ_of_le hs))
 
 /-- The loose bound `Λ(βₜ) ≤ (2t+1)·dY·D` for a numerator sequence presented through its
-coefficients, obtained from `numerator_shape_weight_sharp` by `numeratorShapeSharp_le_loose`.  This
+coefficients, obtained from `numerator_shape_weight_sharp` by
+`numeratorShapeSharpContent_le_loose`.  This
 is the form consumers usually want. -/
 theorem numerator_shape_weight_bound (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     [_H_irreducible : Fact (Irreducible H)] [_H_natDegree_pos : Fact (0 < H.natDegree)]
@@ -1009,7 +1084,8 @@ theorem numerator_shape_weight_bound (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     numerator_shape_weight_sharp x₀ R H hHyp hH hD_H hD_R hRdeg αseq βseq hα0 hroot hshape t
   refine (regularWeight_le_of_regularWeightLe (βseq t) hsharp).trans ?_
   rw [WithBot.coe_le_coe]
-  exact numeratorShapeSharp_le_loose x₀ R H hHyp hH (by simpa [Bivariate.natDegreeY] using hRdeg)
+  exact numeratorShapeSharpContent_le_loose x₀ R H hHyp hH
+    (by simpa [Bivariate.natDegreeY] using hRdeg)
     hD_H (evalX_totalDegree_le_of_coeff_bound x₀ R hD_R) t
 
 /-- A sequence with the Hensel-lift semantics has the numerator shape witnessed by
@@ -1026,7 +1102,7 @@ lemma hasNumeratorShape_alphaOfNumerators (x₀ : F) (R : F[X][X][Y]) (H : F[X][
 
 /-- The **sharp** weight bound for an arbitrary Hensel numerator sequence:
 `Λ(βₜ) ≤ 1 + (t+1)Λ(W) + eₜΛ(ξ)`, with the bounds `Λ(W) ≤ D - dH` and
-`Λ(ξ) ≤ (dY-1)(D - dH + 1)` substituted, plus the correction term of `numeratorShapeSharp`.
+`Λ(ξ) ≤ (dY-1)(D - dH + 1)` substituted, plus the correction term of `numeratorShapeSharpContent`.
 
 This is the form to use when the bound has to telescope across `t = 0, …, k`:
 `max_t (Λ(βₜ) + (k-t)Λ(W) + (e_k-eₜ)Λ(ξ)) = 1 + (k+1)Λ(W) + e_kΛ(ξ) ≤ (2k+1)dD`.
@@ -1040,7 +1116,7 @@ theorem hensel_numerator_weight_sharp_le (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y
     {βseq : ℕ → 𝒪 H} (hβ : IsHenselNumeratorSequence x₀ R H hHyp βseq) :
     ∀ t : ℕ,
       regularWeight hH (βseq t) D ≤
-        (WithBot.some (numeratorShapeSharp x₀ R H D t) : WithBot ℕ) := by
+        (WithBot.some (numeratorShapeSharpContent x₀ R H D t) : WithBot ℕ) := by
   intro t
   exact regularWeight_le_of_regularWeightLe (βseq t)
     (numerator_shape_weight_sharp x₀ R H hHyp hH hD_H hD_R hRdeg
@@ -1062,7 +1138,8 @@ theorem hensel_numerator_weight_le (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
   intro t
   refine (hensel_numerator_weight_sharp_le x₀ R H hHyp hH hD_H hD_R hRdeg hβ t).trans ?_
   rw [WithBot.coe_le_coe]
-  exact numeratorShapeSharp_le_loose x₀ R H hHyp hH (by simpa [Bivariate.natDegreeY] using hRdeg)
+  exact numeratorShapeSharpContent_le_loose x₀ R H hHyp hH
+    (by simpa [Bivariate.natDegreeY] using hRdeg)
     hD_H (evalX_totalDegree_le_of_coeff_bound x₀ R hD_R) t
 
 

--- a/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Weight.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Weight.lean
@@ -21,9 +21,8 @@ import ArkLib.Data.Polynomial.RationalFunctions.HenselNumerators.Hensel
 # Weight Bounds for the Hensel Numerators
 
 Appendix A.4 of [BCIKS20], the quantitative half of Claim A.2: the `RegularWeightLe`
-certificate calculus on `𝕃 H`, the sharp per-step budget
-`numeratorShapeSharp = 1 + (t+1)Λ(W) + eₜΛ(ξ)`, its weakening to the paper's `(2t+1)·d·D`, and the
-induction transporting them along the cleared Hensel residual.
+certificate calculus on `𝕃 H`, the corrected sharp per-step budget, its loose weakening, and
+the induction transporting them along the cleared Hensel residual.
 
 Everything here is proved.  Two places diverge from the inequalities [BCIKS20] states.
 
@@ -33,8 +32,10 @@ docstring.  It and `numeratorShapeSharp_le_loose` are exactly as the paper's acc
 
 The numerators are then bounded not by `numeratorShapeSharp` but by
 `numeratorShapeSharpContent`, which adds `eₜ · contentWeight`, and the loose bound becomes
-`(2t+1)·(dY+1)·D` in place of `(2t+1)·dY·D`.  That is forced: A.2's `Λ(ξ)` bound omits a content
-charge and is false without it.  See `RationalFunctions.HenselNumerators.contentWeight`.
+`(2t+1)·(dY+1)·D` in place of `(2t+1)·dY·D`.  The content charge is required by the proved
+sharp estimate because A.2's `Λ(ξ)` bound is false without it.  The `dY+1` form is a convenient
+uniform weakening; it is not claimed to be optimal.  See
+`RationalFunctions.HenselNumerators.contentWeight`.
 
 ## References
 
@@ -330,11 +331,12 @@ parts each `≤ t`, hence at least two nonzero parts `S ≥ 2`, and then
 `t·(D - dY) - ∑ᵢ (lᵢ-1)·(D - dY) = (S-1)·(D - dY) ≥ D - dY`.
 Every other summand satisfies `∑ᵢ (lᵢ-1) ≤ t`, so the correction never costs anything there.
 
-## Why the correction costs nothing
+## Arithmetic weakening of the uncharged budget
 
-`numeratorShapeSharp_le_loose` still gives the loose bound `(2t+1)·dY·D`, and that is the form
-consumers want, since the correction is invisible to the telescoping they perform:
-`max_t (sharp t + (k-t)Λ(W) + (e_k-eₜ)Λ(ξ)) = sharp k ≤ (2k+1)·dY·D`.
+`numeratorShapeSharp_le_loose` still gives `(2t+1)·dY·D` for this defined quantity: the recursion
+correction alone fits within the paper's loose arithmetic budget.  The theorem is retained because
+it is valid, but it is not the final numerator bound after the separate specialization-content
+charge below is included.
 
 The uncorrected bound would follow instead from `Λ(αₜ) ≤ Λ(T) - Λ(W)`, i.e. from a weight function
 on `𝕃` rather than on `𝒪`, giving `Λ(T) + t·deg W ≤ 1 + (t+1)(D - dH)`.  That route is not taken
@@ -413,8 +415,8 @@ def numeratorShapeSharpContent (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y]) (D t : 
 `(2t+1)·dY·D`.  Arithmetic, using `dH ≥ 1`, `dH ≤ dY`, `dH ≤ D`, `eₜ ≤ 2t` and
 `contentWeight ≤ D - dY`.
 
-The `dY + 1` is necessary, not slack: at `dY = 2`, `dH = 2`, `D = 100`, `t = 10` the paper's bound
-is `4200` while the charged quantity reaches `5704`. -/
+This proves a safe uniform budget.  It does not show that an actual Hensel numerator can attain the
+budget, or that the paper's smaller loose bound is false after cancellations in the recursion. -/
 lemma numeratorShapeSharpContent_le_loose (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     (hHyp : Hypotheses x₀ R H) (hH : 0 < H.natDegree) (hRdeg : 2 ≤ R.natDegree) {D : ℕ}
     (hD_H : Bivariate.totalDegree H ≤ D)
@@ -1062,10 +1064,9 @@ theorem numerator_shape_weight_sharp (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
         exact henselClearedResidual_weight x₀ R H hHyp hH hD_H hD_R hD_Rx0 hRdeg αseq βseq hα0
           hroot hshape t (fun s hs => ih s (Nat.lt_succ_of_le hs))
 
-/-- The loose bound `Λ(βₜ) ≤ (2t+1)·dY·D` for a numerator sequence presented through its
+/-- The loose bound `Λ(βₜ) ≤ (2t+1)·(dY+1)·D` for a numerator sequence presented through its
 coefficients, obtained from `numerator_shape_weight_sharp` by
-`numeratorShapeSharpContent_le_loose`.  This
-is the form consumers usually want. -/
+`numeratorShapeSharpContent_le_loose`.  This is the form consumers usually want. -/
 theorem numerator_shape_weight_bound (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     [_H_irreducible : Fact (Irreducible H)] [_H_natDegree_pos : Fact (0 < H.natDegree)]
     (hHyp : Hypotheses x₀ R H) (hH : 0 < H.natDegree)
@@ -1102,11 +1103,12 @@ lemma hasNumeratorShape_alphaOfNumerators (x₀ : F) (R : F[X][X][Y]) (H : F[X][
 
 /-- The **sharp** weight bound for an arbitrary Hensel numerator sequence:
 `Λ(βₜ) ≤ 1 + (t+1)Λ(W) + eₜΛ(ξ)`, with the bounds `Λ(W) ≤ D - dH` and
-`Λ(ξ) ≤ (dY-1)(D - dH + 1)` substituted, plus the correction term of `numeratorShapeSharpContent`.
+`Λ(ξ) ≤ (dY-1)(D - dH + 1) + contentWeight` substituted, plus the recursion correction
+term of `numeratorShapeSharpContent`.
 
 This is the form to use when the bound has to telescope across `t = 0, …, k`:
-`max_t (Λ(βₜ) + (k-t)Λ(W) + (e_k-eₜ)Λ(ξ)) = 1 + (k+1)Λ(W) + e_kΛ(ξ) ≤ (2k+1)dD`.
-The loose bound `numerator_shape_weight_bound` does *not* suffice there. -/
+the explicit content-charged shape preserves the dependence on `t` that the assembly needs.  The
+loose bound `numerator_shape_weight_bound` does *not* by itself suffice for that step. -/
 theorem hensel_numerator_weight_sharp_le (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     [_H_irreducible : Fact (Irreducible H)] [_H_natDegree_pos : Fact (0 < H.natDegree)]
     (hHyp : Hypotheses x₀ R H) (hH : 0 < H.natDegree)
@@ -1123,7 +1125,7 @@ theorem hensel_numerator_weight_sharp_le (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y
       (alphaOfNumerators x₀ R H hHyp βseq) βseq hβ.1 hβ.2
       (hasNumeratorShape_alphaOfNumerators x₀ R H hHyp βseq) t)
 
-/-- The loose weight bound `Λ(βₜ) ≤ (2t+1)·dY·D` for an arbitrary Hensel numerator sequence.
+/-- The loose weight bound `Λ(βₜ) ≤ (2t+1)·(dY+1)·D` for an arbitrary Hensel numerator sequence.
 Weakening of `hensel_numerator_weight_sharp_le`. -/
 theorem hensel_numerator_weight_le (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     [_H_irreducible : Fact (Irreducible H)] [_H_natDegree_pos : Fact (0 < H.natDegree)]

--- a/docs/kb/audits/bciks20-appendix-a-rational-functions.md
+++ b/docs/kb/audits/bciks20-appendix-a-rational-functions.md
@@ -47,11 +47,11 @@ Downstream users include the BCIKS20 list-decoding agreement files under
 | Claim A.2 Hensel lift exists (`α₀ = T/W`, `R(X, γ, Z) = 0`) | present | `exists_hensel_alpha_sequence`, `formalHenselAlphaSequence` | Axiom-clean. |
 | A.4 uniqueness of the lift | present | `hensel_alpha_sequence_unique`, `IsHenselNumeratorSequence.unique`, `IsHenselNumeratorSequence.eq_betaSeq` | Axiom-clean. Needed by [BCIKS20] Claim 5.9; also makes `betaSeq` canonical rather than an arbitrary choice. |
 | Claim A.2 regularity of `ξ` | present | `xi_regular`, `embeddingOf𝒪Into𝕃_xi` | The total Lean form of `ξ` has a concrete quotient representative `xiPre`. |
-| Claim A.2 bound for `ξ` | present | `xi_weight_le` | Assumes `2 ≤ natDegreeY R`, which is the paper's standing assumption in A.4 (see below). |
+| Claim A.2 bound for `ξ` | corrected | `contentWeight`, `contentWeight_le`, `xi_weight_le` | Assumes `2 ≤ natDegreeY R` and adds the specialization-content term omitted by the paper (finding 3). |
 | Claim A.2 regular numerators `βₜ` exist | present | `exists_hensel_numerator_sequence`, `IsHenselNumeratorSequence`, `exists_regular_numerator_shape`, `henselCoeffResidual_regular_after_clearing` | Axiom-clean, and deliberately *free of the weight conjunct* so that `betaSeq`/`α`/`γ` do not depend on the open quantitative step. |
-| Claim A.2 sharp weight bound | present | `numerator_shape_weight_sharp`, `hensel_numerator_weight_sharp_le`, `betaSeq_weight_sharp_le` | Proved, with a correction term relative to the paper's stated inequality — see finding 2. This is the form Claim 5.10 needs. |
-| Claim A.2 loose weight bound `Λ(βₜ) ≤ (2t+1)dD` | present | `numerator_shape_weight_bound`, `hensel_numerator_weight_le`, `betaSeq_weight_le` | Weakening of the sharp bound via `numeratorShapeSharp_le_loose`; unaffected by the correction, so Claim 5.10 gets exactly what the paper gives it. |
-| Claim A.2 as stated in the paper | present | `exists_hensel_numerators_with_weight_bounds` | Bundles existence with both weight bounds. Axiom-clean. |
+| Claim A.2 sharp weight bound | corrected | `numeratorShapeSharpContent`, `numerator_shape_weight_sharp`, `hensel_numerator_weight_sharp_le`, `betaSeq_weight_sharp_le` | Includes both the recursion correction (finding 2) and the specialization-content charge (finding 3). |
+| Claim A.2 loose weight bound | corrected | `numeratorShapeSharpContent_le_loose`, `numerator_shape_weight_bound`, `hensel_numerator_weight_le`, `betaSeq_weight_le` | The proved uniform form is `Λ(βₜ) ≤ (2t+1)(dY+1)D`. It is sufficient, but not asserted to be optimal. |
+| Corrected Claim A.2 package | present | `exists_hensel_numerators_with_weight_bounds` | Bundles existence with the content-aware sharp and conservative loose bounds. Axiom-clean. |
 | Hensel-lift coefficients `α`, `γ` | present | `alpha`, `alpha'`, `gamma`, `gamma'`, `betaSeq`, `betaSeq_spec` | Now defined from the qualitative existence theorem alone, hence axiom-clean. |
 
 ## Three findings on Appendix A.4
@@ -107,13 +107,11 @@ The correction pays that deficit and is superadditive on precisely the configura
 deficit occurs. The boundary summand needs `p.2 = t+1` split into `d` parts each `≤ t`, hence at
 least two nonzero parts `S₁ ≥ 2`, and then
 `t·(D - dY) - ∑ᵢ (lᵢ-1)·(D - dY) = (S₁-1)·(D - dY) ≥ D - dY ≥ Λ(c)`.
-Every other summand has `∑ᵢ (lᵢ-1) ≤ t`, so the correction is free there. Simply raising the
-`ξ`-charge instead would *not* work: it breaks the loose bound the paper quotes
-(`d = 2, dH = 1, D = 100, Λ(W) = 0, t = 5` gives `2377 > 2200 = (2t+1)dD`).
+Every other summand has `∑ᵢ (lᵢ-1) ≤ t`, so the correction is free there.
 
-**Nothing downstream is weakened.** `numeratorShapeSharp_le_loose` still yields `(2t+1)·dY·D`, and
-that is the only form Claim 5.10 consumes: its telescoping maximizes at `t = k`, giving
-`max_t (sharp t + (k-t)Λ(W) + (e_k-eₜ)Λ(ξ)) = sharp k ≤ (2k+1)·dY·D`.
+The arithmetic theorem `numeratorShapeSharp_le_loose` still yields `(2t+1)·dY·D` for that
+*defined budget*. It must not be confused with a bound on the actual numerators after finding 3:
+the latter use `numeratorShapeSharpContent`.
 
 The paper's *literal* inequality would follow from its other route — `Λ(αₜ) = Λ(Y)`, i.e. a weight
 function on `𝕃` rather than on `𝒪`, which gives `Λ(T) + t·deg W ≤ 1 + (t+1)(D - dH)` with no
@@ -122,25 +120,40 @@ from `weight_mul`, since multiplying by an `F[Z]`-element never triggers reducti
 the crux is open: bounding `αₜ = -cₜ/ζ` requires a **lower** bound on `Λ(ζ)`, and only upper bounds
 are available. Newton-polygon reasoning has the same shape — bounding root degrees needs a lower
 bound on the leading coefficient. That is what the paper's one-line "γ has the same weight as Y,
-since X and x₀ have weight 0" conceals. Since both routes deliver the same usable consequence, this
-is a fidelity question only.
+since X and x₀ have weight 0" conceals. Completing that route could recover the paper's smaller
+budget; it is not currently part of the proved API.
 
-### 3. The paper's sharper `Λ(ξ)` bound also assumes `Λ(W) = D - dH`
+### 3. The paper's `Λ(ξ)` bound omits specialization content
 
-A.4 states `Λ(ξ) ≤ (D-1) + (d-2)Λ(W) ≤ (d-1)(D-dH+1)`. Only the second, weaker form is formalized
-(`xi_weight_le`), and the first is *not* provable as stated. With `ξ`'s explicit representative
-`xiPre = ∑_{i<d-1} C(Pᵢ W^{d-2-i}) Tⁱ + C(P_{d-1}/W) T^{d-1}` (`P = ∂R/∂Y(x₀,·,Z)`, so
-`deg_Z Pᵢ ≤ D-1-i`), the `i`-th monomial has weight `i·(D-dH+1) + (D-1-i) + (d-2-i)Λ(W)`, and
-requiring that to be `≤ (D-1) + (d-2)Λ(W)` for all `i` reduces to `D - dH ≤ Λ(W)` — the same hidden
-assumption as in finding 2, since `Λ(W) ≤ D - dH` always. Under that assumption the two forms agree
-up to `d - dH`; in general only the weaker one holds, and it is the one used here.
+A.4 states `Λ(ξ) ≤ (D-1) + (d-2)Λ(W) ≤ (d-1)(D-dH+1)`. The final `T^{d-1}` coefficient of
+the explicit representative is `P_{d-1}/W`; when `dH = d`, this is the content left in
+`R(x₀,Y,Z) = H(Y,Z)·C(Z)`. Fraction-field separability does not force `C` to be a unit.
+
+The missing contribution is formalized as `contentWeight x₀ R H`, with
+`contentWeight ≤ D-dY`, and the proved estimate is
+
+```
+Λ(ξ) ≤ (dY-1)(D-dH+1) + contentWeight x₀ R H.
+```
+
+This is a genuine counterexample to the literal Claim A.2 bound. Over `𝔽₅`, take
+`R = Z·Y² + Z·Y + (Z+X)`, `x₀ = 0`, `H = Y²+Y+1`, and `D = 3`. The specialization is separable
+over `𝔽₅(Z)`, while `ξ` has representative `Z + 2Z·T` of weight `3`; the paper's bound is `2`.
+
+Propagating the proved sharp budget gives the safe loose bound `(2t+1)(dY+1)D`. This does **not**
+show that an actual numerator attains that arithmetic budget, so the extra `+1` is not claimed to
+be necessary and the paper's smaller loose numerator bound is not marked disproved.
 
 ## Near-Term Work
 
-1. Case-split on `deg_Y R` in §5 to discharge `2 ≤ natDegreeY R` (finding 1 above).
-2. Optional, fidelity only: extend `Λ` to `𝕃` and prove `Λ(αₜ) ≤ Λ(T) - Λ(W)` to obtain the
+1. Complete the degree-one/direct-root branch in §5; the Claims 5.8--5.11 APIs now explicitly
+   isolate the `2 ≤ natDegreeY R` branch (finding 1).
+2. Formalize the finite exceptional-set argument behind
+   `Claim57Assumptions.positive_pair_for_every_z`, so content roots cannot masquerade as
+   positive-`Y`-degree factors.
+3. Optional, fidelity only: extend `Λ` to `𝕃` and prove `Λ(αₜ) ≤ Λ(T) - Λ(W)` to obtain the
    paper's uncorrected sharp inequality (finding 2 above). No downstream consequence.
 
 **Appendix A is otherwise complete**: every declaration in
-`ArkLib/Data/Polynomial/RationalFunctions/` is axiom-clean (266 declarations, zero `sorryAx`, zero
-non-standard axioms), including Lemma A.1 and all of Claim A.2.
+`ArkLib/Data/Polynomial/RationalFunctions/` is axiom-clean, including Lemma A.1 and the corrected
+Claim A.2 package.

--- a/scripts/axiom_baseline.json
+++ b/scripts/axiom_baseline.json
@@ -206,7 +206,7 @@
   "ProximityGap.correlatedAgreement_affine_curves",
   "ProximityGap.correlatedAgreement_affine_spaces",
   "ProximityGap.discr_of_irred_components_nonzero",
-  "ProximityGap.evalX_R_separable",
+  "ProximityGap.evalX_R_separable_over_ratFunc",
   "ProximityGap.exists_a_set_and_a_matching_polynomial",
   "ProximityGap.exists_factors_with_large_common_root_set",
   "ProximityGap.exists_points_with_large_matching_subset",


### PR DESCRIPTION
## Summary

This PR repairs two genuine defects in the BCIKS20 formalization and cleans up the surrounding
§5 statement interfaces after a line-by-line review against [BCIKS20, ePrint
2020/654](https://eprint.iacr.org/2020/654.pdf) and the downstream ABF26/EF-Millenium usage.

1. The separability needed by Appendix A is separability of `R(x₀, Y, Z)` as a polynomial in `Y`
   over `F(Z)`, not over `F[Z]`.
2. The literal Claim A.2 bound on `ξ` omits the cost of clearing content introduced by
   specialization. The corrected formal bound includes `contentWeight`.

The review also found that several §5 statements had silently omitted load-bearing hypotheses or
bridges. Those are now explicit instead of being hidden behind too-weak theorem interfaces.

## What changed

### Separability and Appendix A

- State the Hensel separability hypothesis over `RatFunc F` and prove the required map from the
  polynomial-ring specialization.
- Add an exact `𝔽₅` counterexample to the paper's literal `ξ` weight bound:
  `R = ZY² + ZY + (Z + X)`, `x₀ = 0`, `H = Y² + Y + 1`, `D = 3`.
- Account for specialization content with `contentWeight` and prove the resulting sharp and loose
  numerator bounds.
- Use `(2t+1)(dY+1)D` only as a conservative proved bound. The PR no longer claims that the extra
  `+1` is necessary or that an actual numerator attains the arithmetic budget; the invalid
  numerical witness for that claim was removed.

### Section 5 statement repair

- Add `Section5Regime`, recording the standing assumptions used by §5: `m ≥ 3`, `k+1 < n`, the
  permitted `δ` range, `D_Y Q > 0`, and the content-aware cardinality bound.
- Use real-valued division/cardinality comparisons in Proposition 5.5 and Claim 5.7 rather than
  truncated natural-number division.
- Give Claim 5.6 the finite-field discriminant-degree premise needed to choose a good `x₀`.
- Count only positive-`Y`-degree factors in Claim 5.7. `Claim57Assumptions` explicitly records the
  remaining content/exceptions bridge and specialization separability until the paper's finite
  exceptional-set argument is formalized.
- Restrict the Appendix A weight path to the `2 ≤ natDegreeY R` branch and expose its factor-degree
  premises. A degree-one factor should instead use its rational root directly; that branch remains
  a separate proof obligation.
- Thread the corrected `D_YZ Q` and content-aware bounds through Claims 5.10 and 5.11.

### API and scope cleanup

- Retain the existing ring-level separability helper theorems that were valid; add filtered and
  fraction-field APIs instead of deleting sound statements.
- Remove the unrelated `Bivariate.rootMultiplicity₀` proof rewrite from the final PR diff.
- Rebase onto current `main`; the already-merged Proposition 5.5 / `D_YZ` repair from #772 is no
  longer duplicated here.
- Update the Appendix A audit to distinguish proved corrections, conservative bounds, and open
  proof obligations.

## Verification

- `./scripts/validate.sh`
- `lake exe axiomsweep --check` — no new `sorryAx` or non-standard-axiom taint
- Full `lake build ArkLib`
- Targeted compilation of the modified BCIKS20 and rational-function modules
- Existing `sorry` counts in the touched §5 modules are unchanged

## Scope note

This PR fixes the statements and proved Appendix A support it touches. It does not claim to have
completed the existing `sorry` proofs for the Claim 5.7 exceptional-set/content bridge or the
degree-one direct-root branch; those obligations are now visible in the APIs and documentation.
