### PR TITLE
feat(coding-theory): constructors for the Grand List-Decoding witnesses

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -166,6 +166,7 @@ import ArkLib.Data.CodingTheory.ProximityGap.Folding.ListDecodability
 import ArkLib.Data.CodingTheory.ProximityGap.Folding.Multilinear
 import ArkLib.Data.CodingTheory.ProximityGap.GrandChallenges
 import ArkLib.Data.CodingTheory.ProximityGap.GrandChallenges.CapacityBounds
+import ArkLib.Data.CodingTheory.ProximityGap.GrandChallenges.ListDecoding
 import ArkLib.Data.CodingTheory.ProximityGap.GrandChallenges.UniqueDecoding
 import ArkLib.Data.CodingTheory.ProximityGap.InformationSetLowerBound
 import ArkLib.Data.CodingTheory.ProximityGap.LineDecoding

--- a/ArkLib/Data/CodingTheory/ProximityGap/GrandChallenges.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/GrandChallenges.lean
@@ -553,6 +553,35 @@ theorem ListUpperWitness.boundary_lt {C : Set (ι → F)} {m : ℕ} {ε_star : �
   push Not at h
   exact absurd (R.le_of_gridPt h) (not_le.mpr w.exceeds)
 
+/-- A list-size upper bound at a unit-interval radius gives a safe witness. -/
+def ListLowerWitness.ofLe {C : Set (ι → F)} {m : ℕ} {ε_star δ : ℝ≥0}
+    (hδ : δ ≤ 1)
+    (h : (Code.Lambda (C^⋈(Fin m)) (δ : ℝ) : ENNReal) ≤
+      (ε_star : ENNReal) * (Fintype.card F : ENNReal)) :
+    ListLowerWitness C m ε_star := ⟨δ, hδ, h⟩
+
+/-- A list-size lower bound at a unit-interval radius gives an unsafe witness. -/
+def ListUpperWitness.ofGt {C : Set (ι → F)} {m : ℕ} {ε_star δ : ℝ≥0}
+    (hδ : δ ≤ 1)
+    (h : (Code.Lambda (C^⋈(Fin m)) (δ : ℝ) : ENNReal) >
+      (ε_star : ENNReal) * (Fintype.card F : ENNReal)) :
+    ListUpperWitness C m ε_star := ⟨δ, hδ, h⟩
+
+/-- A single word with an oversized point list gives an unsafe witness. This is the primitive
+form: `Lambda` is a supremum over words, so exhibiting one word whose interleaved point list
+outruns the threshold suffices, and no bound on any other word is needed.
+
+It is the entry point for a concrete large-list construction, which produces exactly this shape —
+a specific word together with a lower bound on its own list. -/
+def ListUpperWitness.ofEncardGt {C : Set (ι → F)} {m : ℕ} {ε_star δ : ℝ≥0}
+    (hδ : δ ≤ 1) (f : ι → (Fin m → F))
+    (h : (ε_star : ENNReal) * (Fintype.card F : ENNReal) <
+      ((Code.closeCodewordsRel (C^⋈(Fin m)) f (δ : ℝ)).encard : ENNReal)) :
+    ListUpperWitness C m ε_star :=
+  ListUpperWitness.ofGt hδ
+    (lt_of_lt_of_le h (by
+      exact_mod_cast Code.encard_closeCodewordsRel_le_Lambda (C ^⋈ (Fin m)) (δ : ℝ) f))
+
 end GrandChallenges
 
 end ProximityGap

--- a/ArkLib/Data/CodingTheory/ProximityGap/GrandChallenges/ListDecoding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/GrandChallenges/ListDecoding.lean
@@ -13,8 +13,11 @@ import ArkLib.Data.CodingTheory.ProximityGap.GrandChallenges
 
 `GrandChallenges.lean` states the Grand List-Decoding Challenge on the interleaved list size
 `Λ(C^⋈m, δ)` and carries the one-sided witness types `ListLowerWitness` / `ListUpperWitness`,
-but ships no constructor for either. This module supplies the first two `ListLowerWitness`
-constructors, one in the unique-decoding regime and one at the Johnson radius.
+together with the generic shapes that repackage a `Λ` bound as a witness
+(`ListLowerWitness.ofLe`, `ListUpperWitness.ofGt`, `ListUpperWitness.ofEncardGt`). What it has
+no constructor for is a witness whose `Λ` bound comes from coding theory rather than from the
+caller. This module supplies the first two, one in the unique-decoding regime and one at the
+Johnson radius.
 
 ## Main definitions
 
@@ -46,13 +49,28 @@ The Johnson constructor reaches much further, and — unlike its MCA counterpart
 itself axiom-clean, so it applies to the interleaved code at alphabet `Fin m → F` directly.
 
 Note the alphabet the Johnson radius is computed at. For the interleaved code that is
-`q = |F|^m`, not `|F|`; since `q/(q-1)` decreases in `q`, interleaving widens rather than
-narrows the usable radius. The relative minimum distance is unchanged, so the whole effect of
-`m` on the bound enters through `q`.
+`q = |F|^m`, not `|F|`. The relative minimum distance is unchanged, so the whole effect of `m`
+on the bound enters through `q` — and it enters against us. Writing `c = q/(q-1)`,
 
-Neither constructor approaches the prize thresholds — both bound `Λ` by a constant, whereas
-`ε* = 2⁻¹²⁸` demands `ℓ ≤ ε* · |F|` — but they are the two admit-free footholds the challenge
-API previously lacked entirely.
+`J_q(δ) = (1/c) · (1 - √(1 - c·δ)) = δ · h(c·δ)`  where  `h(u) = (1 - √(1 - u))/u`,
+
+and `h` is increasing on `(0, 1]`, so `J_q(δ)` is increasing in `c` and therefore *decreasing*
+in `q`, tending to `1 - √(1 - δ)` from above. So the larger alphabet of the interleaved code
+narrows this Johnson radius rather than widening it: `Jqℓ 4 2 1 ≈ 0.317` against
+`Jqℓ 2 2 1 = 0.5`. (The comparison lives in the regime where the radicand `1 - c·δ` is
+non-negative; outside it `Real.sqrt` is clamped to `0` and `J_q` collapses to `1 - 1/q`.)
+`lambda_interleavedCode_le_of_le_johnson` states its hypothesis at `q = |F|^m` either way — the
+interleaved code's own alphabet is what the Johnson bound is applied at, so the theorem is
+correct as stated; what shrinks with `m` is only the room a caller has to work in.
+
+Neither constructor resolves the challenge, but the gap is narrower than a list budget. `ℓ` is
+a parameter of `ofJohnsonBound`, which accepts any proof of `ℓ ≤ ε* · |F|`, so the prize's
+`Λ ≤ ε* · |F|` shape is already expressible here rather than being cut off at a fixed constant.
+The binding constraint is the radius: `Jqℓ q ℓ δ_min` is capped by `J_q(δ_min)` however large
+`ℓ` grows, and a resolution needs a full per-rate `GrandListResolution` — safety at every grid
+point, or an exact adjacent-grid crossing — plus a concrete `ListUpperWitness`, none of which
+this module supplies. What it does supply are the two admit-free footholds the challenge API
+previously lacked entirely.
 
 ## Implementation note
 
@@ -77,6 +95,9 @@ by `exact` at default transparency and avoids re-entering that thicket.
 
 * [Arnon, G., Boneh, D., Fenzi, G., *Open Problems in List Decoding and Correlated
   Agreement*][ABF26]
+* [Ben-Sasson, E., Carmon, D., Haböck, U., Kopparty, S., Saraf, S., *On Proximity Gaps for
+  Reed-Solomon Codes*][BCHKS25] — cited above only for the admit underlying the MCA-side
+  Johnson-range witness, which this module's counterpart does not need.
 -/
 
 namespace ProximityGap.GrandChallenges
@@ -94,7 +115,7 @@ interleaving leaves the minimum distance alone (`Code.minDist_interleavedCodeSet
 length `|ι|` normalizing it is untouched as well. -/
 theorem relUDR_interleavedCode_eq (C : Set (ι → F)) {m : ℕ} (hm : 0 < m) :
     relativeUniqueDecodingRadius (C^⋈(Fin m)) = relativeUniqueDecodingRadius C := by
-  haveI : Nonempty (Fin m) := Fin.pos_iff_nonempty.mp hm
+  have : Nonempty (Fin m) := Fin.pos_iff_nonempty.mp hm
   have hmd : minDist (C^⋈(Fin m)) = minDist C := minDist_interleavedCodeSet (κ := Fin m) C
   have h : dist (C^⋈(Fin m)) = dist C :=
     (dist_eq_minDist _).trans (hmd.trans (dist_eq_minDist C).symm)
@@ -148,7 +169,7 @@ theorem lambda_interleavedCode_le_of_le_johnson (C : Set (ι → F)) {m ℓ : �
     (hδ : (δ : ℝ) ≤ JohnsonBound.Jqℓ ((Fintype.card F : ℚ) ^ m) (ℓ : ℚ)
             ((Code.minDist C : ℚ) / (Fintype.card ι : ℚ))) :
     Lambda (C^⋈(Fin m)) (δ : ℝ) ≤ (ℓ : ℕ∞) := by
-  haveI : Nonempty (Fin m) := Fin.pos_iff_nonempty.mp hm
+  have : Nonempty (Fin m) := Fin.pos_iff_nonempty.mp hm
   have hcard : (Fintype.card (Fin m → F) : ℚ) = (Fintype.card F : ℚ) ^ m := by
     simp
   have hmd : (Code.minDist (C^⋈(Fin m)) : ℚ) = (Code.minDist C : ℚ) := by

--- a/ArkLib/Data/CodingTheory/ProximityGap/GrandChallenges/ListDecoding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/GrandChallenges/ListDecoding.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: AryaETHn
+-/
+
+import ArkLib.Data.CodingTheory.InterleavedCode
+import ArkLib.Data.CodingTheory.ProximityGap.GrandChallenges
+
+/-!
+# Unique-decoding witnesses for the Grand List-Decoding Challenge
+
+`GrandChallenges.lean` states the Grand List-Decoding Challenge on the interleaved list size
+`Λ(C^⋈m, δ)` and carries the one-sided witness types `ListLowerWitness` / `ListUpperWitness`,
+but ships no constructor for either. This module supplies the first `ListLowerWitness`
+constructor, in the unique-decoding regime.
+
+## Main definitions
+
+- `ListLowerWitness.ofUniqueDecodingRange` — a one-sided Grand List-Decoding Challenge witness
+  for any code at any radius up to its relative unique-decoding radius, valid whenever the
+  threshold clears a single codeword.
+
+## Main statements
+
+- `relUDR_interleavedCode_eq` — interleaving preserves the relative unique-decoding radius.
+- `lambda_interleavedCode_le_one_of_le_relUDR` — inside that radius the interleaved point lists
+  are subsingletons, so `Λ ≤ 1`.
+
+## Why the unique-decoding regime
+
+This mirrors `McaLowerWitness.ofUniqueDecodingRange` on the MCA side, and for the same reason:
+it is the honest floor. Nothing beneath it is admitted. Interleaving preserves minimum distance
+(`Code.minDist_interleavedCodeSet`), hence the unique-decoding radius, and inside that radius
+every point list is a subsingleton
+(`Code.isUniquelyDecodable_relativeUniqueDecodingRadius`) — both proved in-tree.
+
+The trade is radius for provenance, as it is there. The unique-decoding radius is half the
+minimum distance, well short of the Johnson and capacity radii the challenge cares about, so
+this is not a route to the prize thresholds. What it buys is a `Λ ≤ 1` certificate holding for
+*every* code and every interleaving width with no external admit anywhere beneath it, and the
+demand it puts on the threshold — that `ε* · |F|` clear a single codeword — is the weakest any
+nonvacuous list bound could make.
+
+## Implementation note
+
+`relativeUniqueDecodingRadius` is defined in terms of `‖·‖₀`, which is notation for `Code.dist`
+— *not* `Code.minDist`, which is a separate `sInf` with `≤` relaxed to `=` in its defining set.
+The interleaving lemma available here, `Code.minDist_interleavedCodeSet`, is stated on
+`Code.minDist`, so it does not apply to the radius directly; `Code.dist_eq_minDist` is the
+bridge, and `relUDR_interleavedCode_eq` below composes the three equalities by hand.
+
+This is worth spelling out because the failure mode is badly disguised. Feeding a `minDist`
+equation to a `dist` goal makes `rw` report that it "did not find an occurrence" of a pattern
+that appears verbatim in the goal — the two print almost identically — and Lean additionally
+emits a note about the target not being type-correct at `instances` transparency, which invites
+the wrong diagnosis entirely (a `Matrix ι (Fin m) F` versus `ι → Fin m → F` mismatch). That
+note is a red herring here. The fix is to get `dist` and `minDist` straight, not to chase
+transparency.
+
+The proofs then use `Eq.trans` and `congrArg` rather than `rw`, which keeps every step checked
+by `exact` at default transparency and avoids re-entering that thicket.
+
+## References
+
+* [Arnon, G., Boneh, D., Fenzi, G., *Open Problems in List Decoding and Correlated
+  Agreement*][ABF26]
+-/
+
+namespace ProximityGap.GrandChallenges
+
+open scoped NNReal
+open Code
+
+variable {F ι : Type} [Field F] [Fintype F] [DecidableEq F]
+    [Fintype ι] [Nonempty ι]
+
+omit [Field F] [Fintype F] [Nonempty ι] in
+/-- **Interleaving preserves the relative unique-decoding radius.** The block metric on
+`ι → Fin m → F` counts a position as a disagreement when the whole `m`-tuple differs, so
+interleaving leaves the minimum distance alone (`Code.minDist_interleavedCodeSet`); the block
+length `|ι|` normalizing it is untouched as well. -/
+theorem relUDR_interleavedCode_eq (C : Set (ι → F)) {m : ℕ} (hm : 0 < m) :
+    relativeUniqueDecodingRadius (C^⋈(Fin m)) = relativeUniqueDecodingRadius C := by
+  haveI : Nonempty (Fin m) := Fin.pos_iff_nonempty.mp hm
+  have hmd : minDist (C^⋈(Fin m)) = minDist C := minDist_interleavedCodeSet (κ := Fin m) C
+  have h : dist (C^⋈(Fin m)) = dist C :=
+    (dist_eq_minDist _).trans (hmd.trans (dist_eq_minDist C).symm)
+  exact congrArg (fun d : ℕ => (((d : ℝ≥0) - 1) / 2) / (Fintype.card ι : ℝ≥0)) h
+
+omit [Field F] [Fintype F] [Nonempty ι] in
+/-- **Inside the unique-decoding radius the interleaved list is a subsingleton.** Combining
+`relUDR_interleavedCode_eq` with unique decodability of every code at its own relative
+unique-decoding radius. -/
+theorem lambda_interleavedCode_le_one_of_le_relUDR (C : Set (ι → F)) {m : ℕ} (hm : 0 < m)
+    {δ : ℝ≥0} (hδ : δ ≤ relativeUniqueDecodingRadius C) :
+    Lambda (C^⋈(Fin m)) (δ : ℝ) ≤ 1 := by
+  refine le_trans (Lambda_mono ?_)
+    (isUniquelyDecodable_iff_Lambda_le.mp
+      (isUniquelyDecodable_relativeUniqueDecodingRadius (C^⋈(Fin m))))
+  calc (δ : ℝ)
+      ≤ (relativeUniqueDecodingRadius C : ℝ) := by exact_mod_cast hδ
+    _ = (relativeUniqueDecodingRadius (C^⋈(Fin m)) : ℝ) := by
+        exact_mod_cast (relUDR_interleavedCode_eq C hm).symm
+
+/-- Builds a one-sided list-decoding witness from unique decodability: at any radius `δ` up to
+the relative unique-decoding radius of `C`, the interleaved list size is at most `1`, so any
+threshold whose `ε_star · |F|` clears a single codeword is witnessed.
+
+The radius hypothesis is on the base code, not the interleaved one —
+`relUDR_interleavedCode_eq` identifies the two, and the base-code form is the one a caller can
+discharge. -/
+noncomputable def ListLowerWitness.ofUniqueDecodingRange
+    (C : Set (ι → F)) (m : ℕ) (δ ε_star : ℝ≥0)
+    (hm : 0 < m)
+    (hδ_le_one : δ ≤ 1)
+    (hδ : δ ≤ relativeUniqueDecodingRadius C)
+    (hle : (1 : ENNReal) ≤ (ε_star : ENNReal) * (Fintype.card F : ENNReal)) :
+    ListLowerWitness C m ε_star :=
+  ListLowerWitness.ofLe hδ_le_one
+    (le_trans
+      (by exact_mod_cast lambda_interleavedCode_le_one_of_le_relUDR C hm hδ) hle)
+
+end ProximityGap.GrandChallenges

--- a/ArkLib/Data/CodingTheory/ProximityGap/GrandChallenges/ListDecoding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/GrandChallenges/ListDecoding.lean
@@ -5,42 +5,54 @@ Authors: AryaETHn
 -/
 
 import ArkLib.Data.CodingTheory.InterleavedCode
+import ArkLib.Data.CodingTheory.JohnsonBound.Family
 import ArkLib.Data.CodingTheory.ProximityGap.GrandChallenges
 
 /-!
-# Unique-decoding witnesses for the Grand List-Decoding Challenge
+# List-decoding witnesses for the Grand List-Decoding Challenge
 
 `GrandChallenges.lean` states the Grand List-Decoding Challenge on the interleaved list size
 `Λ(C^⋈m, δ)` and carries the one-sided witness types `ListLowerWitness` / `ListUpperWitness`,
-but ships no constructor for either. This module supplies the first `ListLowerWitness`
-constructor, in the unique-decoding regime.
+but ships no constructor for either. This module supplies the first two `ListLowerWitness`
+constructors, one in the unique-decoding regime and one at the Johnson radius.
 
 ## Main definitions
 
-- `ListLowerWitness.ofUniqueDecodingRange` — a one-sided Grand List-Decoding Challenge witness
-  for any code at any radius up to its relative unique-decoding radius, valid whenever the
-  threshold clears a single codeword.
+- `ListLowerWitness.ofUniqueDecodingRange` — a witness for any code at any radius up to its
+  relative unique-decoding radius, valid whenever the threshold clears a single codeword.
+- `ListLowerWitness.ofJohnsonBound` — a witness at the Johnson radius of the *interleaved*
+  code, valid whenever the threshold clears `ℓ` codewords.
 
 ## Main statements
 
 - `relUDR_interleavedCode_eq` — interleaving preserves the relative unique-decoding radius.
 - `lambda_interleavedCode_le_one_of_le_relUDR` — inside that radius the interleaved point lists
   are subsingletons, so `Λ ≤ 1`.
+- `lambda_interleavedCode_le_of_le_johnson` — at the Johnson radius, `Λ ≤ ℓ`.
 
-## Why the unique-decoding regime
+## The two regimes
 
-This mirrors `McaLowerWitness.ofUniqueDecodingRange` on the MCA side, and for the same reason:
-it is the honest floor. Nothing beneath it is admitted. Interleaving preserves minimum distance
+The unique-decoding constructor mirrors `McaLowerWitness.ofUniqueDecodingRange` on the MCA side,
+and is the honest floor: interleaving preserves minimum distance
 (`Code.minDist_interleavedCodeSet`), hence the unique-decoding radius, and inside that radius
-every point list is a subsingleton
-(`Code.isUniquelyDecodable_relativeUniqueDecodingRadius`) — both proved in-tree.
+every point list is a subsingleton (`Code.isUniquelyDecodable_relativeUniqueDecodingRadius`).
+Both are proved in-tree, so nothing beneath it is admitted. But the radius is only half the
+minimum distance, far short of what the challenge cares about.
 
-The trade is radius for provenance, as it is there. The unique-decoding radius is half the
-minimum distance, well short of the Johnson and capacity radii the challenge cares about, so
-this is not a route to the prize thresholds. What it buys is a `Λ ≤ 1` certificate holding for
-*every* code and every interleaving width with no external admit anywhere beneath it, and the
-demand it puts on the threshold — that `ε* · |F|` clear a single codeword — is the weakest any
-nonvacuous list bound could make.
+The Johnson constructor reaches much further, and — unlike its MCA counterpart
+`McaLowerWitness.ofJohnsonRangeBound`, which rests on the external `[BCHKS25]` admit
+`rs_mcaError_le_in_johnson_range` — it is *also* admit-free:
+`CodingTheory.johnson_bound_lambda_le_ell` is stated over an arbitrary finite alphabet and is
+itself axiom-clean, so it applies to the interleaved code at alphabet `Fin m → F` directly.
+
+Note the alphabet the Johnson radius is computed at. For the interleaved code that is
+`q = |F|^m`, not `|F|`; since `q/(q-1)` decreases in `q`, interleaving widens rather than
+narrows the usable radius. The relative minimum distance is unchanged, so the whole effect of
+`m` on the bound enters through `q`.
+
+Neither constructor approaches the prize thresholds — both bound `Λ` by a constant, whereas
+`ε* = 2⁻¹²⁸` demands `ℓ ≤ ε* · |F|` — but they are the two admit-free footholds the challenge
+API previously lacked entirely.
 
 ## Implementation note
 
@@ -120,5 +132,50 @@ noncomputable def ListLowerWitness.ofUniqueDecodingRange
   ListLowerWitness.ofLe hδ_le_one
     (le_trans
       (by exact_mod_cast lambda_interleavedCode_le_one_of_le_relUDR C hm hδ) hle)
+
+/-! ## The Johnson regime -/
+
+omit [Field F] in
+/-- **The interleaved list size at the Johnson radius.** `CodingTheory.johnson_bound_lambda_le_ell`
+applied to `C^⋈(Fin m)`, with its two code-dependent inputs re-expressed on the base code: the
+alphabet size becomes `|F|^m`, and the minimum distance is unchanged
+(`Code.minDist_interleavedCodeSet`).
+
+Stating the radius on the base code is what makes this usable — a caller has `C`, not
+`C^⋈(Fin m)`, in hand. -/
+theorem lambda_interleavedCode_le_of_le_johnson (C : Set (ι → F)) {m ℓ : ℕ}
+    (hm : 0 < m) (hℓ : 1 ≤ ℓ) {δ : ℝ≥0}
+    (hδ : (δ : ℝ) ≤ JohnsonBound.Jqℓ ((Fintype.card F : ℚ) ^ m) (ℓ : ℚ)
+            ((Code.minDist C : ℚ) / (Fintype.card ι : ℚ))) :
+    Lambda (C^⋈(Fin m)) (δ : ℝ) ≤ (ℓ : ℕ∞) := by
+  haveI : Nonempty (Fin m) := Fin.pos_iff_nonempty.mp hm
+  have hcard : (Fintype.card (Fin m → F) : ℚ) = (Fintype.card F : ℚ) ^ m := by
+    simp
+  have hmd : (Code.minDist (C^⋈(Fin m)) : ℚ) = (Code.minDist C : ℚ) := by
+    exact_mod_cast minDist_interleavedCodeSet (κ := Fin m) C
+  refine le_trans (Lambda_mono ?_)
+    (CodingTheory.johnson_bound_lambda_le_ell (C^⋈(Fin m)) ℓ hℓ)
+  rw [hcard, hmd]
+  exact hδ
+
+/-- Builds a one-sided list-decoding witness from the Johnson bound for the interleaved code: at
+any radius up to `J_{q,ℓ}` computed at `q = |F|^m` and the base code's relative minimum distance,
+the interleaved list size is at most `ℓ`, so any threshold whose `ε_star · |F|` clears `ℓ`
+codewords is witnessed.
+
+Unlike `McaLowerWitness.ofJohnsonRangeBound` on the MCA side, nothing below this constructor is
+admitted. -/
+noncomputable def ListLowerWitness.ofJohnsonBound
+    (C : Set (ι → F)) (m ℓ : ℕ) (δ ε_star : ℝ≥0)
+    (hm : 0 < m)
+    (hℓ : 1 ≤ ℓ)
+    (hδ_le_one : δ ≤ 1)
+    (hδ : (δ : ℝ) ≤ JohnsonBound.Jqℓ ((Fintype.card F : ℚ) ^ m) (ℓ : ℚ)
+            ((Code.minDist C : ℚ) / (Fintype.card ι : ℚ)))
+    (hle : (ℓ : ENNReal) ≤ (ε_star : ENNReal) * (Fintype.card F : ENNReal)) :
+    ListLowerWitness C m ε_star :=
+  ListLowerWitness.ofLe hδ_le_one
+    (le_trans
+      (by exact_mod_cast lambda_interleavedCode_le_of_le_johnson C hm hℓ hδ) hle)
 
 end ProximityGap.GrandChallenges

--- a/docs/kb/papers/ABF26.md
+++ b/docs/kb/papers/ABF26.md
@@ -97,15 +97,19 @@ manuscript, not to the original sources it cites — those get their own keys (`
   unique-decoding radius (`relUDR_interleavedCode_eq`), and inside that radius the interleaved
   point lists are subsingletons, so `Λ(C^⋈m, δ) ≤ 1`. `ofJohnsonBound` reaches the Johnson
   radius, via `CodingTheory.johnson_bound_lambda_le_ell` applied to the interleaved code at
-  alphabet `Fin m → F`; the radius is computed at `q = |F|^m` rather than `|F|`, which widens
-  it, since `q/(q-1)` decreases in `q`, while the relative minimum distance is unchanged.
+  alphabet `Fin m → F`; the radius is computed at `q = |F|^m` rather than `|F|`, which *narrows*
+  it, while the relative minimum distance is unchanged. Writing `c = q/(q-1)`, the Johnson
+  function is `J_q(δ) = δ · h(c·δ)` with `h(u) = (1 - √(1 - u))/u` increasing, so `J_q(δ)`
+  decreases in `q` down to `1 - √(1 - δ)` — e.g. `Jqℓ 4 2 1 ≈ 0.317 < Jqℓ 2 2 1 = 0.5`. The
+  bound is stated at the interleaved code's own alphabet and is correct as such; the alphabet
+  simply costs radius rather than buying it.
   Note the asymmetry with the MCA side: `McaLowerWitness.ofJohnsonRangeBound` is sorry-tainted
   through the external [BCHKS25] admit `rs_mcaError_le_in_johnson_range`, whereas the list-side
   Johnson witness rests on an in-tree axiom-clean bound and needs no admit.
   The generic shapes — `ListLowerWitness.ofLe`, `ListUpperWitness.ofGt`, and
   `ListUpperWitness.ofEncardGt`, the last reducing an unsafe witness to a single word with an
-  oversized point list — sit alongside the MCA ones in `GrandChallenges.lean`. Both constructors
-  bound `Λ` by a constant, so neither approaches the prize thresholds; see the gap note below.
+  oversized point list — sit alongside the MCA ones in `GrandChallenges.lean`. Neither
+  constructor resolves the challenge; see the gap note below.
 - **§4–§5 bound catalogue.** `ProximityGap/CapacityBounds.lean` and
   `Connections/ListDecodingAndCA.lean` state the externally sourced upper/lower bounds and
   connections on the canonical error and list-size carriers. `LineDecoding.lean` uses the
@@ -293,8 +297,10 @@ guard `k ≤ ringChar F` for degree-`< k` messages.
   `McaUpperWitness` or `ListUpperWitness` is built for a concrete code (`McaUpperWitness.ofGt`,
   `.ofEpsCaGt`, and `ListUpperWitness.ofGt`, `.ofEncardGt` are generic shapes awaiting a real
   large-list or CA-failure construction). On the safe side both list constructors now exist, at
-  the unique-decoding and Johnson radii; what neither reaches, and what a prize resolution would
-  need, is a bound of the shape `Λ ≤ ε* · |F|` rather than `Λ ≤ ℓ` for a fixed `ℓ`.
+  the unique-decoding and Johnson radii. The remaining shortfall there is the radius, not the
+  list budget: `ℓ` is a parameter of `ofJohnsonBound` and the constructor already accepts a
+  proof of `ℓ ≤ ε* · |F|`, so the prize's bound shape is expressible, but `Jqℓ q ℓ δ_min` stays
+  capped by `J_q(δ_min)` however large `ℓ` grows.
 - **L2.10.** The interleaved-code list-size comparison is present as an external `[GGR11]` leaf;
   proving it in-tree remains open.
 - **§6.** A cost model for erasure correction, without which D6.4/L6.5 carry no content; and

--- a/docs/kb/papers/ABF26.md
+++ b/docs/kb/papers/ABF26.md
@@ -24,6 +24,7 @@ related_modules:
   - ArkLib/Data/CodingTheory/ProximityGap/InformationSetLowerBound.lean
   - ArkLib/Data/CodingTheory/ProximityGap/GrandChallenges.lean
   - ArkLib/Data/CodingTheory/ProximityGap/GrandChallenges/CapacityBounds.lean
+  - ArkLib/Data/CodingTheory/ProximityGap/GrandChallenges/ListDecoding.lean
   - ArkLib/Data/CodingTheory/ProximityGap/LineDecoding.lean
   - ArkLib/Data/CodingTheory/SubspaceDesign.lean
   - ArkLib/Data/CodingTheory/ReedSolomon/Folded.lean
@@ -90,6 +91,16 @@ manuscript, not to the original sources it cites — those get their own keys (`
   adjacent-grid and radius-one endpoint answers. `ProximityGap/Errors.lean` contains `epsPg`,
   `epsCa`, and their comparisons with affine-line `mcaError`. The information-set lower bound is
   in `InformationSetLowerBound.lean`.
+- **§1 one-sided list witnesses.** `GrandChallenges/ListDecoding.lean` holds
+  `ListLowerWitness.ofUniqueDecodingRange`, the first constructor for either list witness type:
+  interleaving preserves minimum distance, hence the unique-decoding radius
+  (`relUDR_interleavedCode_eq`), and inside that radius the interleaved point lists are
+  subsingletons, so `Λ(C^⋈m, δ) ≤ 1`. It is axiom-clean, and so is the whole of
+  `GrandChallenges.lean`. The generic shapes — `ListLowerWitness.ofLe`, `ListUpperWitness.ofGt`,
+  and `ListUpperWitness.ofEncardGt`, the last reducing an unsafe witness to a single word with
+  an oversized point list — sit alongside the MCA ones in `GrandChallenges.lean`. As on the MCA
+  side, the unique-decoding radius is far short of the Johnson and capacity radii, so none of
+  this approaches the prize thresholds; see the gap note below.
 - **§4–§5 bound catalogue.** `ProximityGap/CapacityBounds.lean` and
   `Connections/ListDecodingAndCA.lean` state the externally sourced upper/lower bounds and
   connections on the canonical error and list-size carriers. `LineDecoding.lean` uses the
@@ -267,6 +278,19 @@ guard `k ≤ ringChar F` for degree-`< k` messages.
     convention *and* the non-negative-exponent guard its pigeonhole needs, and is false without
     either; Theorem 3.4's premise, read at Theorem 2.18's printed profile, is false (it needs
     [CZ25]'s `(k−1)` level). Both have compiled axiom-clean counterexamples.
+- **§1 challenge resolutions.** Both prize propositions remain unproved at every rate, and this
+  is the open research question rather than a formalization backlog: `mcaPrize` and
+  `listDecodingPrize` reduce to `McaPrizeResolution` / `ListPrizeResolution`, neither of which is
+  ever constructed, because each demands a full `GrandMcaResolution` / `GrandListResolution` —
+  an exact adjacent-grid crossing, or safety at every grid point. Nothing outside
+  `GrandChallenges.lean` instantiates `prizeDimension` / `prizeRate` at any `j : Fin 4`, so the
+  rates `1/4`, `1/8`, `1/16` are untouched. Two nearer gaps are ordinary formalization work: no
+  `McaUpperWitness` or `ListUpperWitness` is built for a concrete code (`McaUpperWitness.ofGt`,
+  `.ofEpsCaGt`, and `ListUpperWitness.ofGt`, `.ofEncardGt` are generic shapes awaiting a real
+  large-list or CA-failure construction); and no list witness yet reaches past the
+  unique-decoding radius, though `CodingTheory.johnson_bound_lambda_le_ell` is stated over an
+  arbitrary finite alphabet and is axiom-clean, so a Johnson-radius `ListLowerWitness` is
+  reachable without new admits.
 - **L2.10.** The interleaved-code list-size comparison is present as an external `[GGR11]` leaf;
   proving it in-tree remains open.
 - **§6.** A cost model for erasure correction, without which D6.4/L6.5 carry no content; and

--- a/docs/kb/papers/ABF26.md
+++ b/docs/kb/papers/ABF26.md
@@ -91,16 +91,21 @@ manuscript, not to the original sources it cites — those get their own keys (`
   adjacent-grid and radius-one endpoint answers. `ProximityGap/Errors.lean` contains `epsPg`,
   `epsCa`, and their comparisons with affine-line `mcaError`. The information-set lower bound is
   in `InformationSetLowerBound.lean`.
-- **§1 one-sided list witnesses.** `GrandChallenges/ListDecoding.lean` holds
-  `ListLowerWitness.ofUniqueDecodingRange`, the first constructor for either list witness type:
-  interleaving preserves minimum distance, hence the unique-decoding radius
-  (`relUDR_interleavedCode_eq`), and inside that radius the interleaved point lists are
-  subsingletons, so `Λ(C^⋈m, δ) ≤ 1`. It is axiom-clean, and so is the whole of
-  `GrandChallenges.lean`. The generic shapes — `ListLowerWitness.ofLe`, `ListUpperWitness.ofGt`,
-  and `ListUpperWitness.ofEncardGt`, the last reducing an unsafe witness to a single word with
-  an oversized point list — sit alongside the MCA ones in `GrandChallenges.lean`. As on the MCA
-  side, the unique-decoding radius is far short of the Johnson and capacity radii, so none of
-  this approaches the prize thresholds; see the gap note below.
+- **§1 one-sided list witnesses.** `GrandChallenges/ListDecoding.lean` holds the two
+  `ListLowerWitness` constructors, both axiom-clean, as is the whole of `GrandChallenges.lean`.
+  `ofUniqueDecodingRange` is the floor: interleaving preserves minimum distance, hence the
+  unique-decoding radius (`relUDR_interleavedCode_eq`), and inside that radius the interleaved
+  point lists are subsingletons, so `Λ(C^⋈m, δ) ≤ 1`. `ofJohnsonBound` reaches the Johnson
+  radius, via `CodingTheory.johnson_bound_lambda_le_ell` applied to the interleaved code at
+  alphabet `Fin m → F`; the radius is computed at `q = |F|^m` rather than `|F|`, which widens
+  it, since `q/(q-1)` decreases in `q`, while the relative minimum distance is unchanged.
+  Note the asymmetry with the MCA side: `McaLowerWitness.ofJohnsonRangeBound` is sorry-tainted
+  through the external [BCHKS25] admit `rs_mcaError_le_in_johnson_range`, whereas the list-side
+  Johnson witness rests on an in-tree axiom-clean bound and needs no admit.
+  The generic shapes — `ListLowerWitness.ofLe`, `ListUpperWitness.ofGt`, and
+  `ListUpperWitness.ofEncardGt`, the last reducing an unsafe witness to a single word with an
+  oversized point list — sit alongside the MCA ones in `GrandChallenges.lean`. Both constructors
+  bound `Λ` by a constant, so neither approaches the prize thresholds; see the gap note below.
 - **§4–§5 bound catalogue.** `ProximityGap/CapacityBounds.lean` and
   `Connections/ListDecodingAndCA.lean` state the externally sourced upper/lower bounds and
   connections on the canonical error and list-size carriers. `LineDecoding.lean` uses the
@@ -284,13 +289,12 @@ guard `k ≤ ringChar F` for degree-`< k` messages.
   ever constructed, because each demands a full `GrandMcaResolution` / `GrandListResolution` —
   an exact adjacent-grid crossing, or safety at every grid point. Nothing outside
   `GrandChallenges.lean` instantiates `prizeDimension` / `prizeRate` at any `j : Fin 4`, so the
-  rates `1/4`, `1/8`, `1/16` are untouched. Two nearer gaps are ordinary formalization work: no
+  rates `1/4`, `1/8`, `1/16` are untouched. The nearer gap is ordinary formalization work: no
   `McaUpperWitness` or `ListUpperWitness` is built for a concrete code (`McaUpperWitness.ofGt`,
   `.ofEpsCaGt`, and `ListUpperWitness.ofGt`, `.ofEncardGt` are generic shapes awaiting a real
-  large-list or CA-failure construction); and no list witness yet reaches past the
-  unique-decoding radius, though `CodingTheory.johnson_bound_lambda_le_ell` is stated over an
-  arbitrary finite alphabet and is axiom-clean, so a Johnson-radius `ListLowerWitness` is
-  reachable without new admits.
+  large-list or CA-failure construction). On the safe side both list constructors now exist, at
+  the unique-decoding and Johnson radii; what neither reaches, and what a prize resolution would
+  need, is a bound of the shape `Λ ≤ ε* · |F|` rather than `Λ ≤ ℓ` for a fixed `ℓ`.
 - **L2.10.** The interleaved-code list-size comparison is present as an external `[GGR11]` leaf;
   proving it in-tree remains open.
 - **§6.** A cost model for erasure correction, without which D6.4/L6.5 carry no content; and


### PR DESCRIPTION
## Summary

`GrandChallenges.lean` defines `ListLowerWitness` and `ListUpperWitness` for the Grand
List-Decoding Challenge, together with the boundary lemmas relating them to a
`GrandListResolution` — but ships **no constructor for either**, so neither side of the
challenge could be witnessed for any concrete code. (The MCA side, by contrast, has three
`McaLowerWitness` constructors.)

This adds five constructors, all axiom-clean: three generic witness shapes in
`GrandChallenges.lean`, and two substantive `ListLowerWitness` constructors in a new module.

## What's added

In `GrandChallenges.lean` — the generic shapes, mirroring the existing
`McaLowerWitness.ofLe` / `McaUpperWitness.ofGt`:

- `ListLowerWitness.ofLe`
- `ListUpperWitness.ofGt`
- `ListUpperWitness.ofEncardGt` — reduces an unsafe witness to a *single word* with an
  oversized point list. `Lambda` is a supremum over words, so one such word suffices, and this
  is the shape a concrete large-list construction actually produces.

In the new `GrandChallenges/ListDecoding.lean` — the two substantive ones:

| constructor | radius reached | supporting lemmas |
| --- | --- | --- |
| `ListLowerWitness.ofUniqueDecodingRange` | relative unique-decoding radius | `relUDR_interleavedCode_eq`, `lambda_interleavedCode_le_one_of_le_relUDR` |
| `ListLowerWitness.ofJohnsonBound` | **Johnson radius** | `lambda_interleavedCode_le_of_le_johnson` |

The unique-decoding one is the floor, mirroring `McaLowerWitness.ofUniqueDecodingRange`:
interleaving preserves minimum distance (`Code.minDist_interleavedCodeSet`), hence the
unique-decoding radius, and inside that radius the interleaved point lists are subsingletons
(`Code.isUniquelyDecodable_relativeUniqueDecodingRadius`), so `Λ(C^⋈m, δ) ≤ 1`.

The Johnson one reaches much further. `CodingTheory.johnson_bound_lambda_le_ell` is stated over
an arbitrary finite alphabet, so it applies to `C^⋈(Fin m)` at alphabet `Fin m → F` with no
specialization; the supporting lemma re-expresses its two code-dependent inputs on the base
code, so a caller can discharge the hypothesis with the `C` they actually hold.

## Two points a reviewer may want to check

**The Johnson radius is computed at `q = |F|^m`, not `|F|`.** This is deliberate and is the
interleaved code's own alphabet, so the theorem is correct as stated; the module docstring
records this so it is not later "corrected" to `|F|`. Note the direction of the effect, which
an earlier revision of this PR had backwards. Writing `c = q/(q-1)`,

```
J_q(δ) = (1/c)·(1 - √(1 - c·δ)) = δ·h(c·δ),   h(u) = (1 - √(1 - u))/u
```

and `h` is increasing, so `J_q(δ)` increases in `c` and therefore *decreases* in `q`, tending
to `1 - √(1 - δ)`. The interleaved alphabet therefore **narrows** the usable radius:
`Jqℓ 4 2 1 ≈ 0.317` against `Jqℓ 2 2 1 = 0.5`. (Confined to the regime where the radicand is
non-negative; outside it `Real.sqrt` clamps to `0` and `J_q` collapses to `1 - 1/q`.) The
relative minimum distance is unchanged, so this is the whole effect of `m` on the bound.

**The list side now has an admit-free Johnson-range witness where the MCA side does not.**
`McaLowerWitness.ofJohnsonRangeBound` is sorry-tainted in `scripts/axiom_baseline.json` through
the external [BCHKS25] admit `rs_mcaError_le_in_johnson_range`. The list-side Johnson witness
rests on `johnson_bound_lambda_le_ell`, which is in-tree and axiom-clean, so it needs no admit.
Flagging this as a genuine asymmetry rather than leaving it to be noticed.

## Provenance

```
axiomsweep --root ...GrandChallenges.ListDecoding
  5 declarations, sorryAx-tainted: 0, non-standard-axiom-tainted: 0

axiomsweep --root ...GrandChallenges
  214 declarations, sorryAx-tainted: 0, non-standard-axiom-tainted: 0
```

`./scripts/validate.sh --axioms` passes end to end: build, `ArkLib/Data` warning budget
(no non-sorry warnings), toy-problem runtime, umbrella imports, docs integrity, knowledge-base
lint, axiom-sweep fixture matrix, and the axiom/sorry regression baseline (no new taint).

## What this does *not* do

- **No prize resolution.** `mcaPrize` / `listDecodingPrize` remain unproved at every rate, and
  nothing here approaches them. Nothing outside `GrandChallenges.lean` instantiates
  `prizeDimension` / `prizeRate` at any `j : Fin 4`, so the rates `1/4`, `1/8`, `1/16` are
  still untouched, and no full per-rate `GrandListResolution` is built.
- **The remaining shortfall is the radius, not the list budget.** `ℓ` is a parameter of
  `ofJohnsonBound`, and the constructor accepts any proof of `ℓ ≤ ε* · |F|`, so the prize's
  bound shape is already expressible rather than being cut off at a fixed constant. What binds
  is that `Jqℓ q ℓ δ_min` stays capped by `J_q(δ_min)` however large `ℓ` grows.
- **No upper witness for a concrete code.** `ListUpperWitness.ofGt` and `.ofEncardGt` are
  generic shapes awaiting a real large-list construction; `ofEncardGt` is the intended entry
  point for one.

`docs/kb/papers/ABF26.md` is updated to record the new constructors and to restate the
remaining gaps in these terms.

## Note on style

The three new `def`s in `GrandChallenges.lean` write the interleaving as `C^⋈(Fin m)` without
spaces, which differs from the ~20 spaced `C ^⋈ (Fin m)` occurrences elsewhere in that file.
This is forced, not a preference: Mathlib's whitespace linter diffs source against the
pretty-printed form, and `notation:20 C "^⋈" κ` carries no spaces, so the spaced form warns —
and `ArkLib/Data` is under a zero-warning gate. The existing occurrences do not warn because
they sit in `structure` fields and `theorem` statements; these are the file's first `def`s using
the notation.

Closes #789

