### PR TITLE
perf: eliminate high-cost Lean proof search hotspots

### DIFF
--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
@@ -1013,6 +1013,76 @@ lemma sufficient_multiplicity_bound {dist : ℕ}
     · unfold proximity_gap_johnson; ring_nf; norm_num
       norm_num [mul_assoc, mul_comm, mul_left_comm, ne_of_gt (zero_lt_one.trans_le hm)]
 
+private theorem dvd_property_of_sufficient_multiplicity_bound [DecidableEq F]
+    (hk : k + 1 ≤ n) (p : code ωs k) {D : ℕ} {radius : ℝ} {Q : F[X][Y]}
+    (hQ_deg : weightedDegree Q 1 (k - 1) ≤ D)
+    (hQ_mult : ∀ i, m ≤ rootMultiplicity Q (ωs i) (f i))
+    (h_dist : (hammingDist f (fun i ↦ (toPolynomial p).eval (ωs i)) : ℝ) / n < radius)
+    (hsufficient : ∀ {dist : ℕ}, (dist : ℝ) / n < radius → (D : ℝ) < m * (n - dist)) :
+    X - C (toPolynomial p) ∣ Q := by
+  contrapose! h_dist with h_distots
+  have hR_nonzero : (Q.eval (toPolynomial p)) ≠ 0 := by
+    contrapose! h_distots
+    exact dvd_iff_isRoot.mpr h_distots
+  have hR_roots : (Q.eval (toPolynomial p)).natDegree ≥
+      m * (n - hammingDist f (fun i ↦ (toPolynomial p).eval (ωs i))) := by
+    have hR_roots : ∀ i ∈ Finset.univ.filter (fun i ↦ f i = (toPolynomial p).eval (ωs i)), m ≤
+        (Q.eval (toPolynomial p)).rootMultiplicity (ωs i) := by
+      intro i hi
+      have h_root : m ≤ (Q.eval (toPolynomial p)).rootMultiplicity (ωs i) := by
+        have hQ_mult : ∀ i, HasOrderAt Q (ωs i) (f i) m := by
+          intro i s t hst
+          contrapose! hQ_mult
+          use i
+          refine fun h ↦ hst.not_ge <| le_of_not_gt fun h_lt ↦ ?_
+          exact (by
+            convert rootMultiplicity_le_of_coeff_ne_zero hQ_mult using 1
+            cases h' : rootMultiplicity Q (ωs i) (f i)
+            · aesop
+            · simp_all only [ne_eq, WithTop.some_eq_coe, ENat.some_eq_natCast, false_iff]
+              exact_mod_cast not_le_of_gt (lt_of_lt_of_le h_lt (mod_cast h)))
+        have := hQ_mult i
+        have := orderAt_eval_ge Q (toPolynomial p) (ωs i) m (by aesop)
+        aesop
+      exact h_root
+    have hR_roots_card : (Finset.univ.filter (fun i ↦
+        f i = (toPolynomial p).eval (ωs i))).card * m ≤
+          (Q.eval (toPolynomial p)).natDegree := by
+      have hR_roots_card : (∏ i ∈ Finset.univ.filter (fun i ↦
+          f i = (toPolynomial p).eval (ωs i)), (X - C (ωs i)) ^ m) ∣
+            (Q.eval (toPolynomial p)) := by
+        refine Finset.prod_dvd_of_coprime ?_ ?_
+        · intros i hi j hj hij
+          exact IsCoprime.pow (irreducible_X_sub_C (ωs i) |> fun hi ↦
+            hi.coprime_iff_not_dvd.mpr fun h => hij <| by
+              have := dvd_iff_isRoot.mp h
+              simp_all [sub_eq_iff_eq_add])
+        · exact fun i hi ↦
+            dvd_trans (pow_dvd_pow _ (hR_roots i hi)) (pow_rootMultiplicity_dvd _ _)
+      have := natDegree_le_of_dvd hR_roots_card
+      convert this hR_nonzero using 1
+      rw [natDegree_prod _ _ fun i hi ↦ pow_ne_zero _ <| Polynomial.X_sub_C_ne_zero _]
+      simp [natDegree_sub_eq_left_of_natDegree_lt]
+    convert hR_roots_card.ge using 1
+    simp only [hammingDist, ne_eq, mul_comm, mul_eq_mul_left_iff]
+    rw [Finset.filter_not, Finset.card_sdiff]
+    norm_num
+    exact Or.inl (Nat.sub_sub_self (le_trans (Finset.card_le_univ _) (by norm_num)))
+  have hR_deg : (Q.eval (toPolynomial p)).natDegree ≤ D := by
+    have hR_deg : (Q.eval (toPolynomial p)).natDegree ≤ natWeightedDegree Q 1 (k - 1) := by
+      apply degree_eval_le_weightedDegree
+      exact toPolynomial_degree_le hk p
+    refine le_trans hR_deg ?_
+    convert hQ_deg using 1
+    rw [weightedDegree_eq_natWeightedDegree]
+    aesop
+  contrapose! hR_roots
+  refine lt_of_le_of_lt hR_deg ?_
+  convert hsufficient hR_roots using 1
+  rw [← @Nat.cast_lt ℝ]
+  norm_num [Nat.cast_sub (show hammingDist f (fun i ↦ (toPolynomial p).eval (ωs i)) ≤ n
+    from le_trans (Finset.card_le_univ _) (by norm_num))]
+
 /-- If $Q$ satisfies the weighted degree bound and vanishes to order $m$ at each point
     $(\omega_i, f_i)$, and if $P$ is a codeword close enough to $f$, then $Y - P(X)$
     divides $Q(X,Y)$. -/
