### PR TITLE
fix(ci): keep axiom fixtures out of workspace imports

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -57,4 +57,5 @@ root = "ToyProblemRuntime"
 [[lean_lib]]
 name = "AxiomSweepTestFixtures"
 srcDir = "scripts"
+roots = []
 globs = ["AxiomSweepTestFixtures.+"]


### PR DESCRIPTION
## Summary

Keep `AxiomSweepTestFixtures` available as an explicitly buildable, glob-only test library without advertising an implicit workspace root module.

This fixes the Pages/docs failure `unknown module prefix 'AxiomSweepTestFixtures'` seen in [the failing checkdecls job](https://github.com/Verified-zkEVM/ArkLib/actions/runs/32589514385/job/97071000581).

## Root cause

The fixture library was added with `srcDir = "scripts"` and a `AxiomSweepTestFixtures.+` glob, but without an explicit `roots` value. Lake therefore inferred `AxiomSweepTestFixtures` as a root module.

The pinned `checkdecls` executable imports the configured roots of every root-package Lean library. It consequently tried to import `AxiomSweepTestFixtures`, but that synthetic root module does not exist: the fixture modules only exist below the namespace and are built explicitly by the axiom-sweep test matrix.

## Change

Set `roots = []` for `AxiomSweepTestFixtures`.

| Behavior | Before | After |
| --- | --- | --- |
| Workspace/checkdecls roots | Implicit `AxiomSweepTestFixtures` root | No fixture root |
| Fixture discovery | `AxiomSweepTestFixtures.+` glob | Unchanged |
| Explicit fixture builds | Supported | Supported and verified |

This is the same narrow configuration correction already present in the broader Lean 4.33 migration PR #791, isolated here so the current docs pipeline can be repaired independently.

## Validation

Validated at head `7e48b047eb904f9371f769b0546692cf51f7e7c1` against base `df2339f7a5024a55369705fc78488abb2b4a996f`:

- `lake exe cache get`
- `lake query AxiomSweepTestFixtures`
- `./scripts/test-axiomsweep.sh`
- `./scripts/validate.sh`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

All passed. The full validation included the Lean build, native runtime checks, umbrella-import check, docs-integrity check, and knowledge-base lint.

## Compatibility and security

No Lean declarations, public APIs, dependencies, workflows, or fixture contents change. The deliberately synthetic axiom fixtures remain test-only and explicitly buildable; they are only removed from automatic workspace-root imports.

## Diff metadata

- Base: `df2339f7a5024a55369705fc78488abb2b4a996f`
- Head: `7e48b047eb904f9371f769b0546692cf51f7e7c1`
- Commits: 1
- Files: 1
- Churn: +1 / -0

## Reviewer map

- `lakefile.toml`: declares the axiom-sweep fixture library as rootless while preserving its module glob.
- `scripts/test-axiomsweep.sh`: unchanged consumer that explicitly builds and exercises the fixture modules.
