### PR TITLE
feat: module-level Theorem 6.1, and Theorem 8.2 from it alone

### DIFF
--- a/ArkLib/Data/CodingTheory/InterleavedCode.lean
+++ b/ArkLib/Data/CodingTheory/InterleavedCode.lean
@@ -521,6 +521,28 @@ theorem minDist_interleavedCodeSet
       rw [hempty, Nat.sInf_empty]
     rw [hbase, hinter]
 
+/-- Interleaving over a nonempty row index preserves the *relative* minimum distance:
+`δᵣ (MC ^⋈ κ) = δᵣ MC`. The relative form of `minDist_interleavedCodeSet`, via the bridge
+`minDist_div_card_eq_minRelHammingDistCode`: both codes have block length `ι`, so equal
+absolute distances give equal relative ones. -/
+lemma minRelHammingDistCode_moduleInterleavedCode
+    {ι F A κ : Type*} [Fintype ι] [Nonempty ι] [Semiring F]
+    [AddCommMonoid A] [Module F A] [DecidableEq A] [Fintype κ] [Nonempty κ]
+    (MC : ModuleCode ι F A) :
+    minRelHammingDistCode (ModuleCode.moduleInterleavedCode F A κ ι MC).carrier
+      = minRelHammingDistCode MC.carrier := by
+  have hmd : minDist ((ModuleCode.moduleInterleavedCode F A κ ι MC).carrier)
+      = minDist (MC.carrier : Set (ι → A)) :=
+    minDist_interleavedCodeSet (κ := κ) (MC.carrier : Set (ι → A))
+  have h1 := minDist_div_card_eq_minRelHammingDistCode
+    ((ModuleCode.moduleInterleavedCode F A κ ι MC).carrier)
+  have h2 := minDist_div_card_eq_minRelHammingDistCode (MC.carrier : Set (ι → A))
+  have hq : ((minRelHammingDistCode
+        (ModuleCode.moduleInterleavedCode F A κ ι MC).carrier : ℚ≥0) : ℚ)
+      = ((minRelHammingDistCode MC.carrier : ℚ≥0) : ℚ) := by
+    rw [← h1, ← h2, hmd]
+  exact_mod_cast hq
+
 section Finrank
 
 /-! ### Structure and dimension of an interleaved module code -/

