### PR TITLE
refactor(polynomial): make trivariate axes explicit

### DIFF
--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Agreement.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Agreement.lean
@@ -28,14 +28,14 @@ open Bivariate in
 lemma exists_factors_with_large_common_root_set (δ : ℚ) (x₀ : F)
   (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
   ∃ R H, R ∈ (irreducible_factorization_of_gs_solution h_gs).choose_spec.choose ∧
-    Irreducible H ∧ 0 < H.natDegree ∧ H ∣ (Bivariate.evalX (Polynomial.C x₀) R) ∧
-    (Bivariate.evalX (Polynomial.C x₀) R).Separable ∧
+    Irreducible H ∧ 0 < H.natDegree ∧ H ∣ Trivariate.evalAtX x₀ R ∧
+    (Trivariate.evalAtX x₀ R).Separable ∧
     #(@Set.toFinset _ { z : coeffs_of_close_proximity (F := F) k ωs δ u₀ u₁ |
         letI Pz := Pz z.2
-        (Trivariate.eval_on_Z R z.1).eval Pz = 0 ∧
+        (Trivariate.evalAtZ z.1 R).eval Pz = 0 ∧
         (Bivariate.evalX z.1 H).eval (Pz.eval x₀) = 0} (Fintype.ofFinite _))
-    ≥ #(coeffs_of_close_proximity k ωs δ u₀ u₁) / (Bivariate.natDegreeY Q)
-    ∧ #(coeffs_of_close_proximity k ωs δ u₀ u₁) / (Bivariate.natDegreeY Q) >
+    ≥ #(coeffs_of_close_proximity k ωs δ u₀ u₁) / Trivariate.degreeInY Q
+    ∧ #(coeffs_of_close_proximity k ωs δ u₀ u₁) / Trivariate.degreeInY Q >
       2 * D_Y Q ^ 2 * (D_X ((k + 1 : ℚ) / n) n m) * D_YZ Q := by sorry
 
 /-- Claim 5.7 establishes existens of a polynomial `R`. his is the extraction of this polynomial. -/
@@ -60,12 +60,12 @@ lemma natDegree_H_pos (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
 
 /-- The extracted `H` divides `R(x₀, Y, Z)`, as required for the Hensel setup in Claim A.2. -/
 lemma H_dvd_evalX_R (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
-    H k δ x₀ h_gs ∣ Bivariate.evalX (Polynomial.C x₀) (R k δ x₀ h_gs) :=
+    H k δ x₀ h_gs ∣ Trivariate.evalAtX x₀ (R k δ x₀ h_gs) :=
   (exists_factors_with_large_common_root_set k δ x₀ h_gs).choose_spec.choose_spec.2.2.2.1
 
 /-- The specialization `R(x₀, Y, Z)` is separable in `Y`, as required for Claim A.2. -/
 lemma evalX_R_separable (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
-    (Bivariate.evalX (Polynomial.C x₀) (R k δ x₀ h_gs)).Separable :=
+    (Trivariate.evalAtX x₀ (R k δ x₀ h_gs)).Separable :=
   (exists_factors_with_large_common_root_set k δ x₀ h_gs).choose_spec.choose_spec.2.2.2.2.1
 
 open RationalFunctions.HenselNumerators in
@@ -74,7 +74,7 @@ open RationalFunctions.HenselNumerators in
 Note for Claims 5.8/5.10: this supplies the *qualitative* half of Claim A.2 (existence and
 uniqueness of the Hensel lift, regularity of the numerators), which is all that
 `RationalFunctions.HenselNumerators.exists_hensel_numerator_sequence` and hence `alpha`/`gamma`
-need.  The **weight** bounds additionally require `2 ≤ Bivariate.natDegreeY R`, and that side
+need. The **weight** bounds additionally require `2 ≤ Trivariate.degreeInY R`, and that side
 condition cannot be obtained from Claim 5.7:
 
 * `R` is an arbitrary irreducible factor of `Q` at that point, and `deg_Y R = 1` is precisely what
@@ -192,7 +192,7 @@ lemma solution_gamma_matches_word_if_subset_large
     (hx : (matching_set_at_x k δ h_gs x).card >
       (2 * k + 1)
         * (Bivariate.natDegreeY <| H k δ x₀ h_gs)
-        * (Bivariate.natDegreeY <| R k δ x₀ h_gs)
+        * (Trivariate.degreeInY <| R k δ x₀ h_gs)
         * D)
     : (P k δ x₀ h_gs).eval (Polynomial.C (ωs x)) =
       (Polynomial.C <| u₀ x) + u₁ x • Polynomial.X
@@ -214,7 +214,7 @@ lemma exists_points_with_large_matching_subset
       (matching_set_at_x k δ h_gs x).card >
         (2 * k + 1)
         * (Bivariate.natDegreeY <| H k δ x₀ h_gs)
-        * (Bivariate.natDegreeY <| R k δ x₀ h_gs)
+        * (Trivariate.degreeInY <| R k δ x₀ h_gs)
         * D := by sorry
 
 end BCIKS20ProximityGapSection5

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Extraction.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Extraction.lean
@@ -100,7 +100,7 @@ noncomputable def pg_candidatePairs
   let Rset := pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs
   Rset.biUnion (fun R =>
     (UniqueFactorizationMonoid.normalizedFactors
-        (Bivariate.evalX (Polynomial.C x₀) R)).toFinset.image (fun H => (R, H)))
+        (Trivariate.evalAtX x₀ R)).toFinset.image (fun H => (R, H)))
 
 omit [DecidableEq (RatFunc F)] [Finite F] in
 theorem pg_natDegree_pos_of_mem_normalizedFactors_of_separable (p : F[Z][X])
@@ -133,7 +133,7 @@ theorem pg_candidatePairs_snd_natDegree_pos (x₀ : F)
     (hsep : ∀ R : F[Z][X][Y],
       R ∈ pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
           (u₀ := u₀) (u₁ := u₁) h_gs →
-        (Bivariate.evalX (Polynomial.C x₀) R).Separable)
+        (Trivariate.evalAtX x₀ R).Separable)
     {R : F[Z][X][Y]} {H : F[Z][X]}
     (hmem : (R, H) ∈ pg_candidatePairs (m := m) (n := n) (k := k) (ωs := ωs)
       (Q := Q) (u₀ := u₀) (u₁ := u₁) x₀ h_gs) :
@@ -144,10 +144,10 @@ theorem pg_candidatePairs_snd_natDegree_pos (x₀ : F)
           (u₀ := u₀) (u₁ := u₁) h_gs ∧
         H ∈
           UniqueFactorizationMonoid.normalizedFactors
-            (Bivariate.evalX (Polynomial.C x₀) R) := by
+            (Trivariate.evalAtX x₀ R) := by
     simpa [pg_candidatePairs] using hmem
   exact pg_natDegree_pos_of_mem_normalizedFactors_of_separable
