### PR TITLE
ci: validate merge queue groups

### DIFF
--- a/.github/workflows/check-imports.yml
+++ b/.github/workflows/check-imports.yml
@@ -3,6 +3,8 @@ name: Check Imports
 on:
   pull_request:
     branches: ["main"]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docs-integrity.yml
+++ b/.github/workflows/docs-integrity.yml
@@ -3,6 +3,8 @@ name: Docs Integrity
 on:
   pull_request:
     branches: ["main"]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint-whitespaces.yml
+++ b/.github/workflows/lint-whitespaces.yml
@@ -3,6 +3,8 @@ name: Lint trailing whitespaces
 on:
   pull_request:
     branches: ["main"]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -211,6 +211,12 @@ python3 -m pip install leanblueprint
 - [`../../.github/workflows/kb-generated.yml`](../../.github/workflows/kb-generated.yml)
   opens generated-files PRs for KB indexes and missing cited-paper stubs after pushes to `main`.
 
+Pull requests enter GitHub's merge queue after their normal review and required checks pass. The
+queue creates a temporary integration ref containing the queued changes on current `main`; the CI,
+import, docs-integrity, and whitespace workflows run again on that `merge_group` ref before GitHub
+may merge it. PR-only timing comparisons and comments remain attached to the ordinary PR run and
+are intentionally skipped for merge groups, which do not carry a pull-request payload.
+
 ## Manual Timing Helper
 
 If you need to reproduce the timing workflow locally, the same helper script can


### PR DESCRIPTION
## Summary

This PR prepares ArkLib for GitHub's merge queue without changing the current review or required-check policy.

It:

- runs the build, import, docs-integrity, and whitespace workflows for `merge_group` `checks_requested` events;
- preserves PR-only timing comparisons and comments behind their existing `pull_request` guards; and
- documents that queued integration refs are validated again against current `main` before merge.

This mirrors the bootstrap in Verified-zkEVM/VCVio#600. The queue ruleset is deliberately not enabled until this PR lands, because the required `build` and `Check Library File Imports` contexts must exist on merge-group refs first.

### Diff metadata

- Base: `8824469ea484634ac00773520645b3e9eebc9a37` (`main`)
- Head: `858b97f5351bd748f2f70449b9f50e430042377e`
- Commits: 1
- Files changed: 5
- Diff: 14 insertions, 0 deletions

## Motivation

ArkLib has enough concurrent PR activity that individually green branches can repeatedly become stale while earlier work merges. A merge queue serializes or batches those ready PRs and tests their actual combined integration commit rather than trusting only checks from each earlier PR head.

Without `merge_group` triggers, enabling the queue would leave its temporary `gh-readonly-queue/main/...` refs without ArkLib's required check contexts, blocking the queue or weakening the intended gate.

## Before and after

| Concern | Before | After this PR |
| --- | --- | --- |
| Ordinary PR validation | Four workflows run on the PR merge ref | Unchanged |
| Queued integration validation | No workflows subscribe to `merge_group` | The same four workflows run on the queue's combined ref |
| PR timing reports | Produced for `pull_request` runs | Unchanged; intentionally skipped for payload-less merge groups |
| Reviews and required checks | One approval plus `build` and import checks | Unchanged |
| Queue requirement | Disabled | Still disabled until this bootstrap merges |

## Event behavior

```mermaid
flowchart LR
    A[PR approved and checks green] --> B[Enter merge queue]
    B --> C[GitHub creates integration ref on current main]
    C --> D[CI build]
    C --> E[Import check]
    C --> F[Docs integrity]
    C --> G[Whitespace lint]
    D --> H{Integration group all green?}
    E --> H
    F --> H
    G --> H
    H -->|yes| I[Squash merge]
    H -->|no| J[Remove or regroup failing entry]
```

The existing `github.event_name == 'pull_request'` guards in `ci.yml` keep PR-payload-only work out of merge-group runs:

- generated-KB path attribution;
- PR timing merge-base selection;
- previous-PR timing artifact selection and comparison comments.

All build, validation, axiom-sweep, blueprint, and documentation checks still execute on the queue ref. Pages deployment remains push-only.

## Trust and operational impact

- No workflow permissions change.
- No review, status-check, axiom, import, or generated-file gate is removed or relaxed.
- Queue validation is additive: ready PRs are checked once normally and again on the integration ref.
- The second full build costs additional runner time, but prevents stale-green merges. A two-entry queue batch can amortize that cost when several PRs are ready together.
- Administrator bypass policy is not changed by this PR.

## Validation completed at `858b97f5`

- all four edited workflow files parse as YAML;
- each edited workflow contains exactly one `merge_group` / `checks_requested` trigger;
- `python3 ./scripts/check-docs-integrity.py`;
- `git diff --check`;
- explicit trailing-whitespace checks over all five changed files.

`bash ./scripts/lintWhitespace.sh` did not complete locally on macOS: its existing `find | while` pipeline exited with `Trace/BPT trap: 5`. The changed files are clean, and the hosted Linux whitespace workflow remains the authoritative check for this PR.

## Follow-up after merge

Enable a separate active merge-queue ruleset on the default branch, matching the conservative VCVio policy:

- all entries green;
- squash merge;
- build and merge at most two entries per group;
- one entry is sufficient, with no batching delay;
- 60-minute check-response timeout;
- no queue-rule bypass actors.

Then enqueue one real ready PR and verify that `build` and `Check Library File Imports` attach to the `merge_group` head and that GitHub merges only after the group passes.

## Reviewer map

1. `.github/workflows/ci.yml`: queue event plus existing PR-only guards.
2. `.github/workflows/check-imports.yml`: required import context on queue refs.
3. `.github/workflows/docs-integrity.yml` and `lint-whitespaces.yml`: remaining substantive PR checks.
4. `docs/wiki/quickstart.md`: maintainer-facing queue behavior.