@@ -1023,66 +1093,8 @@ theorem dvd_property [DecidableEq F] (hk : k + 1 ≤ n) (hm : 1 ≤ m) (p : code
   (h_dist : (hammingDist f (fun i ↦ (toPolynomial p).eval (ωs i)) : ℝ) / n <
     proximity_gap_johnson k n m) :
   X - C (toPolynomial p) ∣ Q := by
-    contrapose! h_dist with h_distots
-    have hR_nonzero : (Q.eval (toPolynomial p)) ≠ 0 := by
-      contrapose! h_distots
-      exact dvd_iff_isRoot.mpr h_distots
-    have hR_roots : (Q.eval (toPolynomial p)).natDegree ≥
-        m * (n - hammingDist f (fun i ↦ (toPolynomial p).eval (ωs i))) := by
-      have hR_roots : ∀ i ∈ Finset.univ.filter (fun i ↦ f i = (toPolynomial p).eval (ωs i)), m ≤
-          (Q.eval (toPolynomial p)).rootMultiplicity (ωs i) := by
-        intro i hi
-        have h_root : m ≤ (Q.eval (toPolynomial p)).rootMultiplicity (ωs i) := by
-          have hQ_mult : ∀ i, HasOrderAt Q (ωs i) (f i) m := by
-            intro i s t hst
-            contrapose! hQ_mult
-            use i
-            refine fun h ↦ hst.not_ge <| le_of_not_gt fun h_lt ↦ ?_
-            exact (by
-              convert rootMultiplicity_le_of_coeff_ne_zero hQ_mult using 1
-              cases h' : rootMultiplicity Q (ωs i) (f i)
-              · aesop
-              · simp_all only [ne_eq, WithTop.some_eq_coe, ENat.some_eq_natCast, false_iff]
-                exact_mod_cast not_le_of_gt (lt_of_lt_of_le h_lt (mod_cast h)))
-          have := hQ_mult i;
-          have := orderAt_eval_ge Q (toPolynomial p) (ωs i) m (by aesop); aesop;
-        exact h_root;
-      have hR_roots_card : (Finset.univ.filter (fun i ↦
-          f i = (toPolynomial p).eval (ωs i))).card * m ≤
-            (Q.eval (toPolynomial p)).natDegree := by
-        have hR_roots_card : (∏ i ∈ Finset.univ.filter (fun i ↦
-            f i = (toPolynomial p).eval (ωs i)), (X - C (ωs i)) ^ m) ∣
-              (Q.eval (toPolynomial p)) := by
-          refine Finset.prod_dvd_of_coprime ?_ ?_
-          · intros i hi j hj hij
-            exact IsCoprime.pow (irreducible_X_sub_C (ωs i) |> fun hi ↦
-              hi.coprime_iff_not_dvd.mpr fun h => hij <| by
-                have := dvd_iff_isRoot.mp h; simp_all [sub_eq_iff_eq_add])
-          · exact fun i hi ↦
-              dvd_trans (pow_dvd_pow _ (hR_roots i hi)) (pow_rootMultiplicity_dvd _ _)
-        have := natDegree_le_of_dvd hR_roots_card
-        convert this hR_nonzero using 1
-        rw [natDegree_prod _ _ fun i hi ↦ pow_ne_zero _ <| Polynomial.X_sub_C_ne_zero _]
-        simp [natDegree_sub_eq_left_of_natDegree_lt]
-      convert hR_roots_card.ge using 1
-      simp only [hammingDist, ne_eq, mul_comm, mul_eq_mul_left_iff]
-      rw [Finset.filter_not, Finset.card_sdiff]
-      norm_num
-      exact Or.inl (Nat.sub_sub_self (le_trans (Finset.card_le_univ _) (by norm_num)))
-    have hR_deg : (Q.eval (toPolynomial p)).natDegree ≤ proximity_gap_degree_bound k n m := by
-      have hR_deg : (Q.eval (toPolynomial p)).natDegree ≤ natWeightedDegree Q 1 (k - 1) := by
-        apply degree_eval_le_weightedDegree
-        exact toPolynomial_degree_le hk p
-      refine le_trans hR_deg ?_
-      convert hQ_deg using 1
-      rw [weightedDegree_eq_natWeightedDegree]
-      aesop
-    contrapose! hR_roots
-    refine lt_of_le_of_lt hR_deg ?_
-    convert sufficient_multiplicity_bound hk hm hR_roots using 1
-    rw [← @Nat.cast_lt ℝ]
-    norm_num [Nat.cast_sub (show hammingDist f (fun i ↦ (toPolynomial p).eval (ωs i)) ≤ n
-      from le_trans (Finset.card_le_univ _) (by norm_num))]
+  exact dvd_property_of_sufficient_multiplicity_bound hk p hQ_deg hQ_mult h_dist
+    (sufficient_multiplicity_bound hk hm)
 
 end divisibility
 
@@ -1145,66 +1157,8 @@ theorem gs_dvd_property [DecidableEq F] (hk : k + 1 ≤ n) (hm : 1 ≤ m) (p : c
   (h_dist : (hammingDist f (fun i ↦ (toPolynomial p).eval (ωs i)) : ℝ) / n <
     gs_johnson k n m) :
   X - C (toPolynomial p) ∣ Q := by
-    contrapose! h_dist with h_distots
-    have hR_nonzero : (Q.eval (toPolynomial p)) ≠ 0 := by
-      contrapose! h_distots
-      exact dvd_iff_isRoot.mpr h_distots
-    have hR_roots : (Q.eval (toPolynomial p)).natDegree ≥
-        m * (n - hammingDist f (fun i ↦ (toPolynomial p).eval (ωs i))) := by
-      have hR_roots : ∀ i ∈ Finset.univ.filter (fun i ↦ f i = (toPolynomial p).eval (ωs i)), m ≤
-          (Q.eval (toPolynomial p)).rootMultiplicity (ωs i) := by
-        intro i hi
-        have h_root : m ≤ (Q.eval (toPolynomial p)).rootMultiplicity (ωs i) := by
-          have hQ_mult : ∀ i, HasOrderAt Q (ωs i) (f i) m := by
-            intro i s t hst
-            contrapose! hQ_mult
-            use i
-            refine fun h ↦ hst.not_ge <| le_of_not_gt fun h_lt ↦ ?_
-            exact (by
-              convert rootMultiplicity_le_of_coeff_ne_zero hQ_mult using 1
-              cases h' : rootMultiplicity Q (ωs i) (f i)
-              · aesop
-              · simp_all only [ne_eq, WithTop.some_eq_coe, ENat.some_eq_natCast, false_iff]
-                exact_mod_cast not_le_of_gt (lt_of_lt_of_le h_lt (mod_cast h)))
-          have := hQ_mult i;
-          have := orderAt_eval_ge Q (toPolynomial p) (ωs i) m (by aesop); aesop;
-        exact h_root;
-      have hR_roots_card : (Finset.univ.filter (fun i ↦
-          f i = (toPolynomial p).eval (ωs i))).card * m ≤
-            (Q.eval (toPolynomial p)).natDegree := by
-        have hR_roots_card : (∏ i ∈ Finset.univ.filter (fun i ↦
-            f i = (toPolynomial p).eval (ωs i)), (X - C (ωs i)) ^ m) ∣
-              (Q.eval (toPolynomial p)) := by
-          refine Finset.prod_dvd_of_coprime ?_ ?_
-          · intros i hi j hj hij
-            exact IsCoprime.pow (irreducible_X_sub_C (ωs i) |> fun hi ↦
-              hi.coprime_iff_not_dvd.mpr fun h => hij <| by
-                have := dvd_iff_isRoot.mp h; simp_all [sub_eq_iff_eq_add])
-          · exact fun i hi ↦
-              dvd_trans (pow_dvd_pow _ (hR_roots i hi)) (pow_rootMultiplicity_dvd _ _)
-        have := natDegree_le_of_dvd hR_roots_card
-        convert this hR_nonzero using 1
-        rw [natDegree_prod _ _ fun i hi ↦ pow_ne_zero _ <| Polynomial.X_sub_C_ne_zero _]
-        simp [natDegree_sub_eq_left_of_natDegree_lt]
-      convert hR_roots_card.ge using 1
-      simp only [hammingDist, ne_eq, mul_comm, mul_eq_mul_left_iff]
-      rw [Finset.filter_not, Finset.card_sdiff]
-      norm_num
-      exact Or.inl (Nat.sub_sub_self (le_trans (Finset.card_le_univ _) (by norm_num)))
-    have hR_deg : (Q.eval (toPolynomial p)).natDegree ≤ gs_degree_bound k n m := by
-      have hR_deg : (Q.eval (toPolynomial p)).natDegree ≤ natWeightedDegree Q 1 (k - 1) := by
-        apply degree_eval_le_weightedDegree
-        exact toPolynomial_degree_le hk p
-      refine le_trans hR_deg ?_
-      convert hQ_deg using 1
-      rw [weightedDegree_eq_natWeightedDegree]
-      aesop
-    contrapose! hR_roots
-    refine lt_of_le_of_lt hR_deg ?_
-    convert gs_sufficient_multiplicity_bound hk hm hR_roots using 1
-    rw [← @Nat.cast_lt ℝ]
-    norm_num [Nat.cast_sub (show hammingDist f (fun i ↦ (toPolynomial p).eval (ωs i)) ≤ n
-      from le_trans (Finset.card_le_univ _) (by norm_num))]
+  exact dvd_property_of_sufficient_multiplicity_bound hk p hQ_deg hQ_mult h_dist
+    (gs_sufficient_multiplicity_bound hk hm)
 
 
 end gs_rate

--- a/ArkLib/Data/CodingTheory/JohnsonBound/Family.lean
+++ b/ArkLib/Data/CodingTheory/JohnsonBound/Family.lean
@@ -97,9 +97,6 @@ open scoped NNReal
 open Code JohnsonBound
 open Real Finset Fintype
 
-set_option maxHeartbeats 1000000 in
--- The numeric core carries several `nlinarith`/`field_simp`/cast steps over ℚ and ℝ; the
--- default heartbeat budget is insufficient.
 /-- Numeric core of the Johnson list-size bound, stated for an arbitrary finite set of
 words `B` rather than for a Hamming ball in a code. -/
 lemma johnson_card_le_ell {n : ℕ} {α : Type*} [Fintype α] [DecidableEq α]
@@ -185,7 +182,10 @@ lemma johnson_card_le_ell {n : ℕ} {α : Type*} [Fintype α] [DecidableEq α]
   have hsq_ge : (1 - (x:ℝ)) ≤ (1 - (frac:ℝ) * ((eB:ℝ)/n))^2 := by
     have h1med : √(1 - (x:ℝ)) ≤ 1 - (frac:ℝ) * ((eB:ℝ)/n) := by linarith
     have hnn : (0:ℝ) ≤ 1 - (frac:ℝ) * ((eB:ℝ)/n) := le_trans hsqrt_nonneg h1med
-    nlinarith [Real.sq_sqrt h1x_nonneg, Real.sqrt_nonneg (1 - (x:ℝ)), h1med, hnn]
+    calc
+      1 - (x : ℝ) = √(1 - (x : ℝ)) ^ 2 := (Real.sq_sqrt h1x_nonneg).symm
+      _ ≤ (1 - (frac : ℝ) * ((eB : ℝ) / n)) ^ 2 :=
+        (sq_le_sq₀ hsqrt_nonneg hnn).2 h1med
   have hdd_ge : (frac:ℝ) * (δ_min:ℝ) ≤ (frac:ℝ) * ((dB:ℝ)/n) := by
     apply mul_le_mul_of_nonneg_left _ (by exact_mod_cast hfrac_pos.le)
     rw [le_div_iff₀ (by exact_mod_cast hn_pos)]
@@ -200,7 +200,11 @@ lemma johnson_card_le_ell {n : ℕ} {α : Type*} [Fintype α] [DecidableEq α]
     have hlFacR : (lFac:ℝ) < 1 := by exact_mod_cast hlFac_lt1
     have hpos : (0:ℝ) < (frac:ℝ) * (δ_min:ℝ) := by
       apply mul_pos (by exact_mod_cast hfrac_pos) (by exact_mod_cast hδmin_pos)
-    nlinarith [hpos, hlFacR, (by exact_mod_cast hlFac_pos.le : (0:ℝ) ≤ (lFac:ℝ))]
+    calc
+      (frac : ℝ) * (lFac : ℝ) * (δ_min : ℝ) =
+          (lFac : ℝ) * ((frac : ℝ) * (δ_min : ℝ)) := by ring
+      _ < 1 * ((frac : ℝ) * (δ_min : ℝ)) := mul_lt_mul_of_pos_right hlFacR hpos
+      _ = (frac : ℝ) * (δ_min : ℝ) := one_mul _
   have hreal : (1 - (frac:ℝ) * ((dB:ℝ)/n)) < (1 - (frac:ℝ) * ((eB:ℝ)/n))^2 := by
     have hxlt : (x:ℝ) < (frac:ℝ) * ((dB:ℝ)/n) := lt_of_lt_of_le hx_lt_fracδ hdd_ge
     linarith [hsq_ge, hxlt]
@@ -241,8 +245,13 @@ lemma johnson_card_le_ell {n : ℕ} {α : Type*} [Fintype α] [DecidableEq α]
           rw [hed_def]; push_cast; rw [mul_div_assoc]; exact hed_le
         have : (ed : ℝ) ≤ 1 := le_trans this (by linarith [hsqrt_nonneg])
         exact_mod_cast this
-      nlinarith [hed_nn, hed_le1]
-    linarith
+      have hed_le2 : ed ≤ 2 := hed_le1.trans (by norm_num)
+      have hprod : 0 ≤ ed * (2 - ed) :=
+        mul_nonneg hed_nn (sub_nonneg.mpr hed_le2)
+      calc
+        (1 - ed) ^ 2 = 1 - ed * (2 - ed) := by ring
+        _ ≤ 1 := sub_le_self _ hprod
+    exact sub_nonneg.mpr this
   have ht_le_x : t ≤ x := by
     rw [ht_def]
     -- (1-ed)^2 ≥ 1 - x  from hsq_ge (ℝ) cast to ℚ
@@ -281,7 +290,11 @@ lemma johnson_card_le_ell {n : ℕ} {α : Type*} [Fintype α] [DecidableEq α]
           have hat : (0:ℚ) < dd - t := hDenom_eq_pos
           have hbt : (0:ℚ) < b - t := by linarith [ht_le_x, hx_lt_b]
           rw [div_le_div_iff₀ hat hbt]
-          nlinarith [ht_nonneg, hb_le_dd]
+          have hmul : b * t ≤ dd * t := mul_le_mul_of_nonneg_right hb_le_dd ht_nonneg
+          calc
+            dd * (b - t) = b * dd - dd * t := by ring
+            _ ≤ b * dd - b * t := sub_le_sub_left hmul _
+            _ = b * (dd - t) := by ring
       _ ≤ b / (b - x) := by
           have hbx : (0:ℚ) < b - x := by linarith [hx_lt_b]
           apply div_le_div_of_nonneg_left hb_pos.le hbx

--- a/ArkLib/Data/CodingTheory/JohnsonBound/Lemmas.lean
+++ b/ArkLib/Data/CodingTheory/JohnsonBound/Lemmas.lean
@@ -342,7 +342,9 @@ lemma almost_johnson_lhs_div_B_card [Zero F] (h_n : 0 < n) (h_B : 2 ≤ B.card) 
     (1 - e B 0 / n) ^ 2 * B.card + B.card * (e B 0) ^ 2 / ((card F - 1) * n ^ 2) - 1 := by
   set E := (n - e B 0) / n
   generalize eqrhs : (_ + _ - 1 : ℚ) = rhs
-  have eqE : E = k B / B.card := by grind only [= k_and_e']
+  have eqE : E = k B / B.card := by
+    simpa only [E] using
+      (k_and_e' (B := B) h_n.ne' (by omega)).symm
   suffices (B.card * E - 1) * E +
       ((B.card - B.card * E) / (card F - 1) - 1) * (1 - E) = rhs by
     rw [eqE, mul_div_cancel₀ _ (by simp only [ne_eq, Rat.natCast_eq_zero_iff]; omega)] at this
@@ -403,7 +405,14 @@ lemma johnson_denom [Zero F] (h_card : 2 ≤ card F) :
   have n₂ : c1 ≠ 0 := by simp [c1, c, sub_eq_zero]; grind only
   suffices c / c1 * (d B / n - 2 * e B 0 / n + c / c1 * e B 0 ^ 2 / n ^ 2) =
       (1 - c / c1 * (e B 0 / n)) ^ 2 - (1 - c / c1 * (d B / n)) by
-    rw [← this]; have : c / c1 = 1 + 1 / c1 := by grind only
+    rw [← this]
+    have : c / c1 = 1 + 1 / c1 := by
+      calc
+        c / c1 = (c1 + 1) / c1 := by
+          congr 1
+          simp only [c1]
+          ring
+        _ = 1 + 1 / c1 := by rw [add_div, div_self n₂]
     grind only [= e.eq_1]
   grind only
 

--- a/ArkLib/Data/CodingTheory/ListDecodability/Bounds/KKH26Asymptotic.lean
+++ b/ArkLib/Data/CodingTheory/ListDecodability/Bounds/KKH26Asymptotic.lean
@@ -146,8 +146,6 @@ theorem core_ineq (ρ : ℝ) (hρ0 : 0 < ρ) (hρ1 : ρ < 1) (cp : ℕ) (hcp : 1
 
 /-! ## Parameter selection -/
 
-set_option maxHeartbeats 1600000 in
--- Long `Filter.Eventually`/`nlinarith`/`Real.log` chain over many hypotheses; raised limit.
 /-- For every rate `ρ ∈ (0,1)` and `c ∈ ℕ`, there is a constant `Kc > 0` and a threshold
 `b₀` such that
 for every `b ≥ b₀` the parameters `a`, `k = ⌈ρ·2^{a+b}⌉`, `khat = ⌈k/2^a⌉` satisfy the
@@ -180,7 +178,8 @@ theorem exists_asymptotic_params (ρ : ℝ) (hρ0 : 0 < ρ) (hρ1 : ρ < 1) (c :
     filter_upwards [this] with b hb
     simp only [pow_one] at hb
     have h2 : (0 : ℝ) < 2 ^ b := by positivity
-    rw [div_lt_iff₀ h2] at hb; nlinarith [hb]
+    rw [div_lt_iff₀ h2] at hb
+    exact hb.le
   have hpowlim : Filter.Tendsto (fun b : ℕ => (2 : ℝ) ^ b) atTop atTop :=
     tendsto_pow_atTop_atTop_of_one_lt (by norm_num)
   have ev2 : ∀ᶠ b : ℕ in atTop, (2 : ℝ) ≤ (1 - ρ) * 2 ^ b :=
@@ -226,15 +225,27 @@ theorem exists_asymptotic_params (ρ : ℝ) (hρ0 : 0 < ρ) (hρ1 : ρ < 1) (c :
     rwa [Nat.cast_mul, Nat.cast_sub hq1, Nat.cast_one] at this
   have hRlo : ρ * 2 ^ b < (khat : ℝ) := by
     have h1 : ρ * (2 : ℝ) ^ a * 2 ^ b < (khat : ℝ) * d := by
-      rw [hnpow] at hrate_lo; nlinarith [hrate_lo, hN1R]
-    rw [hdR] at h1; nlinarith [h1, h2apos]
+      rw [hnpow] at hrate_lo
+      exact lt_of_lt_of_le (by simpa [mul_assoc] using hrate_lo) hN1R
+    rw [hdR] at h1
+    apply lt_of_mul_lt_mul_right (a := (2 : ℝ) ^ a) _ h2apos.le
+    simpa only [mul_assoc, mul_left_comm, mul_comm] using h1
   have hRhi : (khat : ℝ) < ρ * 2 ^ b + 2 := by
     have h1 : ((khat : ℝ) - 1) * d < ρ * (2 : ℝ) ^ a * 2 ^ b + 1 := by
-      rw [hnpow] at hrate_hi; nlinarith [hN2R, hrate_hi]
+      rw [hnpow] at hrate_hi
+      exact lt_of_lt_of_le hN2R (by simpa [mul_assoc] using hrate_hi)
     rw [hdR] at h1
     have h2a1 : (1 : ℝ) ≤ (2 : ℝ) ^ a := one_le_pow₀ (by norm_num)
-    nlinarith [h1, h2apos, h2a1]
-  have hF2 : (khat : ℝ) < 2 ^ b := by nlinarith [hRhi, P2]
+    have hscaled : ((khat : ℝ) - 1) * (2 : ℝ) ^ a <
+        (ρ * 2 ^ b + 1) * 2 ^ a := by
+      calc ((khat : ℝ) - 1) * (2 : ℝ) ^ a
+          < ρ * (2 : ℝ) ^ a * 2 ^ b + 1 := h1
+        _ ≤ ρ * (2 : ℝ) ^ a * 2 ^ b + 2 ^ a := add_le_add_right h2a1 _
+        _ = (ρ * 2 ^ b + 1) * 2 ^ a := by ring
+    have hcancel : (khat : ℝ) - 1 < ρ * 2 ^ b + 1 :=
+      lt_of_mul_lt_mul_right hscaled h2apos.le
+    linarith
+  have hF2 : (khat : ℝ) < 2 ^ b := by linarith [hRhi, P2]
   have hF2n : khat < 2 ^ b := by exact_mod_cast hF2
   have N1' : k ≤ khat * 2 ^ a := by rw [← hddef]; exact N1
   have N2' : (khat - 1) * 2 ^ a < k := by rw [← hddef]; exact N2
@@ -284,7 +295,8 @@ theorem exists_asymptotic_params (ρ : ℝ) (hρ0 : 0 < ρ) (hρ1 : ρ < 1) (c :
     have hfinal : (1 : ℝ) / 2 ^ b ≤ Kc / ((a + b : ℕ) : ℝ) := by
       rw [div_le_div_iff₀ h2bpos hKfpos, one_mul]
       have hcastab : ((a + b : ℕ) : ℝ) = (Kf : ℝ) := by exact_mod_cast hab
-      rw [hcastab]; nlinarith [hKf_le]
+      rw [hcastab]
+      exact hKf_le
     calc (↑(khat * 2 ^ a - k + 1) : ℝ) / 2 ^ (a + b) ≤ (2 : ℝ) ^ a / 2 ^ (a + b) := hstep
       _ = 1 / 2 ^ b := hexp
       _ ≤ Kc / ((a + b : ℕ) : ℝ) := hfinal
@@ -292,8 +304,6 @@ theorem exists_asymptotic_params (ρ : ℝ) (hρ0 : 0 < ρ) (hρ1 : ρ < 1) (c :
 
 /-! ## Main theorem -/
 
-set_option maxHeartbeats 1600000 in
--- Large existential goal with many instance-carrying witnesses; raised limit.
 /-- For every rate `ρ ∈ (0,1)` and `c ∈ ℕ`, given arbitrarily large smooth Reed--Solomon
 evaluation domains, there is a constant `Kc > 0` such
 that for every `N` there is a smooth RS code `C = RS[F, L, k]` with block length `n = |L| ≥ N`,

--- a/ArkLib/Data/CodingTheory/ListDecodability/Bounds/LargeAlphabet/Pigeonhole.lean
+++ b/ArkLib/Data/CodingTheory/ListDecodability/Bounds/LargeAlphabet/Pigeonhole.lean
@@ -1226,6 +1226,15 @@ theorem rounded_barrier_quotient_bounds
       (Nat.mul_le_mul_left (ℓ + 1) hmLower)
   exact ⟨hused, hrUsed, hmLower, hmUpper, hfloorM, haM, hnM⟩
 
+private theorem one_sub_mul_le_nat_sub
+    (p : ℝ) (n radius : ℕ) (hRadiusLe : radius ≤ n)
+    (hRadiusFloor : (radius : ℝ) ≤ p * n) :
+    (1 - p) * (n : ℝ) ≤ (n - radius : ℕ) := by
+  rw [Nat.cast_sub hRadiusLe]
+  calc
+    (1 - p) * (n : ℝ) = (n : ℝ) - p * n := by ring
+    _ ≤ (n : ℝ) - radius := sub_le_sub_left hRadiusFloor _
+
 theorem rounded_barrier_upper_family_density
     (ℓ : ℕ) (hℓ : 2 ≤ ℓ) (R : ℝ) (hRpos : 0 < R) (hRlt : R < 1)
     (B : ℕ) (hB : 0 < B) (η : ℝ) (hηpos : 0 < η)
@@ -1285,11 +1294,8 @@ theorem rounded_barrier_upper_family_density
   have hRadiusFloor : (d.radius : ℝ) ≤ p * n := by
     dsimp only [d, roundedBarrierData, p]
     exact Nat.floor_le (by positivity)
-  have hSubCast : ((n - d.radius : ℕ) : ℝ) =
-      (n : ℝ) - d.radius := Nat.cast_sub hRadiusLe
-  have hOneP : (1 - p) * (n : ℝ) ≤ (n - d.radius : ℕ) := by
-    rw [hSubCast]
-    nlinarith
+  have hOneP : (1 - p) * (n : ℝ) ≤ (n - d.radius : ℕ) :=
+    one_sub_mul_le_nat_sub p n d.radius hRadiusLe hRadiusFloor
   have hmLowerR : ((n - d.radius : ℕ) : ℝ) ≤ d.unused := by
     exact_mod_cast hmLower
   have hGapN : R * (n : ℝ) < β * ((1 - p) * n) := by
@@ -1368,10 +1374,16 @@ theorem rounded_barrier_upper_union_density
     norm_num
   have hUnionBase : (d.aUnion : ℝ) ≤ (1 - p') * n + 1 := by
     rw [hAUnionCast]
-    nlinarith
+    calc
+      (n : ℝ) + 1 - d.boosted ≤ (n : ℝ) + 1 - p' * n :=
+        sub_le_sub_left hBoostLower _
+      _ = (1 - p') * n + 1 := by ring
   have hUnionBudget : (1 - p') * n + 1 ≤
       (1 - p' + 3 * ξ) * n := by
-    nlinarith
+    calc
+      (1 - p') * n + 1 ≤ (1 - p') * n + 3 * ξ * n :=
+        add_le_add_right hXiBudget _
+      _ = (1 - p' + 3 * ξ) * n := by ring
   have hGapN : (1 - p' + 3 * ξ) * n ≤
       β * ((1 - p) * n) := by
     calc
@@ -1381,11 +1393,8 @@ theorem rounded_barrier_upper_union_density
   have hRadiusFloor : (d.radius : ℝ) ≤ p * n := by
     dsimp only [d, roundedBarrierData, p]
     exact Nat.floor_le (by positivity)
-  have hSubCast : ((n - d.radius : ℕ) : ℝ) =
-      (n : ℝ) - d.radius := Nat.cast_sub hRadiusLe
-  have hOneP : (1 - p) * (n : ℝ) ≤ (n - d.radius : ℕ) := by
-    rw [hSubCast]
-    nlinarith
+  have hOneP : (1 - p) * (n : ℝ) ≤ (n - d.radius : ℕ) :=
+    one_sub_mul_le_nat_sub p n d.radius hRadiusLe hRadiusFloor
   have hmLowerR : ((n - d.radius : ℕ) : ℝ) ≤ d.unused := by
     exact_mod_cast hmLower
   have hBetaSub : β * ((1 - p) * n) ≤ β * d.unused := by

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
@@ -1557,11 +1557,16 @@ lemma exists_gs_multiplicity {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
         have hμ6 : μ ^ 6 < (1/20 : ℝ) ^ 6 :=
           pow_lt_pow_left₀ hμ_lt_one20 hμ_pos.le (by omega)
         have h4 : (4 : ℝ) ≤ (deg : ℝ) ^ 2 := by
-          nlinarith [show (2 : ℝ) ≤ deg from by exact_mod_cast hdeg]
-        nlinarith
+          exact_mod_cast Nat.pow_le_pow_left (show 2 ≤ deg by omega) 2
+        calc
+          160 * μ ^ 6 < 160 * (1 / 20 : ℝ) ^ 6 :=
+            mul_lt_mul_of_pos_left hμ6 (by norm_num)
+          _ < 4 := by norm_num
+          _ ≤ (deg : ℝ) ^ 2 := h4
       have h_54_lt_deg2 : 5 / (4 * μ) < (deg : ℝ) ^ 2 / (128 * μ ^ 7) := by
         rw [div_lt_div_iff₀ (by positivity) (by positivity)]
-        nlinarith [h_160]
+        convert mul_lt_mul_of_pos_right h_160 (show (0 : ℝ) < 4 * μ by positivity) using 1
+        all_goals ring
       -- Extract |F| bound from hε
       have h_field : (deg : ℝ) ^ 2 / (128 * μ ^ 7) < Fintype.card F := by
         classical

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/UniqueDecoding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/UniqueDecoding.lean
@@ -363,7 +363,10 @@ private theorem bchks_parameter_facts_of_target_hypotheses
   have hbxSumR : (bx : ℝ) + e + 1 = n := by exact_mod_cast hbxSum
   have hbxratio : (bx : ℝ) / n < 1 - (δ : ℝ) := by
     rw [div_lt_iff₀ hnR_pos]
-    nlinarith [hfloorR, hbxSumR]
+    calc
+      (bx : ℝ) = n - ((e : ℝ) + 1) := by linarith only [hbxSumR]
+      _ < n - (δ : ℝ) * n := sub_lt_sub_left hfloorR n
+      _ = (1 - (δ : ℝ)) * n := by ring
   have hnum_eq :
       1 - (k : ℝ) / n - (δ : ℝ) =
         (1 - (k : ℝ) / n - 2 * (δ : ℝ)) + (δ : ℝ) := by ring

--- a/ArkLib/Data/CodingTheory/ProximityGap/DG25/MainResults.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/DG25/MainResults.lean
@@ -407,16 +407,15 @@ lemma disjoint_R_star_star_filter_columns_in_D_not_in_D (U₀ U₁ : Interleaved
   -- The goal is now `Disjoint (R_ss.filter P) (R_ss.filter (¬P))`
   apply disjoint_filter_filter_not
 
-set_option maxHeartbeats 400000 in
--- Destructured `let` avoids repeated elaboration of
--- `constructInterleavedCodewordsAndRowWiseCA`
+-- Keep the code coercion explicit: asking elaboration to infer it here unfolds the large
+-- `e_ε_correlatedAgreementAffineLinesNat` proposition during definitional equality checking.
 omit [NoZeroDivisors F] [DecidableEq F] [Fintype A] [Module.Free F A] in
 lemma D_card_le_e_implies_interleaved_correlatedAgreement₂
     (U₀ U₁ : InterleavedWord A (Fin m) ι)
-  (hC_gap : e_ε_correlatedAgreementAffineLinesNat (F := F) (C := MC) e ε)
+  (hC_gap : e_ε_correlatedAgreementAffineLinesNat (F := F) (C := (MC : Set (ι → A))) e ε)
   (hR_star_card : (R_star (A := A) (F := F) (ι := ι) (C := MC) (m := m) (e := e) U₀ U₁).card > ε) :
     let ⟨V₀, V₁, _⟩ := constructInterleavedCodewordsAndRowWiseCA (F := F)
-      (A := A) (ι := ι) (C := MC) (U₀ := U₀) (U₁ := U₁) (hC_gap := by exact hC_gap)
+      (A := A) (ι := ι) (C := MC) (U₀ := U₀) (U₁ := U₁) (hC_gap := hC_gap)
       (hR_star_card := hR_star_card)
     (disagreementSet U₀ U₁ V₀ V₁).card ≤ e
     → jointProximityNat₂ (C := MC ^⋈ (Fin m)) U₀ U₁ e := by
@@ -424,22 +423,18 @@ lemma D_card_le_e_implies_interleaved_correlatedAgreement₂
   set C_m := MC ^⋈ (Fin m)
   set U_rowwise := finMapTwoWords U₀ U₁
   set U_colwise := ⋈| U_rowwise
-  set C_m_2 := C_m ^⋈ (Fin 2)
   -- Unfold the goal
   unfold jointProximityNat₂
-  -- Goal: (let ⟨V₀, V₁, _⟩ := ... in (disagreementSet ...).card ≤ e) → (Δ₀(U_comb, C_m_2) ≤ e)
+  -- Goal: (let ⟨V₀, V₁, _⟩ := ... in (disagreementSet ...).card ≤ e) →
+  --   (Δ₀(U_comb, C_m ^⋈ (Fin 2)) ≤ e)
   simp only
   -- 2. Introduce the bindings and the hypothesis
   intro hDisagreeementCard_Le_e -- The assumption: (disagreementSet U₀ U₁ V₀ V₁).card ≤ e
-  set V₀ := (constructInterleavedCodewordsAndRowWiseCA (F := F)
-    (A := A) (ι := ι) (C := MC) (U₀ := U₀) (U₁ := U₁) (hC_gap := by exact hC_gap)
-    (hR_star_card := hR_star_card)).1
-  set V₁ := (constructInterleavedCodewordsAndRowWiseCA (F := F)
-    (A := A) (ι := ι) (C := MC) (U₀ := U₀) (U₁ := U₁) (hC_gap := by exact hC_gap)
-    (hR_star_card := hR_star_card)).2.1
-  set hRowPairCA_U_V := (constructInterleavedCodewordsAndRowWiseCA
-    (F := F) (A := A) (ι := ι) (C := MC) (U₀ := U₀) (U₁ := U₁) (hC_gap := by exact hC_gap)
-    (hR_star_card := hR_star_card)).2.2
+  set V := constructInterleavedCodewordsAndRowWiseCA (F := F)
+    (A := A) (ι := ι) (C := MC) (U₀ := U₀) (U₁ := U₁) (hC_gap := hC_gap)
+    (hR_star_card := hR_star_card)
+  set V₀ := V.1
+  set V₁ := V.2.1
   have hD_card_le_e : #(disagreementSet U₀ U₁ V₀ V₁) ≤ e :=
     hDisagreeementCard_Le_e
   -- 3. Show LHS assumption is equal to Δ₀(U_comb, V_constructed) ≤ e
@@ -478,7 +473,7 @@ lemma D_card_le_e_implies_interleaved_correlatedAgreement₂
         exact h_fun_ne_i
   -- Our assumption `h_LHS` is now: Δ₀(U_comb, V_constructed) ≤ e
   simp_rw [h_LHS_eq_dist] at hD_card_le_e
-  -- 4. Prove the RHS: Δ₀(U_comb, C_m_2) ≤ e
+  -- 4. Prove the RHS: Δ₀(U_comb, C_m ^⋈ (Fin 2)) ≤ e
   rw [jointProximityNat]
   rw [Code.closeToCode_iff_closeToCodeword_of_minDist]
   -- ⊢ ∃ v ∈ ↑(C ^⋈ (Fin 2) ^⋈ (Fin m)),

--- a/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
@@ -626,15 +626,7 @@ private lemma indicated_polynomial_eq_foldAux'
     (Polynomial.evalRingHom x)
     (indicatedPolynomial domain f k s')) =
     foldWordAux domain f k x := by
-  apply Polynomial.eq_of_eval_eq_natDegree (s := Finset.univ) (n := (2 ^ k))
-    <;> try tauto
-  · aesop
-     (add safe [(by rw [←eval_comm]),
-      (by rw
-        [indicated_polynomial_eq_combination_of_correlated,
-          ←foldValue_def,
-          foldValue_eq_sum_of_foldAuxCoeff_mul_pow_alpha])])
-     (add simp [eval_finsetSum])
+  refine Polynomial.eq_of_eval_eq_natDegree (s := Finset.univ) (n := 2 ^ k) ?_ ?_ ?_ ?_
   · simp only
       [indicatedPolynomial, Polynomial.map_sum,
         Polynomial.map_mul, map_C, coe_evalRingHom]
@@ -644,6 +636,14 @@ private lemma indicated_polynomial_eq_foldAux'
           (add simp [Polynomial.map_map])
           (add safe [foldWordAux_natDegree])
   · exact foldWordAux_natDegree
+  · simpa using h_card
+  · aesop
+      (add safe [(by rw [←eval_comm]),
+        (by rw
+          [indicated_polynomial_eq_combination_of_correlated,
+            ←foldValue_def,
+            foldValue_eq_sum_of_foldAuxCoeff_mul_pow_alpha])])
+      (add simp [eval_finsetSum])
 
 private lemma foldWordAux_poly_sum {a : F} :
   ((foldWordAux domain f k a).sum fun e a ↦ Polynomial.C a * Polynomial.X ^ e) =

--- a/ArkLib/Data/CodingTheory/SubspaceDesign.lean
+++ b/ArkLib/Data/CodingTheory/SubspaceDesign.lean
@@ -334,6 +334,17 @@ theorem subspaceDesign_tau_lower
     exact le_trans hb (hτ_nonneg r)
   · exact subspaceDesign_tau_lower_of_ne_bot s τ C h_design hs hCne r hr1
 
+private lemma mul_sub_add_one_le_of_le
+    {S s σ r bound : ℝ} (hS : 0 ≤ S) (hσr : σ ≤ r)
+    (hbound : (s - σ + 1) * S ≤ bound) :
+    S * (s - r + 1) ≤ bound := by
+  have hfactor : s - r + 1 ≤ s - σ + 1 :=
+    by simpa only [add_comm] using add_le_add_right (sub_le_sub_left hσr s) 1
+  calc S * (s - r + 1) ≤ S * (s - σ + 1) :=
+      mul_le_mul_of_nonneg_left hfactor hS
+    _ = (s - σ + 1) * S := mul_comm _ _
+    _ ≤ bound := hbound
+
 /-- Base change for the folded Wronskian: replacing the polynomials by the `F`-linear
 combinations with coefficient matrix `U` multiplies the folded Wronskian by `det U`. -/
 private lemma foldedWronskian_of_linearComb {F : Type*} [Field F] {σ : ℕ} {ω : F}
@@ -861,10 +872,8 @@ theorem isSubspaceDesign_frsCode_sub_one
     exact h2
   have hS_nonneg : (0 : ℝ) ≤ S := Finset.sum_nonneg fun i _ => by positivity
   have hσr : (σ : ℝ) ≤ r := by exact_mod_cast hAr
-  have hSb : S * ((s : ℝ) - r + 1) ≤ σ * ((k : ℝ) - 1) := by
-    have h1 : S * ((s : ℝ) - r + 1) ≤ S * ((s : ℝ) - σ + 1) := by nlinarith
-    have h2 : (0 : ℝ) ≤ σ := by positivity
-    nlinarith
+  have hSb : S * ((s : ℝ) - r + 1) ≤ σ * ((k : ℝ) - 1) :=
+    mul_sub_add_one_le_of_le hS_nonneg hσr hS_real
   rw [hτval, div_le_iff₀ hn_pos]
   have hrw : (σ : ℝ) * (((k : ℝ) - 1) / Fintype.card ι / ((s : ℝ) - r + 1)) * Fintype.card ι
       = σ * ((k : ℝ) - 1) / ((s : ℝ) - r + 1) := by
@@ -1204,10 +1213,8 @@ theorem isSubspaceDesign_umCode_sub_one
     exact h2
   have hS_nonneg : (0 : ℝ) ≤ S := Finset.sum_nonneg fun i _ => by positivity
   have hσr : (σ : ℝ) ≤ r := by exact_mod_cast hAr
-  have hSb : S * ((s : ℝ) - r + 1) ≤ σ * ((k : ℝ) - 1) := by
-    have h1 : S * ((s : ℝ) - r + 1) ≤ S * ((s : ℝ) - σ + 1) := by nlinarith
-    have h2 : (0 : ℝ) ≤ σ := by positivity
-    nlinarith
+  have hSb : S * ((s : ℝ) - r + 1) ≤ σ * ((k : ℝ) - 1) :=
+    mul_sub_add_one_le_of_le hS_nonneg hσr hS_real
   rw [hτval, div_le_iff₀ hn_pos]
   have hrw : (σ : ℝ) * (((k : ℝ) - 1) / Fintype.card ι / ((s : ℝ) - r + 1)) *
       Fintype.card ι = σ * ((k : ℝ) - 1) / ((s : ℝ) - r + 1) := by

--- a/ArkLib/Data/MvPolynomial/EvenAndOdd.lean
+++ b/ArkLib/Data/MvPolynomial/EvenAndOdd.lean
@@ -194,7 +194,25 @@ private lemma shiftDown_shiftUp_eq (q : MvPolynomial (Fin n) R) :
     (fun i : Fin (n - 1) ↦ (X (⟨i.val + 1, by omega⟩ : Fin n) : MvPolynomial (Fin n) R)) =
     q.aeval (fun i ↦ if h : i = (0 : Fin n) then 0 else X i) := by
   unfold MvPolynomial.shiftDown
-  grind +suggestions
+  rw [MvPolynomial.comp_aeval_apply]
+  congr 1
+  apply MvPolynomial.algHom_ext
+  intro i
+  simp only [aeval_X]
+  by_cases hi : i = 0
+  · subst i
+    simp
+  · simp only [hi, ↓reduceDIte, aeval_X]
+    apply congrArg X
+    apply Fin.ext
+    have hiPos : 0 < i.val := by
+      apply Nat.pos_of_ne_zero
+      intro h
+      apply hi
+      apply Fin.ext
+      exact h
+    change i.val - 1 + 1 = i.val
+    omega
 
 private lemma substNoX0_eq_self_of_even
   (p : restrictDegree (Fin n) R 1) :

--- a/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Weight.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Weight.lean
@@ -452,11 +452,10 @@ lemma betaSucc_eq_neg_clearedResidual (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
     ring
   rw [hres, hDfull_eq]; ring
 
-set_option maxHeartbeats 2000000 in
 -- The `Finset.finsuppAntidiag` case split below expands one `PowerSeries.coeff` of a
 -- `d`-fold product into a sum over compositions, and each summand carries a `RegularWeightLe`
--- certificate assembled from seven `.mul`/`.pow`/`.sum` steps; the default heartbeat budget is
--- exhausted by the resulting `ring`/`omega` normalisations.
+-- certificate assembled from seven `.mul`/`.pow`/`.sum` steps. The arithmetic is split into
+-- named monotonicity facts and closed ring identities to keep normalization bounded.
 /-- Weight-tracking per-degree clearing lemma: the `Λ`-graded analogue of
 `henselClearedTerm_regular`.  Each degree-`j` summand of the cleared `(t+1)`-st residual is
 regular with sharp `Λ`-weight at most `numeratorShapeSharp R H D (t+1)`.
@@ -823,16 +822,20 @@ lemma henselClearedTerm_weight (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
           omega
         rw [e1, hE1val, hΛξval]
         -- D + wb*ΛW + 2t*((d-1)(ΛW+1)) ≤ 1 + (t+2)ΛW + (2t+1)((d-1)(ΛW+1))
-        obtain ⟨gap, hgap⟩ : ∃ g, t + R.natDegree = wb + g := ⟨t + R.natDegree - wb, by omega⟩
         obtain ⟨dm, hdmeq⟩ : ∃ dm, R.natDegree = dm + 1 := ⟨R.natDegree - 1, by
           rcases Nat.lt_or_ge R.natDegree 2 with h | h
           · -- d < 2 ⇒ d ≤ 1; need d ≥ 1: R.natDegree ≥ natDegreeY H ≥ 1
             have : 1 ≤ R.natDegree := by rw [← hdY]; rw [← hdH] at *; omega
             omega
           · omega⟩
-        rw [hdmeq] at hkey ⊢
-        rw [show dm + 1 - 1 = dm by omega]
-        nlinarith [hkey, hwb_le, hgap, Nat.mul_le_mul_right ΛW hwb_le]
+        calc D + wb * ΛW + 2 * t * ((R.natDegree - 1) * (ΛW + 1))
+            ≤ (R.natDegree + ΛW) + (t + R.natDegree) * ΛW +
+                2 * t * ((R.natDegree - 1) * (ΛW + 1)) :=
+              Nat.add_le_add (Nat.add_le_add hkey (Nat.mul_le_mul_right ΛW hwb_le)) le_rfl
+          _ = 1 + (t + 2) * ΛW +
+                (2 * t + 1) * ((R.natDegree - 1) * (ΛW + 1)) := by
+              rw [hdmeq, show dm + 1 - 1 = dm by omega]
+              ring
       -- the correction the parts consume is at most the `t·G` the target provides
       calc (D - j) + (j + Pw * ΛW + Pe * Λξ + Pc * G) +
             ((wb - Pw) * ΛW + (E1 - Pe) * Λξ)

--- a/ArkLib/OracleReduction/LiftContext/Reduction.lean
+++ b/ArkLib/OracleReduction/LiftContext/Reduction.lean
@@ -290,7 +290,8 @@ theorem liftContext_runWithLog
           P.runWithLog.uncurry (lens.proj (outerStmtIn, outerWitIn))
         return ⟨⟨fullTranscript, lens.lift (outerStmtIn, outerWitIn) innerCtxOut⟩, queryLog⟩ := by
   rw [runWithLog, liftContext_run]
-  simp [Function.uncurry]
+  simp only [ChallengeIdx, Challenge, Function.uncurry, bind_pure_comp, simulateQ_map,
+    WriterT.run_map]
   congr
 
 end Prover

--- a/ArkLib/ProofSystem/Stir/Combine.lean
+++ b/ArkLib/ProofSystem/Stir/Combine.lean
@@ -112,6 +112,16 @@ private lemma block_start_zero
   {dstar : ℕ} {degs : Fin m.succ → ℕ} :
   block_start dstar degs 0 = 0 := by simp [block_start]
 
+private lemma block_end_le_block_start
+  {dstar : ℕ} {degs : Fin m → ℕ} {i j : Fin m} (hij : i < j) :
+  block_start dstar degs i + block_size dstar degs i ≤ block_start dstar degs j := by
+  unfold block_start
+  rw [add_comm, ← Finset.sum_insert (by simp)]
+  apply Finset.sum_le_sum_of_subset
+  intro k hk
+  simp only [mem_insert, mem_filter, mem_univ, true_and] at hk ⊢
+  exact hk.elim (fun hki ↦ hki ▸ hij) (fun hki ↦ lt_trans hki hij)
+
 private lemma block_start_filter_nonempty
   {dstar : ℕ} {degs : Fin m.succ → ℕ} {l : ℕ} :
   (univ.filter (fun j ↦ block_start dstar degs j ≤ l)).Nonempty := by
@@ -127,21 +137,10 @@ private lemma block_idx_eq_max
   norm_num [Finset.le_max]
   intro a ha
   contrapose! ha
-  exact lt_of_lt_of_le (Nat.add_lt_add_left (Fin.is_lt j) _) <| by
-    unfold block_start block_size
-    have h : (Finset.univ.filter fun j ↦ j < a) =
-      Finset.univ.filter (fun j ↦ j < i) ∪ {i} ∪ Finset.univ.filter (fun j ↦ i < j ∧ j < a) := by
-      grind
-    rw [h,
-        Finset.sum_union (by
-          aesop
-            (add simp [Finset.disjoint_left])
-            (add safe (by grind))),
-        Finset.sum_union (by simp)]
-    simp
+  exact lt_of_lt_of_le (Nat.add_lt_add_left (Fin.is_lt j) _)
+    (block_end_le_block_start ha)
 
 omit [DecidableEq F] in
-set_option maxHeartbeats 0 in
 set_option maxRecDepth 4000 in
 set_option synthInstance.maxHeartbeats 20000 in
 set_option synthInstance.maxSize 128 in
@@ -232,25 +231,12 @@ private lemma combine_eq_flat
               by simp +decide⟩
         · simp only [mem_Ico, and_imp]
           intro a ha₁ ha₂
-          rw [show Finset.max
-              (Finset.filter (block_start dstar degs · ≤ a) Finset.univ) = ↑i from ?_]
-          apply le_antisymm
-          · simp only [Finset.max, Finset.sup_le_iff, mem_filter, mem_univ, true_and,
-            WithBot.coe_le_coe]
-            intro j hj₁
-            contrapose! hj₁
-            apply lt_of_lt_of_le ha₂
-            unfold block_start block_size
-            rw [show (Finset.univ.filter fun k => k < j) =
-                  Finset.univ.filter (fun k => k < i) ∪
-                      {i} ∪ Finset.univ.filter (fun k => i < k ∧ k < j) from ?_,
-                Finset.sum_union, Finset.sum_union] <;> norm_num
-            · exact Finset.disjoint_left.mpr fun x hx₁ hx₂ ↦
-                lt_asymm (Finset.mem_filter.mp hx₁ |>.2) (Finset.mem_filter.mp hx₂ |>.2.1)
-            · grind
-          · simp only [Finset.max, WithBot.bot_lt_coe, Finset.le_sup_iff, mem_filter, mem_univ,
-            true_and, WithBot.coe_le_coe]
-            exact ⟨i, ha₁, le_rfl⟩
+          have hk : a - block_start dstar degs i < block_size dstar degs i := by omega
+          have hmax := block_idx_eq_max
+            (dstar := dstar) (degs := degs) (i := i)
+            (j := ⟨a - block_start dstar degs i, hk⟩)
+          rw [show block_start dstar degs i + (a - block_start dstar degs i) = a by omega] at hmax
+          rw [hmax]
       })
     · intro i _ j _ hij
       have h_disjoint :
@@ -258,36 +244,9 @@ private lemma combine_eq_flat
           block_start dstar degs i + block_size dstar degs i ∨
         block_start dstar degs i ≥
           block_start dstar degs j + block_size dstar degs j := by
-        cases lt_or_gt_of_ne hij
-        · simp_all only [block_start, block_size, coe_univ, Set.mem_univ, ne_eq, ge_iff_le]
-          left
-          apply
-            (Function.swap le_trans <|
-              Finset.sum_le_sum_of_subset
-                (show Finset.filter (· < i) Finset.univ ∪ {i} ⊆
-                  Finset.filter (· < j) Finset.univ from _))
-          · rw [Finset.sum_union] <;> simp [*, Finset.sum_singleton]
-          · simp only [union_singleton, subset_iff, mem_insert, mem_filter, mem_univ, true_and,
-            forall_eq_or_imp, *]
-            exact fun a ha ↦ lt_trans ha ‹_›
-        · simp_all only [block_start, block_size]
-          rw [show (Finset.univ.filter fun x => x < i) =
-            Finset.univ.filter (· < j) ∪ {j} ∪
-              (Finset.univ.filter (· < i) \
-                (Finset.univ.filter (· < j) ∪ {j})) from ?_,
-            Finset.sum_union, Finset.sum_union]
-          · simp
-          · simp
-          · exact fun x hx₁ hx₂ a ha ↦ by
-              specialize hx₁ ha
-              specialize hx₂ ha
-              simp_all
-              omega
-          · simp only [union_singleton, union_sdiff_self_eq_union, insert_union, mem_union,
-            mem_filter, mem_univ, lt_self_iff_false, and_false, and_self, or_true, insert_eq_of_mem,
-            right_eq_union, *]
-            exact fun x hx ↦ Finset.mem_filter.mpr
-              ⟨Finset.mem_univ _, lt_trans (Finset.mem_filter.mp hx |>.2) ‹_›⟩
+        rcases lt_or_gt_of_ne hij with hij | hji
+        · exact Or.inl (block_end_le_block_start hij)
+        · exact Or.inr (block_end_le_block_start hji)
       cases h_disjoint
       · exact Finset.disjoint_left.mpr fun x hx₁ hx₂ ↦ by
           linarith [Finset.mem_Ico.mp hx₁, Finset.mem_Ico.mp hx₂]


### PR DESCRIPTION
## Summary

This PR removes measured Lean elaboration bottlenecks from fourteen chronic build offenders. It replaces broad nonlinear/tautological search, repeated dependent elaboration, and duplicated proof bodies with explicit arithmetic or small private helpers.

It preserves every public theorem statement and removes six exceptional heartbeat scopes. No `sorry`, axiom, native trust, unsafe declaration, import, or executable definition is added or changed.

### Diff metadata

- Base: `ff102df75a53ba7748d1e0e365c58057d96104a6` (`main`)
- Head: `6d0141a02af42ae3d1e294f32e2c1fe9bf28f56d`
- Commits: 14
- Files changed: 14
- Diff: 248 insertions, 262 deletions

## Motivation

CI timing showed that a small set of proof files dominates clean-build work. The recurring failure modes were:

- unrestricted `nlinarith`, `tauto`, and related search over large local contexts;
- expensive implicit-argument definitional equality;
- repeated elaboration of the same construction or proof body;
- heartbeat exceptions masking those costs.

This round changes proof internals only. Each refactor was selected by declaration/substep profiling, then checked against its meaningful consumers and axiom surface.

Companion guardrail PR: #814. Merge #814 first, then update this branch against `main` so the newly enforcing AxiomSweep gate certifies the final proof merge order.

## Measured changes

Measurements below are same-machine, before/after scoped runs; GitHub runner wall times vary substantially and are not used to overstate the aggregate result.

At the exact final head, clean CI completed in 766.26s versus the 1026.37s baseline (25.3% raw reduction). The final runner was materially faster: across 382 unchanged modules taking at least 2s in the baseline, its median timing ratio was 0.769. Normalizing by that ratio gives an estimated 996.1s umbrella build (about 2.9% improvement). The fourteen edited modules fell from 720s to 370s raw, or about 481s normalized (33.2% reduction). This is durable hotspot progress, but it is not the 3× repository-wide target.

| Area | Measured result | Refactor |
|---|---:|---|
| Hensel `Weight` | file 23.38s → 4.69s | replace a 21.6s nonlinear search with monotonicity and a ring identity |
| `KKH26Asymptotic` | file 13.34s → 4.57s | explicit transitivity, cancellation, and monotonicity |
| `SubspaceDesign` | file 11.54s → 7.53s | reuse one private arithmetic lemma |
| `UniqueDecoding` | hot theorem 7.64s → 6.06s | derive the exact subtraction identity before comparison |
| `DG25.MainResults` | file 9.98s → 4.08s | make the code coercion explicit and cache one construction |
| `Folding` | hot theorem 7.25s → 1.89s | supply four exact premises instead of failed speculative `tauto` |
| Guruswami–Sudan | duplicated 3.91s proof work → 1.88s shared helper | retain two exact public wrappers |
| Johnson family | theorem 9.11s → 3.31s; file 11.67s → 6.08s | explicit square, positivity, and fraction monotonicity |
| `BCIKS20.AffineSpaces` | theorem 14.21s → 2.57s | exact power monotonicity and positive multiplication |
| Large-alphabet Pigeonhole | file 8.06s → 5.95s; union theorem 5.75s → 0.50s | shared cast/subtraction lemma and explicit budget chains |
| STIR `Combine` | `combine_eq_flat` 2.95s → 2.27s | reuse block interval ordering |
| Lift-context logging | theorem 3.19s → below 0.10s; file 5.80s → 4.14s | replace broad `simp` with the exact map/run lemmas |
| `MvPolynomial.EvenAndOdd` | private helper 5.53s → 0.51s; file 7.36s → 5.47s | explicit composition and zero/nonzero Fin-index proof |
| Johnson lemmas | two declarations reduced by 1.21s combined | replace equality search with exact existing identities and fraction algebra |

## Proof and API safety

- All changed public theorem declarations retain their exact source-level statements.
- New proof abstractions are `private`.
- Six `maxHeartbeats` scopes are removed; all affected sources elaborate under the default budget.
- Changed public results retain their pre-existing axiom footprints. Axiom-clean results remain exactly `[propext, Classical.choice, Quot.sound]`; declarations inheriting existing `sorryAx` do not gain new taint.
- No definitions used for execution, serialization, protocol transcripts, or verifier behavior change.

## Validation completed at `6d0141a0`

For every checkpoint:

- direct source elaboration passed;
- the changed target and meaningful direct consumers built;
- public theorem types were checked against the baseline surface;
- `#print axioms` was checked for the changed result and downstream public chain;
- added trust-token scans and `git diff --check` passed;
- an independent `review-lean-formalization` audit found no P0–P3 issue.

Representative consumers include `CapacityBounds`, `DG25.ReedSolomon`, Folding `ListDecodability` and `Multilinear`, Guruswami–Sudan and BCIKS20 divisibility wrappers, `ReedSolomonGap`, Johnson `Basic`/`Family`, lift-context `OracleReduction`, and large-alphabet `Barrier`/umbrella modules.

Exact-head CI passed the complete clean/warm/native/runtime/AxiomSweep/validation/docs workflow. This PR does not claim the 3× clean-build target has been reached.

## Non-goals and remaining work

- This PR does not change imports, CI, or trust policy; those are isolated in the companion guardrail PR.
- It does not convert ArkLib to Lean's module system.
- Profiling rejected the non-material canonical-choice rewrite in `AffineSpaces` and every narrow `CapacityBounds.Frs` candidate; only the independently measured AffineSpaces arithmetic refactor was committed.
- Remaining clean-build work is still distributed across capacity-bound files, large-alphabet bounds, STIR, and other 30–60s CI modules.

## Reviewer map

Suggested review order:

1. `HenselNumerators/Weight.lean`, `KKH26Asymptotic.lean`, and `JohnsonBound/Family.lean` for explicit arithmetic replacements.
2. `DG25/MainResults.lean` and `Folding.lean` for elaborator-search removal.
3. `GuruswamiSudan/Basic.lean`, `SubspaceDesign.lean`, and `Stir/Combine.lean` for private-helper factoring.
4. `BCIKS20/AffineSpaces.lean` and `LargeAlphabet/Pigeonhole.lean` for numeric refactors.
5. `EvenAndOdd.lean`, `JohnsonBound/Lemmas.lean`, and `LiftContext/Reduction.lean` for the final search-to-exact-proof replacements.