-    (Bivariate.evalX (Polynomial.C x₀) R) (hsep R h'.1) h'.2
+    (Trivariate.evalAtX x₀ R) (hsep R h'.1) h'.2
 
 omit [DecidableEq (RatFunc F)] [Finite F] in
 theorem pg_card_normalizedFactors_toFinset_le_natDegree (p : F[Z][X]) (hp : p.Separable) :
@@ -195,16 +195,17 @@ theorem pg_card_normalizedFactors_toFinset_le_natDegree (p : F[Z][X]) (hp : p.Se
   simpa [s] using hfin
 
 omit [DecidableEq F] [DecidableEq (RatFunc F)] [Finite F] in
+/-- Compatibility alias for the general trivariate evaluation bridge. -/
+@[deprecated Trivariate.evalAtX_eq_map_evalRingHom (since := "2026-08-21")]
 theorem pg_evalX_eq_map_evalRingHom (x₀ : F) (R : F[Z][X][Y]) :
-    Bivariate.evalX (Polynomial.C x₀) R = R.map (Polynomial.evalRingHom (Polynomial.C x₀)) := by
-  classical
-  ext n n'
-  · simp [Bivariate.evalX, Polynomial.coeff_map]
-    simp [Polynomial.coeff]
+    Bivariate.evalX (Polynomial.C x₀) R =
+      R.map (Polynomial.evalRingHom (Polynomial.C x₀)) := by
+  simpa [Trivariate.evalAtX] using Trivariate.evalAtX_eq_map_evalRingHom x₀ R
 
-open scoped Polynomial.Bivariate in
-noncomputable def pg_eval_on_Z (p : F[Z][X][Y]) (z : F) : Polynomial (Polynomial F) :=
-  p.map (Polynomial.mapRingHom (Polynomial.evalRingHom z))
+/-- Compatibility alias for `Trivariate.evalAtZ`. -/
+@[deprecated Trivariate.evalAtZ (since := "2026-08-21")]
+noncomputable abbrev pg_eval_on_Z (p : F[Z][X][Y]) (z : F) : Polynomial (Polynomial F) :=
+  Trivariate.evalAtZ z p
 
 omit [DecidableEq (RatFunc F)] in
 theorem pg_exists_H_of_R_eval_zero (δ : ℚ) (x₀ : F)
@@ -212,10 +213,10 @@ theorem pg_exists_H_of_R_eval_zero (δ : ℚ) (x₀ : F)
   (z : coeffs_of_close_proximity (F := F) k ωs δ u₀ u₁)
   (R : F[Z][X][Y]) :
   let P : F[X] := Pz (k := k) (ωs := ωs) (δ := δ) (u₀ := u₀) (u₁ := u₁) z.2
-  (pg_eval_on_Z (F := F) R z.1).eval P = 0 →
-  Bivariate.evalX (Polynomial.C x₀) R ≠ 0 →
+  (Trivariate.evalAtZ z.1 R).eval P = 0 →
+  Trivariate.evalAtX x₀ R ≠ 0 →
   ∃ H,
-    H ∈ UniqueFactorizationMonoid.normalizedFactors (Bivariate.evalX (Polynomial.C x₀) R) ∧
+    H ∈ UniqueFactorizationMonoid.normalizedFactors (Trivariate.evalAtX x₀ R) ∧
     (Bivariate.evalX z.1 H).eval (P.eval x₀) = 0 := by
   classical
   dsimp
@@ -228,10 +229,10 @@ theorem pg_exists_H_of_R_eval_zero (δ : ℚ) (x₀ : F)
     simp [Bivariate.evalX, Polynomial.coeff_map]
     simp [Polynomial.coeff]
   -- abbreviate p := evalX at x₀ (this is a bivariate poly in Z,Y)
-  set p := Bivariate.evalX (Polynomial.C x₀) R with hp
+  set p := Trivariate.evalAtX x₀ R with hp
   have hp_root : (Bivariate.evalX z.1 p).eval (P.eval x₀) = 0 := by
     -- evaluate the hypothesis at x₀
-    have hx : ((pg_eval_on_Z (F := F) R z.1).eval P).eval x₀ = 0 := by
+    have hx : ((Trivariate.evalAtZ z.1 R).eval P).eval x₀ = 0 := by
       have := congrArg (fun g : F[X] => g.eval x₀) hR
       simpa using this
     -- set up abbreviations
@@ -248,18 +249,19 @@ theorem pg_exists_H_of_R_eval_zero (δ : ℚ) (x₀ : F)
     have hr : fZ r = x₀ := by
       simp [fZ, r]
     -- rewrite the left-hand evaluation using `map_mapRingHom_eval_map_eval`
-    have hcommZ : ((pg_eval_on_Z (F := F) R z.1).eval P).eval x₀ = fZ ((R.eval q).eval r) := by
+    have hcommZ : ((Trivariate.evalAtZ z.1 R).eval P).eval x₀ =
+        fZ ((R.eval q).eval r) := by
       have h := Polynomial.map_mapRingHom_eval_map_eval (f := fZ) (p := R) (q := q) r
-      simpa [pg_eval_on_Z, fZ, hqmap, hr] using h
+      simpa [Trivariate.evalAtZ, fZ, hqmap, hr] using h
     have hfz0 : fZ ((R.eval q).eval r) = 0 := by
       -- combine `hx` and `hcommZ`
       calc
-        fZ ((R.eval q).eval r) = ((pg_eval_on_Z (F := F) R z.1).eval P).eval x₀ := by
+        fZ ((R.eval q).eval r) = ((Trivariate.evalAtZ z.1 R).eval P).eval x₀ := by
           simp [hcommZ]
         _ = 0 := hx
     -- show `fZ ((R.eval q).eval r)` is the desired evaluation of `p`
     have hp_map : p = R.map (Polynomial.evalRingHom (Polynomial.C x₀)) := by
-      exact hp.trans (pg_evalX_eq_map_evalRingHom (F := F) x₀ R)
+      exact hp.trans (Trivariate.evalAtX_eq_map_evalRingHom x₀ R)
     -- commute evaluation in Y then X with evaluation in X then Y
     have hYX : (R.eval q).eval r = (p.eval (q.eval r)) := by
       have h := (Polynomial.eval₂_hom (p := R) (f := Polynomial.evalRingHom r) q)
@@ -322,23 +324,23 @@ theorem pg_exists_R_of_Q_eval_zero (δ : ℚ)
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
   (z : coeffs_of_close_proximity (F := F) k ωs δ u₀ u₁) :
   let P : F[X] := Pz (k := k) (ωs := ωs) (δ := δ) (u₀ := u₀) (u₁ := u₁) z.2
-  (pg_eval_on_Z (F := F) Q z.1).eval P = 0 →
+  (Trivariate.evalAtZ z.1 Q).eval P = 0 →
   ∃ R,
     R ∈ pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs ∧
-    (pg_eval_on_Z (F := F) R z.1).eval P = 0 := by
+    (Trivariate.evalAtZ z.1 R).eval P = 0 := by
   classical
   dsimp
   intro hQ
   set P : F[X] :=
     Pz (k := k) (ωs := ωs) (δ := δ) (u₀ := u₀) (u₁ := u₁) z.2
-  have hQ' : (pg_eval_on_Z (F := F) Q z.1).eval P = 0 := by
+  have hQ' : (Trivariate.evalAtZ z.1 Q).eval P = 0 := by
     simpa [P] using hQ
   -- Define the ring hom φ : F[Z][X][Y] →+* F[X]
   let evZ : F[Z][X] →+* F[X] := Polynomial.mapRingHom (Polynomial.evalRingHom z.1)
   let evZ' : F[Z][X][Y] →+* Polynomial (Polynomial F) := Polynomial.mapRingHom evZ
   let φ : F[Z][X][Y] →+* F[X] := (Polynomial.evalRingHom P).comp evZ'
   have hφQ : φ Q = 0 := by
-    simpa [φ, evZ', evZ, pg_eval_on_Z] using hQ'
+    simpa [φ, evZ', evZ, Trivariate.evalAtZ] using hQ'
   -- Use associated product of normalizedFactors
   have hassoc : Associated ((UniqueFactorizationMonoid.normalizedFactors Q).prod) Q :=
     UniqueFactorizationMonoid.prod_normalizedFactors (a := Q) h_gs.Q_ne_0
@@ -367,23 +369,23 @@ theorem pg_exists_R_of_Q_eval_zero (δ : ℚ)
   · -- show R ∈ pg_Rset = (normalizedFactors Q).toFinset
     dsimp [pg_Rset]
     exact (Multiset.mem_toFinset).2 hRmem
-  · -- show (pg_eval_on_Z R z.1).eval P = 0
-    simpa [φ, evZ', evZ, pg_eval_on_Z] using hR0
+  · -- show `(evalAtZ z R).eval P = 0`
+    simpa [φ, evZ', evZ, Trivariate.evalAtZ] using hR0
 
 omit [DecidableEq (RatFunc F)] in
 theorem pg_exists_pair_for_z (δ : ℚ) (x₀ : F)
     (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
   (hx0 : ∀ R : F[Z][X][Y],
     R ∈ pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs →
-      Bivariate.evalX (Polynomial.C x₀) R ≠ 0)
+      Trivariate.evalAtX x₀ R ≠ 0)
   (z : coeffs_of_close_proximity (F := F) k ωs δ u₀ u₁) :
   let P : F[X] := Pz (k := k) (ωs := ωs) (δ := δ) (u₀ := u₀) (u₁ := u₁) z.2
-  (pg_eval_on_Z (F := F) Q z.1).eval P = 0 →
+  (Trivariate.evalAtZ z.1 Q).eval P = 0 →
   ∃ R H,
     (R, H) ∈ pg_candidatePairs (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
       (u₀ := u₀) (u₁ := u₁) x₀ h_gs ∧
     let P : F[X] := Pz (k := k) (ωs := ωs) (δ := δ) (u₀ := u₀) (u₁ := u₁) z.2
-    (pg_eval_on_Z (F := F) R z.1).eval P = 0 ∧
+    (Trivariate.evalAtZ z.1 R).eval P = 0 ∧
     (Bivariate.evalX z.1 H).eval (P.eval x₀) = 0 := by
   classical
   -- Unfold the outer `let P := ...` so we can introduce the hypothesis.
@@ -392,7 +394,7 @@ theorem pg_exists_pair_for_z (δ : ℚ) (x₀ : F)
   -- Name the interpolation polynomial associated to `z`.
   let P : F[X] :=
     Pz (k := k) (ωs := ωs) (δ := δ) (u₀ := u₀) (u₁ := u₁) z.2
-  have hQ' : (pg_eval_on_Z (F := F) Q z.1).eval P = 0 := by
+  have hQ' : (Trivariate.evalAtZ z.1 Q).eval P = 0 := by
     simpa [P] using hQ
   -- 1) Extract `R ∈ pg_Rset` with the same vanishing property.
   have hRfun :=
@@ -402,12 +404,12 @@ theorem pg_exists_pair_for_z (δ : ℚ) (x₀ : F)
         R ∈
             pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁)
               h_gs ∧
-          (pg_eval_on_Z (F := F) R z.1).eval P = 0 := by
+          (Trivariate.evalAtZ z.1 R).eval P = 0 := by
     -- `hRfun` has a `let P := ...` binder; rewrite using our local `P`.
     simpa [P] using hRfun hQ'
   obtain ⟨R, hRmem, hRzero⟩ := hR'
   -- 2) Nonzeroness of `evalX` at `x₀` from the hypothesis `hx0`.
-  have hNZ : Bivariate.evalX (Polynomial.C x₀) R ≠ 0 :=
+  have hNZ : Trivariate.evalAtX x₀ R ≠ 0 :=
     hx0 R hRmem
   -- 3) Extract a normalized factor `H` of `evalX x₀ R` with the desired vanishing.
   have hHfun :=
@@ -416,7 +418,7 @@ theorem pg_exists_pair_for_z (δ : ℚ) (x₀ : F)
   have hH' :
       ∃ H,
         H ∈
-            UniqueFactorizationMonoid.normalizedFactors (Bivariate.evalX (Polynomial.C x₀) R) ∧
+            UniqueFactorizationMonoid.normalizedFactors (Trivariate.evalAtX x₀ R) ∧
           (Bivariate.evalX z.1 H).eval (P.eval x₀) = 0 := by
     simpa [P] using hHfun hRzero hNZ
   obtain ⟨H, hHmem, hHzero⟩ := hH'
@@ -430,7 +432,7 @@ theorem pg_exists_pair_for_z (δ : ℚ) (x₀ : F)
             pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁)
               h_gs ∧
           H ∈
-            UniqueFactorizationMonoid.normalizedFactors (Bivariate.evalX (Polynomial.C x₀) R) :=
+            UniqueFactorizationMonoid.normalizedFactors (Trivariate.evalAtX x₀ R) :=
       And.intro hRmem hHmem
     simpa [pg_candidatePairs] using h'
   -- 5) Package everything.
@@ -441,12 +443,12 @@ theorem pg_exists_pair_for_z (δ : ℚ) (x₀ : F)
 
 omit [DecidableEq F] [DecidableEq (RatFunc F)] [Finite F] in
 theorem pg_natDegree_evalX_le_natDegreeY (x₀ : F) (R : F[Z][X][Y]) :
-    (Bivariate.evalX (Polynomial.C x₀) R).natDegree ≤ Bivariate.natDegreeY R := by
+    (Trivariate.evalAtX x₀ R).natDegree ≤ Trivariate.degreeInY R := by
   classical
   -- Rewrite `evalX` in terms of `map`.
-  rw [pg_evalX_eq_map_evalRingHom (x₀ := x₀) (R := R)]
+  rw [Trivariate.evalAtX_eq_map_evalRingHom]
   -- `natDegreeY` is definitional.
-  unfold Bivariate.natDegreeY
+  unfold Trivariate.degreeInY Bivariate.natDegreeY
   -- Apply the standard degree bound for `Polynomial.map`.
   simpa using
     (Polynomial.natDegree_map_le (p := R)
@@ -455,8 +457,8 @@ theorem pg_natDegree_evalX_le_natDegreeY (x₀ : F) (R : F[Z][X][Y]) :
 omit [DecidableEq (RatFunc F)] [Finite F] in
 theorem pg_sum_natDegreeY_Rset_le_natDegreeY_Q (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁) :
     Finset.sum (pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs)
-      (fun R => Bivariate.natDegreeY R)
-    ≤ Bivariate.natDegreeY Q := by
+      (fun R => Trivariate.degreeInY R)
+    ≤ Trivariate.degreeInY Q := by
   classical
   -- Unfold the definition of `pg_Rset`.
   simp only [pg_Rset]
@@ -468,31 +470,32 @@ theorem pg_sum_natDegreeY_Rset_le_natDegreeY_Q (h_gs : ModifiedGuruswami m n k �
   have hs0 : (0 : F[Z][X][Y]) ∉ s := by
     simpa [hs] using (UniqueFactorizationMonoid.zero_notMem_normalizedFactors (x := Q))
   have hsum_le :
-      Finset.sum s.toFinset (fun R => Bivariate.natDegreeY R)
-        ≤ Finset.sum s.toFinset (fun R => s.count R * Bivariate.natDegreeY R) := by
+      Finset.sum s.toFinset (fun R => Trivariate.degreeInY R)
+        ≤ Finset.sum s.toFinset (fun R => s.count R * Trivariate.degreeInY R) := by
     refine Finset.sum_le_sum ?_
     intro R hR
     have hmem : R ∈ s := (Multiset.mem_toFinset.1 hR)
     have hcount : 0 < s.count R := (Multiset.count_pos.2 hmem)
-    exact Nat.le_mul_of_pos_left (Bivariate.natDegreeY R) hcount
+    exact Nat.le_mul_of_pos_left (Trivariate.degreeInY R) hcount
   have hsum_count :
-      Finset.sum s.toFinset (fun R => s.count R * Bivariate.natDegreeY R) =
-        (s.map fun R => Bivariate.natDegreeY R).sum := by
+      Finset.sum s.toFinset (fun R => s.count R * Trivariate.degreeInY R) =
+        (s.map fun R => Trivariate.degreeInY R).sum := by
     simpa [Nat.nsmul_eq_mul] using
-      (Finset.sum_multiset_map_count (s := s) (f := fun R => Bivariate.natDegreeY R)).symm
+      (Finset.sum_multiset_map_count (s := s) (f := fun R => Trivariate.degreeInY R)).symm
   have hdeg_prod :
-      (s.map fun R => Bivariate.natDegreeY R).sum = Bivariate.natDegreeY s.prod := by
-    simpa [Bivariate.natDegreeY] using
+      (s.map fun R => Trivariate.degreeInY R).sum = Trivariate.degreeInY s.prod := by
+    simpa [Trivariate.degreeInY, Bivariate.natDegreeY] using
       (Polynomial.natDegree_multiset_prod (t := s) hs0).symm
   have hfinset_eq_prod :
-      Finset.sum s.toFinset (fun R => s.count R * Bivariate.natDegreeY R) =
-        Bivariate.natDegreeY s.prod := by
+      Finset.sum s.toFinset (fun R => s.count R * Trivariate.degreeInY R) =
+        Trivariate.degreeInY s.prod := by
     calc
-      Finset.sum s.toFinset (fun R => s.count R * Bivariate.natDegreeY R)
-          = (s.map fun R => Bivariate.natDegreeY R).sum := hsum_count
-      _ = Bivariate.natDegreeY s.prod := hdeg_prod
+      Finset.sum s.toFinset (fun R => s.count R * Trivariate.degreeInY R)
+          = (s.map fun R => Trivariate.degreeInY R).sum := hsum_count
+      _ = Trivariate.degreeInY s.prod := hdeg_prod
   have hleft_le_prod :
-      Finset.sum s.toFinset (fun R => Bivariate.natDegreeY R) ≤ Bivariate.natDegreeY s.prod := by
+      Finset.sum s.toFinset (fun R => Trivariate.degreeInY R) ≤
+        Trivariate.degreeInY s.prod := by
     simpa [hfinset_eq_prod] using hsum_le
   have hassoc : Associated s.prod Q := by
     -- `prod_normalizedFactors` gives association between the product of normalized factors and `Q`.
@@ -501,18 +504,18 @@ theorem pg_sum_natDegreeY_Rset_le_natDegreeY_Q (h_gs : ModifiedGuruswami m n k �
     Polynomial.degree_eq_degree_of_associated hassoc
   have hnat_assoc : (s.prod).natDegree = Q.natDegree :=
     Polynomial.natDegree_eq_natDegree (p := s.prod) (q := Q) hdeg_assoc
-  have hnatY_assoc : Bivariate.natDegreeY s.prod = Bivariate.natDegreeY Q := by
-    simp [Bivariate.natDegreeY, hnat_assoc]
+  have hnatY_assoc : Trivariate.degreeInY s.prod = Trivariate.degreeInY Q := by
+    simp [Trivariate.degreeInY, Bivariate.natDegreeY, hnat_assoc]
   simpa [hnatY_assoc] using hleft_le_prod
 
 omit [DecidableEq (RatFunc F)] [Finite F] in
 theorem pg_card_candidatePairs_le_natDegreeY (x₀ : F) (h_gs : ModifiedGuruswami m n k ωs Q u₀ u₁)
     (hsep : ∀ R : F[Z][X][Y],
     R ∈ pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs →
-      (Bivariate.evalX (Polynomial.C x₀) R).Separable)
+      (Trivariate.evalAtX x₀ R).Separable)
     :
   #(pg_candidatePairs (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
-      (u₀ := u₀) (u₁ := u₁) x₀ h_gs) ≤ Bivariate.natDegreeY Q := by
+      (u₀ := u₀) (u₁ := u₁) x₀ h_gs) ≤ Trivariate.degreeInY Q := by
   classical
   -- Shorthands for the set of candidate polynomials `R` and the corresponding set of
   -- pairs for each `R`.
@@ -520,7 +523,7 @@ theorem pg_card_candidatePairs_le_natDegreeY (x₀ : F) (h_gs : ModifiedGuruswam
     pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs with hRset
   set t : F[Z][X][Y] → Finset (F[Z][X][Y] × F[Z][X]) := fun R =>
     (UniqueFactorizationMonoid.normalizedFactors
-        (Bivariate.evalX (Polynomial.C x₀) R)).toFinset.image (fun H => (R, H)) with ht
+        (Trivariate.evalAtX x₀ R)).toFinset.image (fun H => (R, H)) with ht
   -- Unfold `pg_candidatePairs` as a `biUnion` over `Rset`.
   have hcp :
       pg_candidatePairs (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q)
@@ -534,7 +537,7 @@ theorem pg_card_candidatePairs_le_natDegreeY (x₀ : F) (h_gs : ModifiedGuruswam
         ≤ ∑ R ∈ Rset, #(t R) := by
     simpa [hcp] using (Finset.card_biUnion_le (s := Rset) (t := t))
   -- Pointwise bound: for each `R ∈ Rset`, `#(t R)` is bounded by `natDegreeY R`.
-  have hpoint : ∀ R : F[Z][X][Y], R ∈ Rset → #(t R) ≤ Bivariate.natDegreeY R := by
+  have hpoint : ∀ R : F[Z][X][Y], R ∈ Rset → #(t R) ≤ Trivariate.degreeInY R := by
     intro R hR
     -- `t R` is an injective image of the factor set.
     have hinj : Function.Injective (fun H : F[Z][X] => (R, H)) := by
@@ -543,35 +546,36 @@ theorem pg_card_candidatePairs_le_natDegreeY (x₀ : F) (h_gs : ModifiedGuruswam
     have hcard_image :
         #(t R) =
           #((UniqueFactorizationMonoid.normalizedFactors
-              (Bivariate.evalX (Polynomial.C x₀) R)).toFinset) := by
+              (Trivariate.evalAtX x₀ R)).toFinset) := by
       simpa [ht] using
         (Finset.card_image_of_injective
           (s := (UniqueFactorizationMonoid.normalizedFactors
-              (Bivariate.evalX (Polynomial.C x₀) R)).toFinset)
+              (Trivariate.evalAtX x₀ R)).toFinset)
           (f := fun H : F[Z][X] => (R, H)) hinj)
     have hR' : R ∈
         pg_Rset (m := m) (n := n) (k := k) (ωs := ωs) (Q := Q) (u₀ := u₀) (u₁ := u₁) h_gs := by
       simpa [hRset] using hR
     have hcard_nf :
         #((UniqueFactorizationMonoid.normalizedFactors