--- a/ArkLib/Data/CodingTheory/ProximityGenerator/MCAGenerator.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGenerator/MCAGenerator.lean
@@ -238,14 +238,27 @@ noncomputable def ε_MCA_MDS [DecidableEq F] [DecidableEq A] [Nonempty ι] (MC :
         else
         1
 
+/-- `ε_MCA_MDS` reads the code only through the block length `ι` and the relative distance
+`δᵣ`: two module codes over the same index set with equal `δᵣ` get the same error function,
+regardless of their alphabets. In particular the error is unchanged under interleaving
+(`Code.minRelHammingDistCode_moduleInterleavedCode`), which is what lets Theorem 6.1 feed the
+interleaved-hypothesis tensor lemma. -/
+lemma ε_MCA_MDS_congr [DecidableEq F] [Nonempty ι] {A' : Type} [DecidableEq A]
+    [AddCommMonoid A'] [Module F A'] [DecidableEq A']
+    (MC : ModuleCode ι F A) (MC' : ModuleCode ι F A') (ℓ s : ℕ) (η : ℝ)
+    (hδ : Code.minRelHammingDistCode MC'.carrier = Code.minRelHammingDistCode MC.carrier) :
+    ε_MCA_MDS MC' ℓ s η = ε_MCA_MDS MC ℓ s η := by
+  unfold ε_MCA_MDS
+  rw [hδ]
+
 /-- Theorem 6.1 (MCA for MDS generators) [BCGM25]. -/
 theorem isMCAGenerator_of_isMDSGenerator {S : Type} [Nonempty S] [Fintype S] [DecidableEq F]
-    [Nonempty ι]
+    [DecidableEq A] [Nonempty ι]
     (G : Generator S ℓ F)
     (hG : IsMDSGenerator G)
     (hdim : LinearCode.dim (LinearCode.fromColGenMat (M_G G)) = Fintype.card ℓ)
     (η : ℝ) (hη : 0 < η ∧ η < 1) (hℓ : 2 ≤ Fintype.card ℓ)
-    (LC : LinearCode ι F) :
-  IsMCAGenerator G (ε_MCA_MDS LC (Fintype.card ℓ) (Fintype.card S) η) LC := by sorry
+    (MC : ModuleCode ι F A) :
+  IsMCAGenerator G (ε_MCA_MDS MC (Fintype.card ℓ) (Fintype.card S) η) MC := by sorry
 
 end LinearTransformations

--- a/ArkLib/Data/CodingTheory/ProximityGenerator/PolynomialGenerator.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGenerator/PolynomialGenerator.lean
@@ -198,11 +198,11 @@ lemma tensorGeneratorPi_isMCAGenerator_tight {δ₀ : ℚ≥0} :
       Fin.consEquiv ℓ with heL
     -- the (ℓ 0)-fold interleaving has the same δᵣ, so the anchored hypotheses apply there
     have hδI : Code.minRelHammingDistCode
-        (ModuleCode.moduleInterleavedCode F A (ℓ 0) ι MC).carrier = δ₀ := by
+        (Code.ModuleCode.moduleInterleavedCode F A (ℓ 0) ι MC).carrier = δ₀ := by
       rw [Code.minRelHammingDistCode_moduleInterleavedCode]; exact hδ
     have hTail := ih (α := Fin.tail α) (ℓ := Fin.tail ℓ) (Fin.tail G) (Fin.tail ε)
       (fun i {A'} _ _ _ MC' hMC' => hmca i.succ MC' hMC')
-      (ModuleCode.moduleInterleavedCode F A (ℓ 0) ι MC) hδI
+      (Code.ModuleCode.moduleInterleavedCode F A (ℓ 0) ι MC) hδI
     have hBin := TensorMCA.isMCAGenerator_tensorGenerator_of_moduleInterleavedCode
       (G 0) (tensorGeneratorPi (α := Fin.tail α) (ℓ := Fin.tail ℓ) (Fin.tail G))
       (ε 0) (fun γ => ∑ i, Fin.tail ε i γ) MC

--- a/ArkLib/Data/CodingTheory/ProximityGenerator/PolynomialGenerator.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGenerator/PolynomialGenerator.lean
@@ -13,7 +13,10 @@ import Mathlib.RingTheory.MvPolynomial.IrreducibleQuadratic
 ## Main Results
 
 - Definition 8.1 (MCA error for univariate powers) [BCGM25].
-- Theorem 8.2 (MCA for polynomial generators) [BCGM25].
+- Theorem 8.2 (MCA for polynomial generators) [BCGM25] — proved assuming only Theorem 6.1
+(`isMCAGenerator_of_isMDSGenerator`): the tensor induction routes through the proved
+interleaved-hypothesis lemma (`tensorGeneratorPi_isMCAGenerator_tight`), so the open
+`tensor_of_MCA_is_MCA_tight` is not on its path.
 - Statement of Lemma 9.3 [BCGM25] - sorried out. It depends on the Guruswami-Sudan part of Proximity
 Gaps.
 - Definition 9.1 MCA error function for Reed-Solomon codes [BCGM25].
@@ -127,6 +130,83 @@ lemma tensorGeneratorPi_isMCAGenerator {A : Type} [AddCommMonoid A] [Module F A]
       (fun γ => ∑ i, Fin.tail ε i γ)
       (ih (α := Fin.tail α) (ℓ := Fin.tail ℓ) (Fin.tail G) (Fin.tail ε)
         (fun i => hmca (Fin.succ i)))
+    have hR := isMCAGenerator_reindex MC
+      (TensorGenerator_Explicit (G 0)
+        (tensorGeneratorPi (α := Fin.tail α) (ℓ := Fin.tail ℓ) (Fin.tail G)))
+      _ hBin eS eL
+    have hgen : (fun (x' : ∀ i : Fin (s + 1), α i) (j' : ∀ i : Fin (s + 1), ℓ i) =>
+        TensorGenerator_Explicit (G 0)
+          (tensorGeneratorPi (α := Fin.tail α) (ℓ := Fin.tail ℓ) (Fin.tail G)) (eS x') (eL.symm j'))
+        = tensorGeneratorPi G := by
+      funext x' j'
+      rw [heS, heL]
+      simp only [TensorGenerator_Explicit, tensorGeneratorPi, Fin.tail, Fin.prod_univ_succ]
+      simp_all only [eS, eL]
+      rfl
+    have herr : ((ε 0) + fun γ => ∑ i, Fin.tail ε i γ) = (fun γ => ∑ i, ε i γ) := by
+      funext γ
+      simp only [Pi.add_apply, Fin.sum_univ_succ]
+      rfl
+    rw [hgen, herr] at hR
+    exact hR
+
+/-- The tight `s`-fold tensor induction, on the *proved* interleaved-hypothesis binary lemma
+`TensorMCA.isMCAGenerator_tensorGenerator_of_moduleInterleavedCode` instead of the open
+`tensor_of_MCA_is_MCA_tight`.
+
+The factor hypothesis is anchored on a distance value `δ₀` and quantified over alphabets: each
+factor must have MCA, with its fixed error `ε i`, for *every* module code over `ι` of relative
+distance `δ₀`. That is exactly what Theorem 6.1 provides — its error reads the code only through
+`n` and `δᵣ` (`ε_MCA_MDS_congr`) — and it is closed under the interleavings the induction steps
+through (`Code.minRelHammingDistCode_moduleInterleavedCode`), so, unlike
+`tensorGeneratorPi_isMCAGenerator`, this form needs no open-problem input. -/
+lemma tensorGeneratorPi_isMCAGenerator_tight {δ₀ : ℚ≥0} :
+    ∀ {s : ℕ} {α : Fin s → Type} {ℓ : Fin s → Type}
+      [∀ i, Fintype (α i)] [∀ i, Nonempty (α i)] [∀ i, Fintype (ℓ i)] [∀ i, Nonempty (ℓ i)]
+      (G : ∀ i, Generator (α i) (ℓ i) F) (ε : Fin s → I → ℝ≥0),
+      (∀ i, ∀ {A : Type} [AddCommMonoid A] [Module F A] [DecidableEq A]
+        (MC : ModuleCode ι F A), Code.minRelHammingDistCode MC.carrier = δ₀ →
+        IsMCAGenerator (G i) (ε i) MC) →
+      ∀ {A : Type} [AddCommMonoid A] [Module F A] [DecidableEq A]
+        (MC : ModuleCode ι F A), Code.minRelHammingDistCode MC.carrier = δ₀ →
+        IsMCAGenerator (tensorGeneratorPi G) (fun γ => ∑ i, ε i γ) MC := by
+  intro s
+  induction s with
+  | zero =>
+    intro α ℓ _ _ _ _ G ε _ A _ _ _ MC _ γ
+    classical
+    refine iSup_le fun U => ?_
+    have hfalse : ∀ x : (∀ i : Fin 0, α i), ¬ IsMCA (tensorGeneratorPi G) MC x U (γ : ℝ) := by
+      rintro x ⟨T, hT, hmem, j, hj⟩
+      apply hj
+      have hvec : (fun k => ∑ j', tensorGeneratorPi G x j' • U j' k) = U j := by
+        funext w
+        rw [Fintype.sum_subsingleton _ j]
+        simp [tensorGeneratorPi]
+      rwa [hvec] at hmem
+    rw [prob_uniform_eq_ofReal, Finset.filter_false_of_mem fun x _ => hfalse x]
+    simp
+  | succ s ih =>
+    intro α ℓ _ _ _ _ G ε hmca A _ _ _ MC hδ
+    letI : ∀ i : Fin s, Fintype (Fin.tail α i) := fun i => inferInstanceAs (Fintype (α i.succ))
+    letI : ∀ i : Fin s, Nonempty (Fin.tail α i) := fun i => inferInstanceAs (Nonempty (α i.succ))
+    letI : ∀ i : Fin s, Fintype (Fin.tail ℓ i) := fun i => inferInstanceAs (Fintype (ℓ i.succ))
+    letI : ∀ i : Fin s, Nonempty (Fin.tail ℓ i) := fun i => inferInstanceAs (Nonempty (ℓ i.succ))
+    set eS : (∀ i : Fin (s + 1), α i) ≃ (α 0 × (∀ i : Fin s, Fin.tail α i)) :=
+      (Fin.consEquiv α).symm with heS
+    set eL : (ℓ 0 × (∀ i : Fin s, Fin.tail ℓ i)) ≃ (∀ i : Fin (s + 1), ℓ i) :=
+      Fin.consEquiv ℓ with heL
+    -- the (ℓ 0)-fold interleaving has the same δᵣ, so the anchored hypotheses apply there
+    have hδI : Code.minRelHammingDistCode
+        (ModuleCode.moduleInterleavedCode F A (ℓ 0) ι MC).carrier = δ₀ := by
+      rw [Code.minRelHammingDistCode_moduleInterleavedCode]; exact hδ
+    have hTail := ih (α := Fin.tail α) (ℓ := Fin.tail ℓ) (Fin.tail G) (Fin.tail ε)
+      (fun i {A'} _ _ _ MC' hMC' => hmca i.succ MC' hMC')
+      (ModuleCode.moduleInterleavedCode F A (ℓ 0) ι MC) hδI
+    have hBin := TensorMCA.isMCAGenerator_tensorGenerator_of_moduleInterleavedCode
+      (G 0) (tensorGeneratorPi (α := Fin.tail α) (ℓ := Fin.tail ℓ) (Fin.tail G))
+      (ε 0) (fun γ => ∑ i, Fin.tail ε i γ) MC
+      (hmca 0 MC hδ) hTail
     have hR := isMCAGenerator_reindex MC
       (TensorGenerator_Explicit (G 0)
         (tensorGeneratorPi (α := Fin.tail α) (ℓ := Fin.tail ℓ) (Fin.tail G)))
@@ -353,22 +433,27 @@ lemma UnivariatePowersOn.isMDSGenerator [DecidableEq F] (s : Set F) [Fintype s] 
   rw [UnivariatePowersOn.code_eq_reedSolomon]
   exact ReedSolomon.isMDS_code
 
-/-- The restricted univariate powers generator has MCA for every linear code with error `ξ`.
-For `d ≥ 1` this is Theorem 6.1 (`IsMDSGenerator.isMCAGenerator`) together with the identification
-`ε_MCA_MDS = ξ` (`ε_MCA_MDS_eq_ξ`); for `d = 0` the MCA event is vacuous, so the error `0 ≤ ξ`
-suffices. -/
+/-- The restricted univariate powers generator has MCA, with error `ξ LC`, for every module
+code over `ι` whose relative distance equals that of `LC` — in particular for `LC` itself
+(`MC := LC`, `hδ := rfl`) and for every iterated interleaving of `LC`.
+For `d ≥ 1` this is Theorem 6.1 (`isMCAGenerator_of_isMDSGenerator`) together with the
+identifications `ε_MCA_MDS MC = ε_MCA_MDS LC` (`ε_MCA_MDS_congr`, as `ε_MCA_MDS` reads the code
+only through `δᵣ`) and `ε_MCA_MDS LC = ξ LC` (`ε_MCA_MDS_eq_ξ`); for `d = 0` the MCA event is
+vacuous at any alphabet, so the error `0 ≤ ξ` suffices. -/
 lemma UnivariatePowersOn.isMCAGenerator {ι : Type} [Fintype ι] [Nonempty ι] [DecidableEq F]
     (s : Set F) [Fintype s] [Inhabited s]
     (LC : LinearCode ι F) (d : ℕ) (η : ℝ) (hη : 0 < η ∧ η < 1)
-    (h : d + 1 ≤ Fintype.card ↥s) :
-    IsMCAGenerator (UnivariatePowersOn s d) (ξ LC d (Fintype.card ↥s) η) LC := by
+    (h : d + 1 ≤ Fintype.card ↥s)
+    {A : Type} [AddCommMonoid A] [Module F A] [DecidableEq A] (MC : ModuleCode ι F A)
+    (hδ : Code.minRelHammingDistCode MC.carrier = Code.minRelHammingDistCode LC.carrier) :
+    IsMCAGenerator (UnivariatePowersOn s d) (ξ LC d (Fintype.card ↥s) η) MC := by
   rcases Nat.eq_zero_or_pos d with hd | hd
   · subst hd
     classical
     haveI : Subsingleton (Fin (0 + 1)) := inferInstanceAs (Subsingleton (Fin 1))
     intro γ
     refine iSup_le fun U => ?_
-    have hfalse : ∀ x : ↥s, ¬ IsMCA (UnivariatePowersOn s 0) LC x U (γ : ℝ) := by
+    have hfalse : ∀ x : ↥s, ¬ IsMCA (UnivariatePowersOn s 0) MC x U (γ : ℝ) := by
       rintro x ⟨T, hT, hmem, j, hj⟩
       apply hj
       have hvec : (fun k => ∑ j', UnivariatePowersOn s 0 x j' • U j' k) = U j := by
@@ -383,8 +468,9 @@ lemma UnivariatePowersOn.isMCAGenerator {ι : Type} [Fintype ι] [Nonempty ι] [
         = Fintype.card (Fin (d + 1)) := by
       rw [UnivariatePowersOn.code_eq_reedSolomon, ReedSolomon.dim_eq_deg_of_le h, Fintype.card_fin]
     have hmca := isMCAGenerator_of_isMDSGenerator (UnivariatePowersOn s d)
-      (UnivariatePowersOn.isMDSGenerator s d) hdim η hη hℓ LC
-    rwa [Fintype.card_fin, ε_MCA_MDS_eq_ξ] at hmca
+      (UnivariatePowersOn.isMDSGenerator s d) hdim η hη hℓ MC
+    rwa [Fintype.card_fin, ε_MCA_MDS_congr LC MC (d + 1) (Fintype.card ↥s) η hδ,
+      ε_MCA_MDS_eq_ξ] at hmca
 
 /-- The `s`-fold tensor product of restricted univariate powers generators, over the product seed
 space `∏ᵢ Sᵢ`: `(x₁, …, xₛ) ↦ ⊗ᵢ (1, xᵢ, …, xᵢ^{dᵢ})`. -/
@@ -393,18 +479,24 @@ def tensorGeneratorPiUnivariateOn {s : ℕ} (S : Fin s → Set F) (d : Fin s →
   fun x j => ∏ i, ((x i) : F) ^ (j i : ℕ)
 
 /-- The tensor product of the restricted univariate powers generators has MCA for any linear code
-`LC`, with error the sum `∑ᵢ ξ (dᵢ)` of the factors' errors.  This is the `s`-fold iteration of
-Lemma 4.4 (`tensor_of_MCA_is_MCA_tight`) [BCGM25], with each factor's MCA supplied by
-`UnivariatePowersOn.isMCAGenerator`. -/
+`LC`, with error the sum `∑ᵢ ξ (dᵢ)` of the factors' errors — the tight bound of Lemma 4.4
+[BCGM25], reached through `tensorGeneratorPi_isMCAGenerator_tight`: Theorem 6.1 supplies each
+factor's MCA at every module code of relative distance `δᵣ LC`, which covers the iterated
+interleavings the induction routes through, so the open `tensor_of_MCA_is_MCA_tight` is not
+needed. -/
 lemma tensorGeneratorPiUnivariateOn_isMCAGenerator {ι : Type} [Fintype ι] [Nonempty ι]
     [DecidableEq F] (LC : LinearCode ι F) (η : ℝ) (hη : 0 < η ∧ η < 1)
     {s : ℕ} (S : Fin s → Set F) [∀ i, Fintype ↥(S i)] [∀ i, Inhabited ↥(S i)]
     (d : Fin s → ℕ) (hcard : ∀ i, d i + 1 ≤ Fintype.card ↥(S i)) :
     IsMCAGenerator (tensorGeneratorPiUnivariateOn S d)
       (fun γ => ∑ i, ξ LC (d i) (Fintype.card ↥(S i)) η γ) LC :=
-  tensorGeneratorPi_isMCAGenerator LC (fun i => UnivariatePowersOn (S i) (d i))
+  tensorGeneratorPi_isMCAGenerator_tight
+    (δ₀ := Code.minRelHammingDistCode LC.carrier)
+    (fun i => UnivariatePowersOn (S i) (d i))
     (fun i => ξ LC (d i) (Fintype.card ↥(S i)) η)
-    (fun i => UnivariatePowersOn.isMCAGenerator (S i) LC (d i) η hη (hcard i))
+    (fun i {_A} _ _ _ MC hMC =>
+      UnivariatePowersOn.isMCAGenerator (S i) LC (d i) η hη (hcard i) MC hMC)
+    LC rfl
 
 /-- The polynomial generator `G` is the right multiplication of the restricted tensor generator by
 the coefficient matrix (`G = G̃ · Aᵀ` in the proof of Theorem 8.2 [BCGM25]). -/
@@ -427,7 +519,11 @@ lemma generatorByRightMul_coeffMatrix_sub {s : ℕ} {ℓ : Type} [Fintype ℓ]
     _ = (MvPolynomial.eval xc ∘ P) := congrFun hgbm _
     _ = G x := (hG x).symm
 
-/-- Theorem 8.2 (MCA for polynomial generators) [BCGM25]. -/
+/-- Theorem 8.2 (MCA for polynomial generators) [BCGM25].
+
+Its only `sorry` ancestry is Theorem 6.1 (`isMCAGenerator_of_isMDSGenerator`): the tensor stage
+is `tensorGeneratorPi_isMCAGenerator_tight`, which reaches the unscaled error sum through the
+proved interleaved-hypothesis lemma rather than the open `tensor_of_MCA_is_MCA_tight`. -/
 theorem polynomial_gen_MCA {ι : Type} [Fintype ι] [Nonempty ι] [DecidableEq F]
     {ℓ : Type} [Fintype ℓ] (LC : LinearCode ι F)
     (η : ℝ) (hη : 0 < η ∧ η < 1)


### PR DESCRIPTION
Into #766 (`Katy/RSCodeMCA3`). Follow-up to the review discussion on Theorem 6.1's code type ("linear code → module code maybe?"): this implements the generalisation and cashes it in for Theorem 8.2.

## What this does

**1. Theorem 6.1 at module codes** (`isMCAGenerator_of_isMDSGenerator`). The statement now takes `MC : ModuleCode ι F A`, matching the paper's Definition 3.2 (codes over an arbitrary `F`-vector space Σ). No generator-matrix machinery moves: `M_G`, `IsMDSGenerator`, and the rank hypothesis all constrain `G` over the base field and are untouched. The `LinearCode` form is the `A := F` instance — applying the theorem verbatim recovers it, so nothing downstream changes.

**2. Theorem 8.2 now rests on Theorem 6.1 alone.** `polynomial_gen_MCA` keeps its exact statement and error `∑ᵢ ξ(dᵢ)`, but its tensor stage is a new induction `tensorGeneratorPi_isMCAGenerator_tight` whose factor hypothesis is anchored on a δᵣ value and quantified over alphabets. The `succ` step then discharges through the **proved** `TensorMCA.isMCAGenerator_tensorGenerator_of_moduleInterleavedCode` instead of the open `tensor_of_MCA_is_MCA_tight` — the new induction is itself sorry-free. Two small facts make this work:

- `Code.minRelHammingDistCode_moduleInterleavedCode` (new, in `InterleavedCode.lean`): interleaving preserves δᵣ — the relative form of the existing `minDist_interleavedCodeSet`.
- `ε_MCA_MDS_congr` (new): the Theorem 6.1 error reads the code only through the block length and δᵣ, so Theorem 6.1 supplies each factor's MCA at every iterated interleaving *with the same error*.

`UnivariatePowersOn.isMCAGenerator` is generalised in place (any module code of relative distance `δᵣ LC`; at `MC := LC`, `hδ := rfl` it is the previous statement).

## Sorry-ancestry, checked by walking the proof DAGs

| theorem | Thm 6.1 | `tensor_of_MCA_is_MCA_tight` | Lemma 9.3 |
|---|---|---|---|
| `polynomial_gen_MCA` (Thm 8.2), before | yes | **yes** | no |
| `polynomial_gen_MCA` (Thm 8.2), after | yes | **no** | no |
| `tensorGeneratorPi_isMCAGenerator_tight` | no | no | no |

**Theorem 9.2's route is deliberately untouched**: Lemma 9.3 is stated only at the Reed-Solomon code, so its appeal to the printed Lemma 4.4 is genuine — the same gap as the paper's own §9. Both tensor inductions therefore coexist, each with a real consumer.

This also sharpens the fill target: what Theorem 6.1 still needs is its §6.1 unique-decoding branch (Lemma 6.2) — the §6.2 list-decoding branch already exists on main at module generality (`linear_mcaError_powers_le` in `ProximityGap/CapacityBounds/Powers.lean`, with MDS-ness entering at a single private lemma).

Not addressed here, still owed on #766: the axiom-baseline refresh and the `docs/kb/audits/bcgm25-mca-generators.md` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