-            (Bivariate.evalX (Polynomial.C x₀) R)).toFinset)
-          ≤ (Bivariate.evalX (Polynomial.C x₀) R).natDegree :=
+            (Trivariate.evalAtX x₀ R)).toFinset)
+          ≤ (Trivariate.evalAtX x₀ R).natDegree :=
       pg_card_normalizedFactors_toFinset_le_natDegree (F := F)
-        (p := (Bivariate.evalX (Polynomial.C x₀) R)) (hp := hsep R hR')
-    have hdeg : (Bivariate.evalX (Polynomial.C x₀) R).natDegree ≤ Bivariate.natDegreeY R :=
+        (p := Trivariate.evalAtX x₀ R) (hp := hsep R hR')
+    have hdeg : (Trivariate.evalAtX x₀ R).natDegree ≤ Trivariate.degreeInY R :=
       pg_natDegree_evalX_le_natDegreeY (F := F) x₀ R
     -- Combine the bounds.
     calc
       #(t R) =
           #((UniqueFactorizationMonoid.normalizedFactors
-              (Bivariate.evalX (Polynomial.C x₀) R)).toFinset) := hcard_image
-      _ ≤ (Bivariate.evalX (Polynomial.C x₀) R).natDegree := hcard_nf
-      _ ≤ Bivariate.natDegreeY R := hdeg
-  have hsum : (∑ R ∈ Rset, #(t R)) ≤ ∑ R ∈ Rset, Bivariate.natDegreeY R := by
+              (Trivariate.evalAtX x₀ R)).toFinset) := hcard_image
+      _ ≤ (Trivariate.evalAtX x₀ R).natDegree := hcard_nf
+      _ ≤ Trivariate.degreeInY R := hdeg
+  have hsum : (∑ R ∈ Rset, #(t R)) ≤ ∑ R ∈ Rset, Trivariate.degreeInY R := by
     refine Finset.sum_le_sum ?_
     intro R hR
     exact hpoint R hR
-  have hsum_Rset_le : (∑ R ∈ Rset, Bivariate.natDegreeY R) ≤ Bivariate.natDegreeY Q := by
+  have hsum_Rset_le : (∑ R ∈ Rset, Trivariate.degreeInY R) ≤
+      Trivariate.degreeInY Q := by
     -- This is exactly the provided axiom, after rewriting `Rset`.
     simpa [hRset] using
       (pg_sum_natDegreeY_Rset_le_natDegreeY_Q (m := m) (n := n) (k := k)

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Guruswami.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/ListDecoding/Guruswami.lean
@@ -75,7 +75,7 @@ structure ModifiedGuruswami
             ≥ m
   /-- The X-degree bound. -/
   Q_deg_X :
-    degreeX Q < D_X ((k + 1) / (n : ℚ)) n m
+    Trivariate.degreeInX Q < D_X ((k + 1) / (n : ℚ)) n m
   /-- The Y-degree bound. -/
   Q_D_Y :
     D_Y Q < D_X ((k + 1 : ℚ) / n) n m / k
@@ -952,7 +952,7 @@ private theorem symbolicGSPoly_DYZ_term_le {F : Type} [Field F]
 private theorem symbolicGSPoly_DYZ_le {F : Type} [Field F]
     (A : Finset (ℕ × ℕ)) (c : SymbolicGSIndex A → F) :
     Trivariate.D_YZ (symbolicGSPoly (F := F) A c) ≤ symbolicYSum A := by
-  unfold Trivariate.D_YZ
+  unfold Trivariate.D_YZ Trivariate.degreeYZ
   apply finsetMaxGetD_le
   intro outer houter
   rw [Finset.mem_image] at houter
@@ -1060,9 +1060,9 @@ private theorem modified_guruswami_has_a_solution_core
   · apply symbolicGSPolyMultiplicityBridge hQ
     exact symbolicGSKernelWitness_shift_vanish A ωs u₀ u₁ w
   · have hx := Polynomial.Bivariate.degreeX_le_natWeightedDegree Q k
-    exact lt_of_le_of_lt (by exact_mod_cast hx) hdeg
+    exact lt_of_le_of_lt (by simpa [Trivariate.degreeInX] using hx) hdeg
   · have hy := symbolicDY_lt_of_weighted (Q := Q) hk hdeg
-    simpa only [Trivariate.D_Y] using hy
+    simpa only [Trivariate.D_Y, Trivariate.degreeInY] using hy
   · have hyz := symbolicGSPoly_DYZ_le A w.c
     have hyzR : (Trivariate.D_YZ Q : ℝ) ≤ symbolicYSum A := by
       exact_mod_cast hyz

--- a/ArkLib/Data/Polynomial/RationalFunctions.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions.lean
@@ -24,8 +24,10 @@ Import this file for all of it, or an individual module for a narrower dependenc
 
 `H : F[X][Y]` plays the role of the paper's `H(Y, Z)`: the outer variable is `Y` and the
 coefficient variable is the paper's `Z`. For the trivariate `R : F[X][X][Y]` the outer variable is
-`Y`, the middle one is the paper's `X` and the innermost is `Z`, so `Bivariate.evalX (C x₀) R` is
-the specialization `R(x₀, Y, Z)`.
+`Y`, the middle one is the paper's `X` and the innermost is `Z`, so `Trivariate.evalAtX x₀ R`
+(definitionally the existing `Bivariate.evalX (C x₀) R` expressions in this package) is the
+specialization `R(x₀, Y, Z)`. Generic bivariate operations on `R.coeff i` are intentional: that
+coefficient is genuinely bivariate in `(Z, X)`.
 
 ## Layout
 

--- a/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Hensel.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Hensel.lean
@@ -6,6 +6,7 @@ Authors: Katerina Hristova, František Silváši, Julian Sutherland, Ilia Vlasov
 
 import ArkLib.Data.Polynomial.Bivariate
 import ArkLib.Data.Polynomial.Prelims
+import ArkLib.Data.Polynomial.Trivariate
 import Mathlib.FieldTheory.RatFunc.Defs
 import Mathlib.RingTheory.Ideal.Quotient.Defs
 import Mathlib.RingTheory.Ideal.Span
@@ -66,15 +67,13 @@ lemma henselDenominatorExponent_succ (t : ℕ) :
 /-- A total degree for the trivariate polynomial `R`, represented as a polynomial in `Y` with
 bivariate coefficients in the `Z` and `X` variables. -/
 def trivariateTotalDegree (R : F[X][X][Y]) : ℕ :=
-  R.support.sup (fun i => Bivariate.totalDegree (R.coeff i) + i)
+  Trivariate.totalDegreeXYZ R
 
 /-- Each coefficient of `R` is bounded by `trivariateTotalDegree R`. -/
 lemma coeff_totalDegree_add_index_le_trivariateTotalDegree (R : F[X][X][Y]) {i : ℕ}
     (hi : i ∈ R.support) :
     Bivariate.totalDegree (R.coeff i) + i ≤ trivariateTotalDegree R := by
-  classical
-  unfold trivariateTotalDegree
-  exact Finset.le_sup (f := fun i => Bivariate.totalDegree (R.coeff i) + i) hi
+  exact Trivariate.coeff_totalDegree_add_index_le_totalDegree R hi
 
 /-- A canonical degree bound large enough for both `H` and all coefficients of `R`. -/
 def defaultDegreeBound (R : F[X][X][Y]) (H : F[X][Y]) : ℕ :=
@@ -138,23 +137,23 @@ def IsHenselNumeratorSequence (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
 bound on `R(x₀,·,Z)`. -/
 theorem evalX_totalDegree_le_of_coeff_bound (x₀ : F) (R : F[X][X][Y]) {D : ℕ}
     (hD_R : ∀ i ∈ R.support, Bivariate.totalDegree (R.coeff i) + i ≤ D) :
-    Bivariate.totalDegree (Bivariate.evalX (Polynomial.C x₀) R) ≤ D := by
+    Bivariate.totalDegree (Trivariate.evalAtX x₀ R) ≤ D := by
   classical
   unfold Bivariate.totalDegree
   refine Finset.sup_le ?_
   intro i hi
-  have hcoeff_eval_ne : (Bivariate.evalX (Polynomial.C x₀) R).coeff i ≠ 0 :=
+  have hcoeff_eval_ne : (Trivariate.evalAtX x₀ R).coeff i ≠ 0 :=
     Polynomial.mem_support_iff.mp hi
-  have hcoeff_eq : (Bivariate.evalX (Polynomial.C x₀) R).coeff i =
+  have hcoeff_eq : (Trivariate.evalAtX x₀ R).coeff i =
       (R.coeff i).eval (Polynomial.C x₀) := by
-    simp [Bivariate.evalX_eq_map, Polynomial.coeff_map]
+    simp [Trivariate.evalAtX, Bivariate.evalX_eq_map, Polynomial.coeff_map]
   have hRcoeff_ne : R.coeff i ≠ 0 := by
     intro h0
     apply hcoeff_eval_ne
     rw [hcoeff_eq, h0]
     simp
   have hiR : i ∈ R.support := Polynomial.mem_support_iff.mpr hRcoeff_ne
-  have heval_deg : ((Bivariate.evalX (Polynomial.C x₀) R).coeff i).natDegree ≤
+  have heval_deg : ((Trivariate.evalAtX x₀ R).coeff i).natDegree ≤
       Bivariate.totalDegree (R.coeff i) := by
     rw [hcoeff_eq]
     have hP : (Polynomial.C x₀ : F[X]).natDegree ≤ 1 - 1 := by

--- a/ArkLib/Data/Polynomial/Trivariate.lean
+++ b/ArkLib/Data/Polynomial/Trivariate.lean
@@ -8,16 +8,23 @@ import ArkLib.Data.Polynomial.Bivariate
 import Mathlib.FieldTheory.RatFunc.AsPolynomial
 
 /-!
-# Short interface on Trivariate Polynomials
+# Trivariate Polynomials
 
-We define trivariate polynomials to match their representation in statements and proofs
-of [BCIKS20].
+We define trivariate polynomials to match their representation in statements and proofs of
+[BCIKS20]. A value of type `F[Z][X][Y]` is nested with `Y` outermost, `X` in the middle, and `Z`
+innermost. The semantic evaluation and degree operations in this namespace make those axes explicit.
+
+Applying `Polynomial.Bivariate` operations directly to `F[Z][X][Y]` instead treats it as a
+bivariate polynomial over `F[Z]`. In particular, its `evalX` specializes the middle `X` variable,
+while its `totalDegree` measures only `(X, Y)` and ignores `Z`.
 
 ## Main Definitions
 
-### Notation for trivariate polynomials and evaluation homomorphisms
+### Notation, evaluation, and degree projections
 - `eval_on_Z₀`: Evaluate a rational function on a point.
-- `eval_on_Z`: Ring homomorphism evaluating the `Z` variable of a trivariate polynomial.
+- `evalAtX`, `evalAtY`, `evalAtZ`: Evaluate the named variable of a trivariate polynomial.
+- `degreeInX`, `degreeInY`, `degreeInZ`: The degree in one named variable.
+- `degreeXY`, `degreeYZ`, `totalDegreeXYZ`: The projected or full total degrees.
 - `toRatFuncPoly`: Maps a trivariate polynomial to a bivariate polynomial over the rational
   function field.
 - `D_Y`: The `Y`-degree of a trivariate polynomial.
@@ -34,13 +41,7 @@ of [BCIKS20].
 
 namespace Trivariate
 
-variable {F : Type} [Field F] [DecidableEq (RatFunc F)]
-
 open Polynomial Bivariate
-
-/-- Evaluate a rational function on a point. -/
-noncomputable def eval_on_Z₀ (p : (RatFunc F)) (z : F) : F :=
-  RatFunc.eval (RingHom.id _) z p
 
 notation3:max R "[Z][X]" => Polynomial (Polynomial R)
 
@@ -50,11 +51,162 @@ notation3:max "Y" => Polynomial.X
 notation3:max "X" => Polynomial.C Polynomial.X
 notation3:max "Z" => Polynomial.C (Polynomial.C Polynomial.X)
 
-/-- A ring homomorphism mapping a trivariate polynomial with coefficients in `F` and variables
-`Z, X, Y` to a bivariate polynomial with coefficients in `F` and variables in `X, Y` by evaluating
-on a point `z ∈ F`. -/
-noncomputable opaque eval_on_Z (p : F[Z][X][Y]) (z : F) : F[X][Y] :=
+section Semiring
+
+variable {R : Type*} [CommSemiring R]
+
+/-- Evaluate the middle `X` variable of `p : R[Z][X][Y]` at `x`, leaving a polynomial in
+`(Z, Y)`. This is the semantic wrapper around bivariate `evalX` over the coefficient ring `R[Z]`. -/
+noncomputable def evalAtX (x : R) (p : R[Z][X][Y]) : Polynomial (Polynomial R) :=
+  Bivariate.evalX (Polynomial.C x) p
+
+/-- Evaluate the outer `Y` variable of `p : R[Z][X][Y]` at `y`, leaving a polynomial in
+`(Z, X)`. -/
+noncomputable def evalAtY (y : R) (p : R[Z][X][Y]) : R[Z][X] :=
+  Bivariate.evalY (Polynomial.C y) p
+
+/-- Evaluate the innermost `Z` variable of `p : R[Z][X][Y]` at `z`, leaving a polynomial in
+`(X, Y)`. -/
+noncomputable def evalAtZ (z : R) (p : R[Z][X][Y]) : R[X][Y] :=
   p.map (Polynomial.mapRingHom (Polynomial.evalRingHom z))
+
+/-- Backwards-compatible name for `evalAtZ`. New code should use the axis-explicit API. -/
+@[deprecated evalAtZ (since := "2026-08-21")]
+noncomputable abbrev eval_on_Z (p : R[Z][X][Y]) (z : R) : R[X][Y] :=
+  evalAtZ z p
+
+/-- The maximum exponent of the middle `X` variable in a trivariate polynomial. -/
+noncomputable def degreeInX (p : R[Z][X][Y]) : ℕ :=
+  Bivariate.degreeX p
+
+/-- The maximum exponent of the outer `Y` variable in a trivariate polynomial. -/
+noncomputable def degreeInY (p : R[Z][X][Y]) : ℕ :=
+  Bivariate.natDegreeY p
+
+/-- The maximum exponent of the innermost `Z` variable in a trivariate polynomial. -/
+noncomputable def degreeInZ (p : R[Z][X][Y]) : ℕ :=
+  p.support.sup fun j => (p.coeff j).support.sup fun i => ((p.coeff j).coeff i).natDegree
+
+/-- The projected `(X, Y)` total degree of a trivariate polynomial. This is the quantity computed
+by `Bivariate.totalDegree p`; naming the projection prevents it from being mistaken for the full
+trivariate total degree. -/
+noncomputable def degreeXY (p : R[Z][X][Y]) : ℕ :=
+  Bivariate.totalDegree p
+
+/-- The generic bivariate total degree on a trivariate value is exactly the `(X, Y)` projection.
+This bridge is intentionally named so callers do not silently read it as a `(Y, Z)` or full
+trivariate bound. -/
+theorem degreeXY_eq_bivariate_totalDegree (p : R[Z][X][Y]) :
+    degreeXY p = Bivariate.totalDegree p :=
+  rfl
+
+/-- The projected `(Y, Z)` total degree of a trivariate polynomial: the maximum of `degY + degZ`
+over its monomials. The middle `X` exponent is deliberately ignored.
+
+Here `j` is the outer `Y` exponent and `i` is the middle `X` exponent.
+`Bivariate.coeff p i j = (p.coeff j).coeff i` is then a polynomial in `Z`, whose `natDegree`
+supplies the `Z` exponent. -/
+noncomputable def degreeYZ (p : R[Z][X][Y]) : ℕ :=
+  Option.getD (dflt := 0) <| Finset.max
+    (Finset.image
+      (fun j =>
+        Option.getD
+          (Finset.max
+            (Finset.image
+              (fun i => j + (Bivariate.coeff p i j).natDegree)
+              (p.coeff j).support))
+          0)
+      p.support)
+
+/-- The full `(X, Y, Z)` total degree of a trivariate polynomial. -/
+noncomputable def totalDegreeXYZ (p : R[Z][X][Y]) : ℕ :=
+  p.support.sup fun j => Bivariate.totalDegree (p.coeff j) + j
+
+/-- Each `Y`-coefficient's `(Z, X)` total-degree contribution is bounded by the full trivariate
+total degree. -/
+theorem coeff_totalDegree_add_index_le_totalDegree (p : R[Z][X][Y]) {j : ℕ}
+    (hj : j ∈ p.support) :
+    Bivariate.totalDegree (p.coeff j) + j ≤ totalDegreeXYZ p := by
+  classical
+  exact Finset.le_sup (f := fun j => Bivariate.totalDegree (p.coeff j) + j) hj
+
+/-- `evalAtX` is the corresponding coefficient-ring map. -/
+theorem evalAtX_eq_map_evalRingHom (x : R) (p : R[Z][X][Y]) :
+    evalAtX x p = p.map (Polynomial.evalRingHom (Polynomial.C x)) := by
+  simp [evalAtX, Bivariate.evalX_eq_map]
+
+/-- `evalAtZ` is the coefficient-wise evaluation map on the innermost variable. -/
+theorem evalAtZ_eq_map_map_evalRingHom (z : R) (p : R[Z][X][Y]) :
+    evalAtZ z p = p.map (Polynomial.mapRingHom (Polynomial.evalRingHom z)) :=
+  rfl
+
+/-- Following [BCIKS20], this is the `Y`-degree of a trivariate polynomial `Q`. -/
+noncomputable def D_Y (Q : R[Z][X][Y]) : ℕ := degreeInY Q
+
+/-- Following [BCIKS20], this is the total `(Y, Z)`-degree of a trivariate polynomial `Q`. -/
+noncomputable def D_YZ (Q : R[Z][X][Y]) : ℕ := degreeYZ Q
+
+/-- The paper-facing `D_YZ` is the semantic `(Y, Z)` projection. -/
+theorem D_YZ_eq_degreeYZ (Q : R[Z][X][Y]) : D_YZ Q = degreeYZ Q :=
+  rfl
+
+end Semiring
+
+/-! ### Axis regression checks
+
+The unequal exponents in this monomial make accidental permutations observable. In particular,
+the `(X, Y)` projection is `10`, the `(Y, Z)` projection is `8`, and the full degree is `15`.
+-/
+
+private noncomputable def axisRegressionPolynomial :
+    Polynomial (Polynomial (Polynomial ℚ)) :=
+  Polynomial.monomial 3 (Polynomial.monomial 7 (Polynomial.monomial 5 1))
+
+example : degreeInX axisRegressionPolynomial = 7 := by
+  norm_num [axisRegressionPolynomial, degreeInX, Bivariate.degreeX]
+
+example : degreeInY axisRegressionPolynomial = 3 := by
+  norm_num [axisRegressionPolynomial, degreeInY, Bivariate.natDegreeY]
+
+example : degreeInZ axisRegressionPolynomial = 5 := by
+  norm_num [axisRegressionPolynomial, degreeInZ]
+
+example : degreeXY axisRegressionPolynomial = 10 := by
+  norm_num [axisRegressionPolynomial, degreeXY, Bivariate.totalDegree]
+
+example : degreeYZ axisRegressionPolynomial = 8 := by
+  norm_num [axisRegressionPolynomial, degreeYZ, Bivariate.coeff, Option.getD]
+
+example : Bivariate.totalDegree axisRegressionPolynomial ≠ degreeYZ axisRegressionPolynomial := by
+  norm_num [axisRegressionPolynomial, degreeYZ, Bivariate.totalDegree, Bivariate.coeff, Option.getD]
+
+example : totalDegreeXYZ axisRegressionPolynomial = 15 := by
+  norm_num [axisRegressionPolynomial, totalDegreeXYZ, Bivariate.totalDegree]
+
+example : evalAtX 2 axisRegressionPolynomial =
+    Polynomial.monomial 3 (Polynomial.monomial 5 ((2 : ℚ) ^ 7)) := by
+  norm_num [evalAtX, axisRegressionPolynomial, Bivariate.evalX_eq_map]
+  rw [← Polynomial.C_pow, Polynomial.monomial_mul_C]
+  norm_num
+
+example : evalAtY 2 axisRegressionPolynomial =
+    Polynomial.monomial 7 (Polynomial.monomial 5 ((2 : ℚ) ^ 3)) := by
+  norm_num [evalAtY, axisRegressionPolynomial, Bivariate.evalY]
+  rw [← Polynomial.C_pow, Polynomial.monomial_mul_C]
+  rw [← Polynomial.C_pow, Polynomial.monomial_mul_C]
+  norm_num
+
+example : evalAtZ 2 axisRegressionPolynomial =
+    Polynomial.monomial 3 (Polynomial.monomial 7 ((2 : ℚ) ^ 5)) := by
+  norm_num [evalAtZ, axisRegressionPolynomial]
+
+section Field
+
+variable {F : Type*} [Field F] [DecidableEq (RatFunc F)]
+
+/-- Evaluate a rational function on a point. -/
+noncomputable def eval_on_Z₀ (p : RatFunc F) (z : F) : F :=
+  RatFunc.eval (RingHom.id _) z p
 
 open Polynomial.Bivariate in
 /-- A ring homomorphism mapping a trivariate polynomial to an element in the field of rational
@@ -62,29 +214,6 @@ functions of polynomial ring in two variables. -/
 noncomputable def toRatFuncPoly (p : F[Z][X][Y]) : (RatFunc F)[X][Y] :=
   p.map (Polynomial.mapRingHom (algebraMap F[X] (RatFunc F)))
 
-/-- Following [BCIKS20] this the `Y`-degree of a trivariate polynomial `Q`. -/
-noncomputable def D_Y (Q : F[Z][X][Y]) : ℕ := Bivariate.natDegreeY Q
-
-/-- The `YZ`-degree of a trivariate polynomial: the total `(Y, Z)`-degree, i.e. the maximum of
-`degY + degZ` over the monomials of `Q`.
-
-Here `j` ranges over the `Y`-degrees of `Q` and `i` over the `X`-degrees occurring at `Y`-degree
-`j`, so the coefficient of `X ^ i * Y ^ j` is `Bivariate.coeff Q i j` — note that
-`Bivariate.coeff Q i j = (Q.coeff j).coeff i` takes the `X`-index first. -/
-noncomputable def D_YZ (Q : F[Z][X][Y]) : ℕ :=
-  Option.getD (dflt := 0) <| Finset.max
-    (Finset.image
-            (
-              fun j =>
-                Option.getD (
-                  Finset.max (
-                    Finset.image
-                      (fun i => j + (Bivariate.coeff Q i j).natDegree)
-                      (Q.coeff j).support
-                  )
-                ) 0
-            )
-            Q.support
-    )
+end Field
 
 end Trivariate

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -20,6 +20,8 @@ For reusable cross-cutting workflows that are not tied to one repo area, see
 - [`coding-theory-conventions.md`](coding-theory-conventions.md) - notation in scope, which
   numeric type each quantity uses, and the naming and layout choices local to
   `ArkLib/Data/CodingTheory/`.
+- [`polynomial-conventions.md`](polynomial-conventions.md) - semantic axes for nested bivariate
+  and trivariate polynomial representations.
 - [`proximity-error-conventions.md`](proximity-error-conventions.md) - the proximity-gap,
   correlated-agreement, and mutual-correlated-agreement APIs and their numeric types.
 - [`probability-conventions.md`](probability-conventions.md) - namespace and export conventions
@@ -40,6 +42,7 @@ For reusable cross-cutting workflows that are not tied to one repo area, see
   - `blueprint-and-citations.md` for blueprint workflow, references, and citation updates.
   - `knowledge-base.md` for when and how agents should use `docs/kb/`.
   - `coding-theory-conventions.md` for notation, types and local conventions in `CodingTheory/`.
+  - `polynomial-conventions.md` for nested polynomial axes and semantic evaluation/degree APIs.
   - `proximity-error-conventions.md` for the public APIs and numeric types of the proximity-error
     notions in `CodingTheory/ProximityGap/`.
   - `probability-conventions.md` for namespace/export conventions in `Data/Probability/`.

--- a/docs/wiki/polynomial-conventions.md
+++ b/docs/wiki/polynomial-conventions.md
@@ -1,0 +1,40 @@
+# Nested polynomial axis conventions
+
+ArkLib represents the trivariate polynomials used by the BCIKS20 development as
+`F[Z][X][Y] = Polynomial (Polynomial (Polynomial F))`. The nesting order is:
+
+| Semantic variable | Structural position |
+|---|---|
+| `Y` | outer polynomial variable |
+| `X` | middle polynomial variable |
+| `Z` | innermost polynomial variable |
+
+Use the operations in `Trivariate` when the input is trivariate:
+
+- `evalAtX`, `evalAtY`, and `evalAtZ` specialize the variable named in the declaration.
+- `degreeInX`, `degreeInY`, and `degreeInZ` measure one named variable.
+- `degreeXY` and `degreeYZ` are projected total degrees; `totalDegreeXYZ` includes all three
+  variables.
+- `D_Y` and `D_YZ` remain the paper-facing names used by the BCIKS20 statements and are wrappers
+  around `degreeInY` and `degreeYZ`.
+
+Do not read an operation's axis from its type arguments alone. Applying
+`Polynomial.Bivariate` directly to a trivariate value regards it as a bivariate polynomial over
+the coefficient ring `F[Z]`. Consequently:
+
+- `Bivariate.evalX (Polynomial.C x) p` does evaluate the semantic middle variable `X`, but
+  `Trivariate.evalAtX x p` records that intention explicitly.
+- `Bivariate.natDegreeY p` and `Bivariate.degreeX p` are the semantic `Y`- and `X`-degrees,
+  respectively, but the trivariate wrappers are preferred in statements.
+- `Bivariate.totalDegree p` is only the `(X, Y)` projection and ignores `Z`. Write
+  `Trivariate.degreeXY p` for that quantity. It is not the full trivariate total degree and is not
+  the `(Y, Z)` projection.
+
+Generic bivariate operations remain appropriate after a trivariate specialization, or on an
+actual bivariate coefficient. For example, `Bivariate.totalDegree (p.coeff j)` measures the
+`(Z, X)` degree of the `Y ^ j` coefficient, and `Bivariate.totalDegree (Trivariate.evalAtX x p)`
+measures the `(Z, Y)` degree after specializing `X`.
+
+When reviewing axis-sensitive code, test with unequal exponents such as `Z ^ 5 * X ^ 7 * Y ^ 3`.
+For that monomial, `degreeXY = 10`, `degreeYZ = 8`, and `totalDegreeXYZ = 15`; symmetric examples
+can allow an accidental permutation to pass unnoticed.

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -396,9 +396,12 @@ home_page/            site assets and assembled website root
 - Vandermonde matrix utilities shared across Reed-Solomon and proximity-gap developments live in
   `ArkLib/Data/Matrix/Vandermonde.lean`, not in the Reed-Solomon file.
 - Trivariate polynomial utilities used by the BCIKS20 proximity-gap proofs
-  (`eval_on_Z`, `toRatFuncPoly`, `D_Y`, `D_YZ`, and related notation) live in
+  (`evalAtX`, `evalAtY`, `evalAtZ`, the named degree projections, `D_Y`, `D_YZ`, and related
+  notation) live in
   `ArkLib/Data/Polynomial/Trivariate.lean`, not in `ProximityGap/Basic.lean` or
-  `ProximityGap/BCIKS20/ListDecoding/Guruswami.lean`.
+  `ProximityGap/BCIKS20/ListDecoding/Guruswami.lean`. See
+  [`polynomial-conventions.md`](polynomial-conventions.md) before applying generic bivariate
+  operations to a trivariate value.
 - **The reusable way into `perfectCompleteness` is `Reduction.perfectCompleteness_of_run_support`
   in `Security/Basic.lean`**, not the commented-out `perfectCompleteness_forall_challenge` sketch
   a few lines below it. It reduces perfect completeness to a support statement about the


### PR DESCRIPTION
## Confirmed defect fixed

- The canonical innermost-variable operation `Trivariate.eval_on_Z` was opaque, so downstream proofs could not unfold it and `Extraction.lean` had grown a duplicate `pg_eval_on_Z`. This replaces it with the transparent, axis-explicit `evalAtZ` definition and keeps deprecated compatibility aliases.
- The audit confirms that `Bivariate.totalDegree` on `F[Z][X][Y]` measures only the structural `(X, Y)` projection. It is not the `(Y, Z)` degree and it ignores `Z`. The asymmetric regression polynomial `Z^5 X^7 Y^3` proves the distinction: `degreeXY = 10`, `degreeYZ = 8`, and `totalDegreeXYZ = 15`.

No incorrect mathematical statement on current `main` was found or changed.

## Preventive API hardening

- Add semantic trivariate evaluation operations `evalAtX`, `evalAtY`, and `evalAtZ`.
- Add named degree operations `degreeInX`, `degreeInY`, `degreeInZ`, `degreeXY`, `degreeYZ`, and `totalDegreeXYZ`, with bridge lemmas and docstrings.
- Generalize the existing BCIKS20 `D_Y` and `D_YZ` definitions from fields to commutative semirings while preserving their definitions.
- Migrate high-confidence trivariate call sites in BCIKS20 list decoding and the Hensel boundary to the semantic API.
- Reuse the common trivariate total-degree API in Hensel instead of maintaining a local duplicate.
- Add unequal-exponent regression checks for all three evaluation axes and the relevant projected/full degree notions.
- Document the nesting convention and the remaining intentional generic-bivariate uses.

## Audit scope

Reviewed trivariate uses of `Bivariate.evalX`, `evalY`, `degreeX`, `natDegreeY`, `totalDegree`, swaps, and nested coefficient access across BCIKS20 list decoding, Polishchuk-Spielman and affine-line code, and the rational-function Hensel package. The swap sites inspected are genuinely bivariate. Remaining raw Hensel operations are on actual bivariate coefficients, on results after trivariate specialization, or are definitionally correct middle-`X` evaluation inside proof-heavy implementation code; the package and wiki documentation record why they are correct.

## External finding and remaining obligation

PR #787 at head `54e2e918` adds Claim 5.8 hypotheses of the form `Bivariate.totalDegree (R : F[Z][X][Y]) <= D_YZ Q`. The asymmetric regression confirms that the left side is the `(X, Y)` projection, not the intended `(Y, Z)` projection. This main-based PR deliberately does not mutate #787. After rebasing, #787 should express those hypotheses with `Trivariate.degreeYZ R <= D_YZ Q` and revalidate the downstream proof obligations.

## Validation

- Focused builds: `Trivariate`, BCIKS20 `Agreement`, and Hensel `Weight` dependency closure
- `./scripts/validate.sh`
- `./scripts/validate.sh --axioms` (fixture matrix passed; 10,479 declarations checked; no new axiom/sorry taint; no non-standard axiom taint)
- `./scripts/validate.sh --docs`
- `python3 ./scripts/check-docs-integrity.py` after staging the new wiki page
- `git diff --cached --check`

All requested validation passed.