### PR TITLE
perf: refactor ArkLib proof hotspots for faster checking

### DIFF
--- a/ArkLib/Data/CodingTheory/Connections/ListDecodingAndCA/BCHKS25.lean
+++ b/ArkLib/Data/CodingTheory/Connections/ListDecodingAndCA/BCHKS25.lean
@@ -192,11 +192,15 @@ theorem rs_Lambda_le_card_of_epsCa_lt
       have hbadR : (2 * n * (imageAt a).card : ℝ) < q := by exact_mod_cast hbad
       have hNpos : (0 : ℝ) < N a := by
         have hMpos : (0 : ℝ) < L0.card := by rw [hL0card]; positivity
-        nlinarith [hCS a]
+        nlinarith only [hCS a, hMpos]
       have hmul := mul_lt_mul_of_pos_right hbadR hNpos
       have hscale := mul_le_mul_of_nonneg_left (hCS a)
         (show (0 : ℝ) ≤ 2 * n by positivity)
-      nlinarith
+      calc
+        2 * n * (L0.card : ℝ) ^ 2 ≤
+            2 * n * ((imageAt a).card * (N a : ℝ)) := hscale
+        _ = (2 * n * (imageAt a).card : ℝ) * N a := by ring
+        _ < (q : ℝ) * N a := hmul
     have hsum :
         ∑ _a : F, (2 * n * (L0.card : ℝ) ^ 2) <
           ∑ a : F, (q : ℝ) * N a :=
@@ -222,7 +226,7 @@ theorem rs_Lambda_le_card_of_epsCa_lt
     have hL0R : (L0.card : ℝ) = q + 1 := by exact_mod_cast hL0card
     have hnR : (0 : ℝ) < n := by exact_mod_cast hn
     rw [hL0R] at hcomb
-    nlinarith
+    nlinarith only [hcomb, hnR]
   obtain ⟨α, hspreadα⟩ := hspread
   let Z : Finset F := imageAt α
   let f : ι → F := fun x => c x / (domain x - α)

--- a/ArkLib/Data/CodingTheory/Connections/ListDecodingAndCA/CS25.lean
+++ b/ArkLib/Data/CodingTheory/Connections/ListDecodingAndCA/CS25.lean
@@ -407,11 +407,10 @@ theorem rs_Lambda_extended_le_of_epsCa_int_radius
       (Good.card : ℝ) * ((T.card : ℝ) * A.card + k * (T.card : ℝ) ^ 2) := by
     calc
       (T.card : ℝ) ^ 2 * A.card ≤ ((Good.card : ℝ) * (coll a : ℝ)) * A.card := by
-        gcongr
+        exact mul_le_mul_of_nonneg_right hCS (Nat.cast_nonneg _)
       _ = (Good.card : ℝ) * ((coll a : ℝ) * A.card) := by ring
       _ ≤ (Good.card : ℝ) * ((T.card : ℝ) * A.card + k * (T.card : ℝ) ^ 2) := by
-        gcongr
-        exact_mod_cast haavg
+        exact mul_le_mul_of_nonneg_left (by exact_mod_cast haavg) (Nat.cast_nonneg _)
   have hAcardR : (A.card : ℝ) = (q : ℝ) - n := by
     rw [hAcard, Nat.cast_sub hnq]
   by_cases hT0 : T.card = 0

--- a/ArkLib/Data/CodingTheory/DivergenceOfSets.lean
+++ b/ArkLib/Data/CodingTheory/DivergenceOfSets.lean
@@ -494,7 +494,8 @@ theorem errorBound_ge_const {ι : Type} [Fintype ι] [Nonempty ι]
       have hrmul : (↑(Fintype.card ι) : ℝ) * (r : ℝ) ≤ (deg : ℝ) := by
         exact_mod_cast hrmul_nnreal
       have hrmul_div : (↑(Fintype.card ι) : ℝ) * ((r : ℝ) / 100) ≤ (deg : ℝ) / 100 := by
-        nlinarith [hrmul]
+        rw [← mul_div_assoc]
+        exact div_le_div_of_nonneg_right hrmul (by norm_num)
       have hdeg_sq : (deg : ℝ) / 100 ≤ (↑deg ^ 2 : ℝ) := by
         have hdeg1_nat : 1 ≤ deg := Nat.one_le_of_lt hdeg
         have hdeg1 : (1 : ℝ) ≤ (deg : ℝ) := by
@@ -502,9 +503,12 @@ theorem errorBound_ge_const {ι : Type} [Fintype ι] [Nonempty ι]
         have hdeg_nonneg : 0 ≤ (deg : ℝ) := by
           exact_mod_cast (Nat.zero_le deg)
         have hdeg_le_sq : (deg : ℝ) ≤ (deg : ℝ) ^ 2 := by
-          nlinarith [hdeg1]
+          calc
+            (deg : ℝ) = (deg : ℝ) * 1 := by ring
+            _ ≤ (deg : ℝ) * deg := mul_le_mul_of_nonneg_left hdeg1 hdeg_nonneg
+            _ = (deg : ℝ) ^ 2 := by ring
         have hdiv_le : (deg : ℝ) / 100 ≤ (deg : ℝ) := by
-          nlinarith [hdeg_nonneg]
+          exact div_le_self hdeg_nonneg (by norm_num)
         -- rewrite `(deg : ℝ) ^ 2` as `↑deg ^ 2` at the end
         have : (deg : ℝ) / 100 ≤ (deg : ℝ) ^ 2 := hdiv_le.trans hdeg_le_sq
         simpa using this

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
@@ -172,13 +172,14 @@ lemma numVars_eq_of_gt_one {D : ℕ} (hk : 1 < k) :
               ∑ j ∈ range (D / (k - 1) + 1), (k - 1) * j := by
           exact eq_tsub_of_add_eq <| by
             rw [← sum_add_distrib]
-            exact sum_congr rfl fun x hx ↦ tsub_add_cancel_of_le <| by
-              nlinarith [mem_range.mp hx, Nat.div_mul_le_self D (k - 1)]
-        simp_all only [mul_comm, sum_const, card_range, smul_eq_mul]
-        exact congrArg _ (Eq.symm <| Nat.div_eq_of_eq_mul_left zero_lt_two <| by
-          rw [← sum_mul _ _ _]
-          exact (D / (k - 1)).recOn (by norm_num) fun n ih ↦ by
-            norm_num [range_add_one] at *; linarith)
+            refine sum_congr rfl fun x hx ↦ tsub_add_cancel_of_le ?_
+            exact (Nat.mul_le_mul_left _ (Nat.lt_succ_iff.mp (mem_range.mp hx))).trans
+              (Nat.mul_div_le D (k - 1))
+        rw [h_simp, ← Finset.mul_sum, Finset.sum_range_id]
+        simp only [sum_const, card_range, smul_eq_mul]
+        simp only [Nat.add_sub_cancel]
+        rw [Nat.mul_comm (D / (k - 1) + 1) (D / (k - 1)), ← Nat.mul_div_assoc]
+        exact even_iff_two_dvd.mp (by simpa [parity_simps] using Nat.even_or_odd (D / (k - 1)))
       rw [sum_add_distrib]
       simp only [sum_const, card_range, smul_eq_mul, mul_one]
       rw [h_simp]

--- a/ArkLib/Data/CodingTheory/JohnsonBound/Lemmas.lean
+++ b/ArkLib/Data/CodingTheory/JohnsonBound/Lemmas.lean
@@ -218,7 +218,10 @@ private def F2i (B : Finset (Fin n → F)) (i : Fin n) (α : F) :
 lemma F2i_disjoint : Set.PairwiseDisjoint Set.univ (F2i B i) := by
   intros a _ b _ hab
   simp only [disjoint_left, Prod.forall]
-  unfold F2i; aesop
+  intro x y hxa hxb
+  simp only [F2i, Finset.mem_filter, Finset.mem_univ, true_and,
+    Finset.mem_product] at hxa hxb
+  exact hab (hxa.2.2.1.symm.trans hxb.2.2.1)
 
 /-- `|F2i B i α| = K(α) · (K(α) - 1)`. -/
 lemma F2i_card {α : F} : (F2i B i α).card = K B i α * (K B i α - 1) := by
@@ -235,7 +238,15 @@ private def Bi (B : Finset (Fin n → F)) (i : Fin n) :=
   {x ∈ B ×ˢ B | x.1 ≠ x.2 ∧ x.1 i = x.2 i}
 
 /-- `Bi` decomposes as a disjoint union of `F2i` over all field elements. -/
-lemma Bi_biUnion_F2i : Bi B i = univ.biUnion (F2i B i) := by unfold Bi F2i; ext; aesop
+lemma Bi_biUnion_F2i : Bi B i = univ.biUnion (F2i B i) := by
+  ext x
+  simp only [Bi, F2i, Finset.mem_filter, Finset.mem_product, Finset.mem_biUnion,
+    Finset.mem_univ, true_and]
+  constructor
+  · rintro ⟨hmem, hne, heq⟩
+    exact ⟨x.1 i, hmem, hne, rfl, heq.symm⟩
+  · rintro ⟨a, hmem, hne, hxa, hya⟩
+    exact ⟨hmem, hne, hxa.trans hya.symm⟩
 
 /-- `|Bi B i| = ∑ α, K(α) · (K(α) - 1)`. -/
 lemma Bi_card : (Bi B i).card = ∑ α : F, K B i α * (K B i α - 1) := by

--- a/ArkLib/Data/CodingTheory/ListDecodability/Bounds/LargeAlphabet/Centers.lean
+++ b/ArkLib/Data/CodingTheory/ListDecodability/Bounds/LargeAlphabet/Centers.lean
@@ -529,23 +529,24 @@ theorem incidence_power_gap :
   have hsize : 4 * (ℓ : ℝ) ^ 2 / p ≤ (M : ℝ) :=
     (Nat.ceil_le).mp hM
   have hpm : 4 * (ℓ : ℝ) ^ 2 ≤ p * M := by
-    have h := (div_le_iff₀ hp).mp hsize
-    nlinarith
+    simpa only [mul_comm] using (div_le_iff₀ hp).mp hsize
   have hden : (0 : ℝ) < 4 * ℓ := by positivity
   have hratio : (ℓ : ℝ) - 1 ≤ p * M / (4 * ℓ) := by
     rw [le_div_iff₀ hden]
     have haux : 4 * (ℓ : ℝ) * ((ℓ : ℝ) - 1) ≤ 4 * (ℓ : ℝ) ^ 2 := by
-      nlinarith
+      calc
+        4 * (ℓ : ℝ) * ((ℓ : ℝ) - 1) ≤ 4 * (ℓ : ℝ) * ℓ :=
+          mul_le_mul_of_nonneg_left (sub_le_self _ zero_le_one)
+            (mul_nonneg (by norm_num) hℓR.le)
+        _ = 4 * (ℓ : ℝ) ^ 2 := by ring
     exact (by
       simpa only [mul_comm, mul_left_comm, mul_assoc] using haux.trans hpm)
   let q : ℝ := 1 - 1 / (4 * ℓ)
   have hone : 1 / (4 * (ℓ : ℝ)) ≤ 1 :=
-    (div_le_one hden).2 (by nlinarith)
-  have hq : 0 ≤ q := by
-    dsimp [q]
-    linarith
+    (div_le_one hden).2 (by nlinarith only [hℓtwo])
+  have hq : 0 ≤ q := by simpa only [q] using sub_nonneg.mpr hone
   have hneg : (-2 : ℝ) ≤ -(1 / (4 * (ℓ : ℝ))) := by
-    linarith
+    exact neg_le_neg (hone.trans (by norm_num))
   have hbern : (3 : ℝ) / 4 ≤ q ^ ℓ := by
     calc
       (3 : ℝ) / 4 =
@@ -1021,8 +1022,11 @@ theorem rounded_barrier_other_codeword_bound_core
   have hbalanceN :
       R * n + p * n + (p / (ℓ : ℝ)) * n =
         (n : ℝ) - η * n := by
-    have h := congrArg (fun x : ℝ => x * (n : ℝ)) hbalance
-    nlinarith
+    calc
+      R * n + p * n + (p / (ℓ : ℝ)) * n =
+          (R + p + p / (ℓ : ℝ)) * n := by ring
+      _ = (1 - η) * n := by rw [hbalance]
+      _ = (n : ℝ) - η * n := by ring
   have hslack := barrier_k_slack ℓ B hℓ
   change (B : ℝ) + 4 + 1 / (ℓ : ℝ) ≤
     K * (1 - 1 / (ℓ : ℝ)) - 1 at hslack
@@ -1034,7 +1038,11 @@ theorem rounded_barrier_other_codeword_bound_core
   have hfactorGrow :
       K * (1 - 1 / (ℓ : ℝ)) - 1 ≤
         (K * (1 - 1 / (ℓ : ℝ)) - 1) * (η * n) := by
-    nlinarith [mul_nonneg hfactorNonneg (sub_nonneg.mpr hone)]
+    calc
+      K * (1 - 1 / (ℓ : ℝ)) - 1 =
+          (K * (1 - 1 / (ℓ : ℝ)) - 1) * 1 := by ring
+      _ ≤ (K * (1 - 1 / (ℓ : ℝ)) - 1) * (η * n) :=
+        mul_le_mul_of_nonneg_left hone hfactorNonneg
   have hbudget :
       (B : ℝ) + 4 + 1 / (ℓ : ℝ) ≤
         (K * (1 - 1 / (ℓ : ℝ)) - 1) * (η * n) :=
@@ -1139,11 +1147,13 @@ theorem incidence_moment_lower :
   have hsize : 4 * (ℓ : ℝ) ^ 2 / p ≤ (M : ℝ) :=
     (Nat.ceil_le).mp hM
   have hpm : 4 * (ℓ : ℝ) ^ 2 ≤ p * M := by
-    have h := (div_le_iff₀ hp).mp hsize
-    nlinarith
+    simpa only [mul_comm] using (div_le_iff₀ hp).mp hsize
   have hgap_nonneg : 0 ≤ p * M - ((ℓ : ℝ) - 1) := by
     have hℓtwo : (2 : ℝ) ≤ ℓ := by exact_mod_cast hℓ
-    nlinarith
+    have hsmall : (ℓ : ℝ) - 1 ≤ 4 * (ℓ : ℝ) ^ 2 := by
+      nlinarith only [hℓtwo, sq_nonneg (ℓ : ℝ)]
+    apply sub_nonneg.mpr
+    exact hsmall.trans hpm
   have hmeanpow :
       (p * M - ((ℓ : ℝ) - 1)) ^ ℓ ≤ ((∑ i, b i) / n) ^ ℓ :=
     pow_le_pow_left₀ hgap_nonneg hmean ℓ

--- a/ArkLib/Data/CodingTheory/ListDecodability/Bounds/ReedSolomon.lean
+++ b/ArkLib/Data/CodingTheory/ListDecodability/Bounds/ReedSolomon.lean
@@ -227,7 +227,7 @@ theorem rs_lambda_large_prime
     have hceil : (⌈A * (p : ℝ) ^ α⌉₊ : ℝ) < A * (p : ℝ) ^ α + 1 :=
       Nat.ceil_lt_add_one (mul_nonneg hA.le hxpos.le)
     have haAx : (⌈A * (p : ℝ) ^ α⌉₊ : ℝ) ≤ (A + 1) * (p : ℝ) ^ α := by
-      nlinarith [hx.1]
+      nlinarith only [hceil, hx.1]
     have hpowprod : (p : ℝ) ^ s * (p : ℝ) ^ α = (p : ℝ) ^ (α + s) := by
       rw [mul_comm, ← Real.rpow_add hpR]
     have haPow : (2 * ⌈A * (p : ℝ) ^ α⌉₊ : ℝ) ≤ (p : ℝ) ^ (α + s) := by
@@ -244,9 +244,11 @@ theorem rs_lambda_large_prime
       have hx2 := hx.2
       have hscale : α + s + 1 ≤ β * (p : ℝ) ^ α / 4 := by
         have hh := (div_le_iff₀ _hβ_pos).mp hx2
-        nlinarith
+        linarith only [hh]
       have hmul := mul_lt_mul_of_pos_left hceil (add_pos _hα_pos hs)
-      nlinarith [hsA]
+      have hsAx := mul_le_mul_of_nonneg_right hsA hxpos.le
+      have hAeqx := congrArg (fun z : ℝ => z * (p : ℝ) ^ α) hAeq
+      nlinarith only [hk, hscale, hmul, hsAx, hAeqx]
     have hpowhalf : (p : ℝ) ^ α * (p : ℝ) ^ (1 - α) = (p : ℝ) := by
       rw [← Real.rpow_add hpR]
       convert Real.rpow_one (p : ℝ) using 2
@@ -298,7 +300,7 @@ theorem rs_lambda_large_prime
         push_cast
         have ha2 : 2 * a ≤ p := by omega
         have ha2R : (2 : ℝ) * a ≤ p := by exact_mod_cast ha2
-        nlinarith
+        linarith only [ha2R]
       have hnum : ((p : ℝ) / 2) ^ a ≤ ((p + 1 - a : ℕ) : ℝ) ^ a :=
         pow_le_pow_left₀ (by positivity) hbase a
       have hfac : ((a.factorial : ℕ) : ℝ) ≤ (a : ℝ) ^ a := by
@@ -328,7 +330,7 @@ theorem rs_lambda_large_prime
       have hlog0 := Real.one_sub_inv_le_log_of_pos hrpos
       have hcalc : -2 ≤ (p : ℝ) * (1 - (1 - 1 / (p : ℝ))⁻¹) := by
         field_simp
-        nlinarith
+        nlinarith only [hp2R]
       have hlog : -2 ≤ (p : ℝ) * Real.log (1 - 1 / (p : ℝ)) :=
         hcalc.trans (mul_le_mul_of_nonneg_left hlog0 hpR.le)
       have hratio : Real.exp (-2) ≤ (1 - 1 / (p : ℝ)) ^ p := by

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
@@ -1130,7 +1130,9 @@ theorem bucket_exists_common_codeword
           (s := Finset.univ) (p := fun c => v₀ c = u₀ c)
         simp only [Finset.card_univ] at h_compl
         have : (Finset.filter (fun c => ¬v₀ c = u₀ c) Finset.univ).card = hammingDist u₀ v₀ := by
-          congr 1; ext c; simp [ne_eq, eq_comm]
+          unfold hammingDist
+          congr with c
+          exact not_congr eq_comm
         omega
       have hSx_eq_filter : S_x x hx = Finset.filter (fun c => v₀ c = u₀ c) Finset.univ :=
         Finset.eq_of_subset_of_card_le hSx_sub_filter (by

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/WeightedAgreement.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/WeightedAgreement.lean
@@ -375,13 +375,18 @@ lemma list_agreement_on_curve_implies_correlated_agreement_bound
       (l + 1 : ℝ) / S'.card <
         (l + 1 : ℝ) / ((S'.card : ℝ) - (l + 1 : ℝ)) := by
     rw [div_lt_div_iff₀ hcard_pos hgap_pos]
-    nlinarith
-  have hcancel : ((l + 1 : ℝ) / S'.card) * S'.card = l + 1 := by
-    field_simp
+    exact mul_lt_mul_of_pos_left (sub_lt_self _ (by positivity)) (by positivity)
   have hcommon_lower :
       (α : ℝ) - (l + 1 : ℝ) / S'.card ≤ mu_set μ common := by
-    nlinarith [hcore, hcancel]
-  exact lt_of_lt_of_le (by linarith [hfraction]) hcommon_lower
+    apply sub_le_iff_le_add.mpr
+    calc
+      (α : ℝ) = ((S'.card : ℝ) * (α : ℝ)) / S'.card := by
+        rw [mul_div_cancel_left₀ _ hcard_pos.ne']
+      _ ≤ ((S'.card : ℝ) * mu_set μ common + (l + 1 : ℝ)) / S'.card :=
+        div_le_div_of_nonneg_right hcore hcard_pos.le
+      _ = mu_set μ common + (l + 1 : ℝ) / S'.card := by
+        rw [add_div, mul_div_cancel_left₀ _ hcard_pos.ne']
+  exact lt_of_lt_of_le (sub_lt_sub_left hfraction _) hcommon_lower
 
 /-- Lemma 7.6 in [BCIKS20].
 This is the "integral-weight" strengthening of the list-agreement-on-a-curve =>
@@ -504,13 +509,13 @@ lemma sufficiently_large_list_agreement_on_curve_implies_correlated_agreement
     have hcast :
         (((M * Fintype.card ι + 1) * (l + 1) : ℕ) : ℝ) ≤ S'.card := by
       exact_mod_cast hS'_card₁
-    norm_num [Nat.cast_mul] at hcast ⊢
-    nlinarith
+    apply le_sub_iff_add_le.mpr
+    simpa only [Nat.cast_mul, Nat.cast_add, Nat.cast_one, add_mul, one_mul] using hcast
   have herror_le_grid :
       (l + 1 : ℝ) / ((S'.card : ℝ) - (l + 1 : ℝ)) ≤
         1 / ((M * Fintype.card ι : ℕ) : ℝ) := by
     rw [div_le_div_iff₀ hdenom_pos hd_pos]
-    nlinarith
+    simpa only [one_mul, mul_comm] using hdenom_large
   linarith
 
 end ListAgreementLemmas

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/Entropy.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/Entropy.lean
@@ -186,7 +186,7 @@ private theorem cs25OverlapSum_le_exp_two_sqrt
             intro ℓ hℓ
             positivity
           have hexp : 0 < Real.exp x := Real.exp_pos x
-          nlinarith
+          nlinarith only [hsum, hsum_nonneg, hexp]
     _ = Real.exp (2 * Real.sqrt ((f : ℝ) * (n - f : ℕ) / q)) := by
           rw [pow_two, ← Real.exp_add]
           congr 1
@@ -385,9 +385,9 @@ private theorem cs25_quadratic_entropy_gap_proof
     rw [cs25EntropyGapFn_deriv2_proof q y hy0 hy1]
     have hp : 0 < y * (1 - y) := mul_pos hy.1 (sub_pos.mpr hy1lt)
     have hquad : y * (1 - y) ≤ 1 / 4 := by
-      nlinarith [sq_nonneg (y - 1 / 2)]
+      nlinarith only [sq_nonneg (y - 1 / 2)]
     have hmul : 8 * (y * (1 - y)) < Real.log (q : ℝ) := by
-      nlinarith
+      nlinarith only [hquad, hloggt]
     have hdiv : 8 < Real.log (q : ℝ) / (y * (1 - y)) :=
       (lt_div_iff₀ hp).2 hmul
     linarith
@@ -421,15 +421,15 @@ private theorem cs25_shell_factor_lt_q
   apply (Real.sqrt_lt' hqR).2
   let x : ℝ := (f : ℝ) / n
   have hquad : x * (1 - x) ≤ 1 / 4 := by
-    nlinarith [sq_nonneg (x - 1 / 2)]
+    nlinarith only [sq_nonneg (x - 1 / 2)]
   have hmul : (n : ℝ) * (x * (1 - x)) ≤ (n : ℝ) * (1 / 4) :=
     mul_le_mul_of_nonneg_left hquad hnR.le
   have hA : 8 * (n : ℝ) * x * (1 - x) ≤ 2 * n := by
-    nlinarith
+    nlinarith only [hmul]
   have hnqR : (n : ℝ) ≤ q := by exact_mod_cast hnq
   have hq10R : (10 : ℝ) ≤ q := by exact_mod_cast hq
   dsimp [x] at hA ⊢
-  nlinarith
+  nlinarith only [hA, hnqR, hq10R]
 
 private theorem cs25_shell_power_bound
     (q n f : ℕ) (hq : 10 ≤ q) (hnq : n ≤ q)
@@ -1131,7 +1131,7 @@ private theorem rs_entropy_rate_d_le_kf_proof
       _ ≤ k := hkn
   have hreal : (n : ℝ) < 2 * ((k : ℝ) + f) := by
     field_simp [hnR.ne'] at hgap_scaled
-    nlinarith
+    nlinarith only [hgap_scaled, hkn', hs]
   have hnat : n < 2 * (k + f) := by exact_mod_cast hreal
   omega
 
@@ -1161,7 +1161,7 @@ private theorem rs_entropy_rate_parameter_facts
   have hslackR : (k : ℝ) + f + 2 ≤ n := by
     have h := mul_le_mul_of_nonneg_right hhi hnR.le
     field_simp at h
-    nlinarith
+    nlinarith only [h]
   have hslack : k + f + 2 ≤ n := by exact_mod_cast hslackR
   have hfpos : 0 < f := by
     by_contra hf
@@ -1169,7 +1169,7 @@ private theorem rs_entropy_rate_parameter_facts
     subst f
     simp only [Nat.cast_zero, zero_div, qEntropy_zero, sub_zero, one_div] at hlo hhi
     have htwo : (0 : ℝ) < 2 / n := div_pos (by norm_num) hnR
-    linarith
+    linarith only [hlo, hhi, htwo]
   have hflt : f < n := by omega
   let s : ℝ :=
     ((qEntropy q ((f : ℝ) / n) - (f : ℝ) / n) / (n : ℝ)) ^ ((1 : ℝ) / 2)
@@ -1184,10 +1184,10 @@ private theorem rs_entropy_rate_parameter_facts
   have hgap : 4 / (n : ℝ) + s ≤
       qEntropy q ((f : ℝ) / n) - (f : ℝ) / n := by
     rw [show 4 / (n : ℝ) = 2 / (n : ℝ) + 2 / (n : ℝ) by ring]
-    linarith [hcomp]
+    linarith only [hcomp]
   have hfour : (0 : ℝ) < 4 / n := div_pos (by norm_num) hnR
   have hdiff : 0 < qEntropy q ((f : ℝ) / n) - (f : ℝ) / n :=
-    lt_of_lt_of_le (by linarith : 0 < 4 / (n : ℝ) + s) hgap
+    lt_of_lt_of_le (by linarith only [hfour, hs_nonneg] : 0 < 4 / (n : ℝ) + s) hgap
   exact ⟨hslack, hfpos, hflt, hdiff⟩
 
 private theorem rs_entropy_rate_exponent_slack
@@ -1228,7 +1228,7 @@ private theorem rs_entropy_rate_exponent_slack
         (n : ℝ) * qEntropy q ((f : ℝ) / n) - f := by
     field_simp
   rw [hdcast, hrhs]
-  linarith
+  linarith only [hkn']
 
 private theorem rs_entropy_rate_full_parameter_facts_proof
     (q n k f : ℕ) (hq : 10 ≤ q) (hn : 0 < n)
@@ -1804,7 +1804,7 @@ private theorem cs25_overlap_exp_le_entropy_power_proof
   have hlogpos : 0 < Real.log (q : ℝ) := Real.log_pos (by exact_mod_cast hq2)
   have hh : 0 ≤ h := by
     have hleft : 0 < 4 * x * (1 - x) := by positivity
-    nlinarith [sq_nonneg (Real.log (q : ℝ))]
+    nlinarith only [hgap, hleft, sq_nonneg (Real.log (q : ℝ))]
   have hy_nonneg : 0 ≤ y := by dsimp [y]; positivity
   have hnum_nonneg : 0 ≤ (f : ℝ) * (n - f : ℕ) := by positivity
   have hy_le : y ≤ (n : ℝ) * x * (1 - x) := by
@@ -1821,7 +1821,7 @@ private theorem cs25_overlap_exp_le_entropy_power_proof
   have hsq_bound : 4 * y ≤
       (Real.log (q : ℝ)) ^ 2 * (n : ℝ) * h := by
     have hm := mul_le_mul_of_nonneg_left hgap hnR.le
-    nlinarith
+    nlinarith only [hm, hy_le]
   have hs_nonneg : 0 ≤ s := by
     dsimp [s]
     rw [← Real.sqrt_eq_rpow]
@@ -1929,7 +1929,7 @@ private theorem cs25_second_momentA_small_of_entropy_rate_proof
       (((n - f - k : ℕ) : ℝ) + (n : ℝ) * s + ((f + 2 : ℕ) : ℝ)) ≤
         (n : ℝ) * H := by
     norm_num at hexp ⊢
-    nlinarith
+    nlinarith only [hexp, hid]
   have hshell0 := cs25_entropy_shell_le_choose_proof q n f hq hn hfpos hflt
   have hshell :
       (q : ℝ) ^ ((n : ℝ) * H) ≤ (Nat.choose n f : ℝ) * B := by

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/Frs.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/Frs.lean
@@ -98,9 +98,9 @@ private theorem boosted_frs_radius_le_list_radius
   have htR3 : (3 : ℝ) ≤ t := by exact_mod_cast ht
   have htR : (0 : ℝ) < t := by nlinarith
   have hsR : (4 : ℝ) * (t : ℝ) ^ 2 < s := by exact_mod_cast hs
-  have ha : (0 : ℝ) < 2 * t - 1 := by nlinarith
+  have ha : (0 : ℝ) < 2 * t - 1 := by nlinarith only [htR3]
   have hb : (0 : ℝ) < t + 1 := by positivity
-  have hd : (0 : ℝ) < (s : ℝ) - t + 1 := by nlinarith
+  have hd : (0 : ℝ) < (s : ℝ) - t + 1 := by nlinarith only [hsR, htR3]
   rw [div_le_iff₀ ha]
   rw [div_mul_eq_mul_div]
   rw [div_mul_eq_mul_div]
@@ -112,10 +112,10 @@ private theorem boosted_frs_radius_le_list_radius
   have ht2 : (0 : ℝ) ≤ (t : ℝ) ^ 2 := sq_nonneg (t : ℝ)
   have ht3nonneg : (0 : ℝ) ≤ (t : ℝ) ^ 3 := by positivity
   have hc : (0 : ℝ) ≤ 3 * s * t - 2 * (t : ℝ) ^ 3 + 2 * t := by
-    nlinarith
+    nlinarith only [hgap_t, ht3nonneg, htR.le]
   have hbse : (0 : ℝ) ≤ s * t + 4 * s - (t : ℝ) ^ 2 - 3 * t + 4 := by
-    nlinarith [mul_nonneg hgap (show (0 : ℝ) ≤ t + 4 by positivity)]
-  nlinarith [mul_nonneg hR0 hc]
+    nlinarith only [mul_nonneg hgap (show (0 : ℝ) ≤ t + 4 by positivity), ht2, htR3]
+  nlinarith only [mul_nonneg hR0 hc, hbse]
 
 private theorem exists_finset_lift_image_eq_injOn
     {α β : Type} [DecidableEq α] [DecidableEq β]

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/JohnsonCa.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/JohnsonCa.lean
@@ -453,7 +453,7 @@ private theorem linear_bgks_numeric_setup
   let a : ℝ := 1 - (δ_min : ℝ) + (η : ℝ)
   have ha : 0 < a := by
     dsimp [a]
-    nlinarith
+    exact add_pos_of_nonneg_of_pos (sub_nonneg.mpr hdmin_le) heta
   let r : ℝ := a ^ ((1 : ℝ) / 3)
   have hr0 : 0 ≤ r := by
     exact Real.rpow_nonneg (le_of_lt ha) _
@@ -467,20 +467,21 @@ private theorem linear_bgks_numeric_setup
   have hcube : a < (1 - (δ_src : ℝ)) ^ 3 := by
     rw [← hrpow]
     exact pow_lt_pow_left₀ hr_lt hr0 (by norm_num)
-  have heta_lt_one : (η : ℝ) < 1 := by nlinarith
-  have heta_cube_lt : (η : ℝ) ^ 3 < (η : ℝ) := by
-    nlinarith [sq_pos_of_pos heta]
+  have heta_lt_one : (η : ℝ) < 1 := hη_lt_third.trans (by norm_num)
+  have heta_cube_lt : (η : ℝ) ^ 3 < (η : ℝ) :=
+    pow_lt_self_of_lt_one₀ heta heta_lt_one (by norm_num)
   have heta_le_a : (η : ℝ) ≤ a := by
     dsimp [a]
-    nlinarith
+    exact le_add_of_nonneg_left (sub_nonneg.mpr hdmin_le)
   have heta_lt_r : (η : ℝ) < r := by
     by_contra hnot
     have hr_le : r ≤ (η : ℝ) := le_of_not_gt hnot
     have hpow_le : r ^ 3 ≤ (η : ℝ) ^ 3 :=
       pow_le_pow_left₀ hr0 hr_le 3
-    nlinarith [hrpow, heta_cube_lt, heta_le_a]
+    rw [hrpow] at hpow_le
+    exact (not_lt_of_ge hpow_le) (heta_cube_lt.trans_le heta_le_a)
   refine ⟨hdmin_le, ha, hcube, ?_⟩
-  nlinarith [hr_lt, heta_lt_r]
+  simpa [add_comm] using (lt_sub_iff_add_lt.mp (heta_lt_r.trans hr_lt))
 
 private theorem linear_bgks_repeated_triples_card_le
     {α : Type} [Fintype α] [DecidableEq α] :
@@ -503,11 +504,14 @@ private theorem linear_bgks_repeated_triples_card_le
       simpa [R] using (Finset.mem_filter.mp hp).2
     rcases hrep with hxb | hxg | hbg
     · subst b
-      simp [E01, E02, E12]
+      exact Finset.mem_union.mpr (Or.inl (Finset.mem_union.mpr (Or.inl
+        (Finset.mem_image.mpr ⟨(x, g), Finset.mem_univ _, rfl⟩))))
     · subst g
-      simp [E01, E02, E12]
+      exact Finset.mem_union.mpr (Or.inl (Finset.mem_union.mpr (Or.inr
+        (Finset.mem_image.mpr ⟨(x, b), Finset.mem_univ _, rfl⟩))))
     · subst g
-      simp [E01, E02, E12]
+      exact Finset.mem_union.mpr (Or.inr
+        (Finset.mem_image.mpr ⟨(x, b), Finset.mem_univ _, rfl⟩))
   have hE01 : E01.card ≤ (Fintype.card α) ^ 2 := by
     calc
       E01.card ≤ (Finset.univ : Finset (α × α)).card := by
@@ -987,7 +991,22 @@ private theorem linear_bgks_distinct_dense_triples_card_gt
   have hneg : D.filter (fun p => ¬ P p) = B := by
     ext p
     simp only [B, P, Finset.mem_filter]
-    tauto
+    constructor
+    · rintro ⟨hp, hnot⟩
+      refine ⟨hp, ?_⟩
+      by_cases h01 : p.1 = p.2.1
+      · exact Or.inl h01
+      by_cases h02 : p.1 = p.2.2
+      · exact Or.inr (Or.inl h02)
+      by_cases h12 : p.2.1 = p.2.2
+      · exact Or.inr (Or.inr h12)
+      exact (hnot ⟨h01, h02, h12⟩).elim
+    · rintro ⟨hp, hrep⟩
+      refine ⟨hp, fun hall => ?_⟩
+      rcases hrep with h01 | h02 | h12
+      · exact hall.1 h01
+      · exact hall.2.1 h02
+      · exact hall.2.2 h12
   have hpartNat : (D.filter P).card + B.card = D.card := by
     rw [← hneg]
     exact Finset.card_filter_add_card_filter_not P
@@ -1002,8 +1021,13 @@ private theorem linear_bgks_distinct_dense_triples_card_gt
     exact Finset.mem_filter.mpr ⟨Finset.mem_univ p, hrep⟩
   have hR :
       (R.card : ℝ) ≤ 3 * (good.card : ℝ) ^ 2 := by
-    have h := linear_bgks_repeated_triples_card_le (α := α)
-    simpa [R, α] using h
+    have h :
+        (R.card : ℝ) ≤ 3 * (Fintype.card α : ℝ) ^ 2 := by
+      change (((Finset.univ.filter fun p : α × α × α =>
+        p.1 = p.2.1 ∨ p.1 = p.2.2 ∨ p.2.1 = p.2.2).card : ℝ)) ≤
+          3 * (Fintype.card α : ℝ) ^ 2
+      exact linear_bgks_repeated_triples_card_le (α := α)
+    simpa [α] using h
   have hB :
       (B.card : ℝ) ≤ 3 * (good.card : ℝ) ^ 2 := by
     have hcardNat : B.card ≤ R.card := Finset.card_le_card hBsub

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/Subfield.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/Subfield.lean
@@ -447,7 +447,7 @@ private theorem subfield_ca_reciprocal_stack_not_joint
   have hTcardNatR : ((Fintype.card ι -
       ⌊(δ : ℝ) * Fintype.card ι⌋₊ : ℕ) : ℝ) ≤ (T.card : ℝ) := by
     rw [Nat.cast_sub hf_le, hint]
-    nlinarith [hTcardR]
+    nlinarith only [hTcardR]
   have hTcardNat : Fintype.card ι - ⌊(δ : ℝ) * Fintype.card ι⌋₊ ≤ T.card := by
     exact_mod_cast hTcardNatR
   have hkT : k < T.card := by omega
@@ -1944,16 +1944,14 @@ private theorem subfield_ca_support_algebra
     hfirst.trans (mul_le_mul_of_nonneg_left hsecond hH)
   have hchainN := mul_le_mul_of_nonneg_right hchain hN.le
   field_simp [hN.ne'] at hchainN
-  have herror : H * A * G * N ≤ N * A * G * N := by
-    exact mul_le_mul_of_nonneg_right
-      (mul_le_mul_of_nonneg_right
-        (mul_le_mul_of_nonneg_right hHN hA.le) hG) hN.le
+  have herror : H * (N * G) ≤ N * (N * G) :=
+    mul_le_mul_of_nonneg_right hHN (mul_nonneg hN.le hG)
   have hcross : A * N ≤ H * A + N ^ 2 * G := by
-    nlinarith [hchainN, herror]
+    nlinarith only [hchainN, herror]
   apply (le_div_iff₀ hN).2
   apply le_of_mul_le_mul_right (a := A) ?_ hA
   field_simp [hA.ne']
-  nlinarith [hcross]
+  nlinarith only [hcross]
 
 open scoped BigOperators in
 private theorem subfield_ca_support_card_eq_sum_good_scalars
@@ -2391,7 +2389,8 @@ private theorem subfield_radius_parameter_facts
   have hδ_one : (δ : ℝ) < 1 :=
     lt_of_lt_of_le hδ_lt (sub_le_self 1 hkdiv_nonneg)
   have hδR_pos : (0 : ℝ) < δ := by exact_mod_cast hδ_pos
-  have hkdiv_lt : (k : ℝ) / Fintype.card ι < 1 := by linarith
+  have hkdiv_lt : (k : ℝ) / Fintype.card ι < 1 := by
+    linarith only [hδ_lt, hδR_pos]
   have hkR : (k : ℝ) < Fintype.card ι :=
     (div_lt_one hnR).mp hkdiv_lt
   have hk : k < Fintype.card ι := by exact_mod_cast hkR
@@ -2399,7 +2398,8 @@ private theorem subfield_radius_parameter_facts
     rw [h_int]
     exact mul_pos hδR_pos hnR
   have hf : 0 < ⌊(δ : ℝ) * Fintype.card ι⌋₊ := by exact_mod_cast hfR
-  have hadddiv : (δ : ℝ) + (k : ℝ) / Fintype.card ι < 1 := by linarith
+  have hadddiv : (δ : ℝ) + (k : ℝ) / Fintype.card ι < 1 := by
+    linarith only [hδ_lt]
   have hquot :
       ((k : ℝ) + (δ : ℝ) * Fintype.card ι) / Fintype.card ι < 1 := by
     calc

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/UniqueDecoding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/UniqueDecoding.lean
@@ -240,10 +240,10 @@ private theorem bchks_parameter_facts_of_target_hypotheses
   have hscaled := mul_le_mul_of_nonneg_right hud' (le_of_lt hnR_pos)
   have hscaled' : 2 * (δ : ℝ) * n + k + 2 ≤ n := by
     field_simp [hnR_ne] at hscaled ⊢
-    nlinarith [hscaled]
+    linarith only [hscaled]
   have hmargin : k + 2 * e + 2 ≤ n := by
     exact_mod_cast
-      (by nlinarith [heR, hscaled'] : (k : ℝ) + 2 * (e : ℝ) + 2 ≤ n)
+      (by linarith only [heR, hscaled'] : (k : ℝ) + 2 * (e : ℝ) + 2 ≤ n)
   have hgap_pos : 0 < gap := by
     dsimp [gap]
     omega
@@ -1305,7 +1305,7 @@ private theorem affine_many_close_implies_joint_proximity {ι K : Type} [Fintype
   have hgapn :
       (good.card : ℝ) * ((δ_fld : ℝ) * Fintype.card ι) <
         ((good.card : ℝ) - 1) * ((δ_int : ℝ) * Fintype.card ι) := by
-    nlinarith [mul_lt_mul_of_pos_right hgap hnR_pos]
+    simpa only [mul_assoc] using mul_lt_mul_of_pos_right hgap hnR_pos
   have hprod :
       ((good.card : ℝ) - 1) * (D.card : ℝ) <
         ((good.card : ℝ) - 1) * ((δ_int : ℝ) * Fintype.card ι) :=

--- a/ArkLib/Data/CodingTheory/SubspaceDesign.lean
+++ b/ArkLib/Data/CodingTheory/SubspaceDesign.lean
@@ -232,7 +232,8 @@ theorem subspaceDesign_tau_lower_of_ne_bot
         rw [eq_bot_iff]
         rintro y ⟨hyA, hyk⟩
         obtain ⟨c, rfl⟩ := Submodule.mem_span_singleton.mp hyA
-        have hc0 : c • a i = 0 := by simpa [LinearMap.mem_ker] using hyk
+        change c • a i = 0 at hyk
+        have hc0 : c • a i = 0 := hyk
         rcases smul_eq_zero.mp hc0 with hc | hzero
         · simp [hc]
         · exact absurd hzero hai

--- a/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
@@ -550,44 +550,37 @@ lemma sqFoldMapGen_eq_sqFoldMapGen_of_pow_apply_eq_pow_apply [NeZero n] {i : ℕ
   sqFoldMapGen (i := i) j = sqFoldMapGen j' :=
   CosetFftDomainClass.injective (subdomain ω i) <| by simp_all
 
-private lemma subdomain_embed_comp {k : ℕ} (hk : k + 1 ≤ n)
-    (a : Fin (2 ^ (n - k - 1)))
-    (i : Fin (2 ^ (n - (k + 1)))) (hai : (a : ℕ) = (i : ℕ)) :
+private lemma subdomain_embed_comp {k j : ℕ} (hk : k + j ≤ n)
+    (a : Fin (2 ^ (n - k - j)))
+    (i : Fin (2 ^ (n - (k + j)))) (hai : (a : ℕ) = (i : ℕ)) :
     CosetFftDomainClass.subdomain_embed (n := n) k
-        (CosetFftDomainClass.subdomain_embed (n := n - k) 1 a) =
-        CosetFftDomainClass.subdomain_embed (n := n) (k + 1) i := by
+        (CosetFftDomainClass.subdomain_embed (n := n - k) j a) =
+        CosetFftDomainClass.subdomain_embed (n := n) (k + j) i := by
   ext
-  by_cases hk1 : k + 1 = n
-  · have hnk : n - k = 1 := by omega
-    simp only [CosetFftDomainClass.subdomain_embed, hnk, ge_iff_le,
-      show ¬n ≤ k by omega, show n ≤ k + 1 by omega, le_refl,
+  by_cases hkj : k + j = n
+  · simp only [CosetFftDomainClass.subdomain_embed, ge_iff_le,
+      show n - k ≤ j by omega, show n ≤ k + j by omega,
       ↓reduceDIte, Fin.val_zero, mul_zero]
-  · have hk1' : k + 1 < n := by omega
-    simp only [CosetFftDomainClass.subdomain_embed, ge_iff_le,
-      show ¬n ≤ k by omega, show ¬n ≤ k + 1 by omega, show ¬n - k ≤ 1 by omega,
-      ↓reduceDIte, Fin.val_mk, pow_one]
-    rw [hai, pow_succ]
-    ring
+    by_cases hnk : n ≤ k
+    · simp only [hnk, ↓reduceDIte, Fin.val_zero]
+    · simp only [hnk, ↓reduceDIte]
+  · simp only [CosetFftDomainClass.subdomain_embed, ge_iff_le,
+      show ¬n ≤ k by omega, show ¬n ≤ k + j by omega, show ¬n - k ≤ j by omega,
+      ↓reduceDIte, Fin.val_mk]
+    rw [hai, pow_add]
+    ring_nf
 
-/-- Composing the `k`th subdomain with one more folding step gives the `(k+1)`th subdomain
-  (pointwise, under the index identification `n - k - 1 = n - (k + 1)`). -/
+/-- Taking the `j`th subdomain of the `k`th subdomain gives the `(k + j)`th subdomain
+pointwise, under the canonical index identification. -/
 lemma subdomain_comp
   {k j : ℕ} (hk : k + j ≤ n)
   {a : Fin (2 ^ (n - k - j))} {i : Fin (2 ^ (n - (k + j)))}
   (hai : a.val = i.val) :
   subdomain (subdomain ω k) j a = subdomain ω (k + j) i := by
-  by_cases h : n ≤ k <;> by_cases h' : n - k ≤ j
-  · have hk : k = n := by omega
-    have hj : j = 0 := by omega
-    simp_all [subdomain_apply, mkSubgroupUnit, CosetFftDomainClass.subdomain_embed]
-  · simp_all
-  · have : n = k + j := by omega
-    simp_all [subdomain_apply, mkSubgroupUnit, CosetFftDomainClass.subdomain_embed,
-      pow_add, pow_mul]
-  · aesop
-      (add simp [subdomain_apply, mkSubgroupUnit, CosetFftDomainClass.subdomain_embed])
-      (add unsafe (by ring_nf))
-      (add safe [(by omega), (by grind)])
+  simp only [subdomain_apply, mkSubgroupUnit]
+  rw [subdomain_embed_comp hk a i hai]
+  simp only [CosetFftDomainClass.subdomain_embed_zero, pow_add, pow_mul]
+  field_simp
 
 @[simp]
 theorem mem_subdomain_comp_iff_mem

--- a/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
+++ b/ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean
@@ -217,73 +217,48 @@ private lemma fin_nsmul_val {m : ℕ} (k : ℕ) (a : Fin (2 ^ m)) :
 private lemma subdomain_embed_val {i : ℕ} (hi : i < n) (k : Fin (2 ^ (n - i))) :
   (CosetFftDomainClass.subdomain_embed (n := n) i k).val = 2 ^ i * k.val := by grind +locals
 
+/-- Evaluation in a subdomain commutes with the corresponding power map. -/
+private lemma subdomain_eval_pow_core {i j : ℕ} (hij : i + j ≤ n)
+    (k : Fin (2 ^ (n - i))) :
+    ((subdomain ω i) k) ^ (2 ^ j) =
+      (subdomain ω (i + j)) ⟨k.val % 2 ^ (n - (i + j)), Nat.mod_lt _ (Nat.two_pow_pos _)⟩ := by
+  have h_subdomain_embedding :
+    2 ^ j • (CosetFftDomainClass.subdomain_embed (n := n) i k) =
+      CosetFftDomainClass.subdomain_embed (n := n) (i + j) ⟨k.val % 2 ^ (n - (i + j)),
+    Nat.mod_lt _ (by positivity)⟩ := by
+    all_goals generalize_proofs at *
+    have h_subdomain_embedding :
+      (2 ^ j • (CosetFftDomainClass.subdomain_embed (n := n) i k)).val =
+        (2 ^ (i + j) * (k.val % 2 ^ (n - (i + j)))) % 2 ^ n := by
+      rw [fin_nsmul_val]
+      by_cases hi : i < n
+      · rw [subdomain_embed_val hi k]
+        exact nat_mul_pow_mod hij
+      · simp_all only [not_lt, CosetFftDomainClass.subdomain_embed, ge_iff_le, ↓reduceDIte,
+        Fin.coe_ofNat_eq_mod, Nat.zero_mod, mul_zero]
+        norm_num [show i = n by linarith, show j = 0 by linarith]
+    rw [←Fin.val_inj]
+    simp_all only
+      [CosetFftDomainClass.subdomain_embed, ge_iff_le, smul_dite, nsmul_zero]
+    split_ifs <;> simp_all +decide only [Nat.sub_eq_zero_of_le, pow_zero, Order.lt_one_iff,
+      mul_zero, Order.lt_two_iff, pow_pos, Nat.mod_eq_of_lt, Fin.val_eq_zero_iff, dite_eq_left_iff,
+      not_le, Fin.coe_ofNat_eq_mod]
+    rw [Nat.mod_eq_of_lt]
+    exact lt_of_lt_of_le
+      (Nat.mul_lt_mul_of_pos_left ‹_› (pow_pos (by decide) _))
+      (by rw [←pow_add, Nat.add_sub_of_le (by linarith)])
+  rw [subdomain_apply, subdomain_apply, mul_pow, mkSubgroupUnit_pow,
+    h_subdomain_embedding]
+  congr 1
+  rw [← pow_mul, ← pow_add]
+
 /-- If `x` lies in the `j`th subdomain,
   then `x ^ 2 ^ i` lies in the `(j + i)`th subdomain, provided `j + i ≤ n`. -/
 theorem pow_mem_of_mem {i j : ℕ} (hsum : j + i ≤ n) (h : x ∈ subdomain ω j) :
   x ^ 2 ^ i ∈ subdomain ω (j + i) := by
-  obtain ⟨k, hk⟩ :
-    ∃ k : Fin (2 ^ (n - j)), x =
-      (mkSubgroupUnit ω (CosetFftDomainClass.subdomain_embed j k) : F) * (ω 0) ^ 2 ^ j := by
-    obtain ⟨k, rfl⟩ := h
-    exact ⟨k, mul_comm _ _⟩
-  have hx_pow :
-    x ^ 2 ^ i =
-      ((ω 0) ^ 2 ^ (j + i)) *
-        (mkSubgroupUnit ω (2 ^ i • CosetFftDomainClass.subdomain_embed j k) : F) := by
-    convert congr_arg (· ^ 2 ^ i) hk using 1
-    ring_nf
-    simp [←mkSubgroupUnit_pow]
-  have h_mod :
-    (2 ^ i • CosetFftDomainClass.subdomain_embed j k).val =
-      (2 ^ (j + i) *
-        (k.val % 2 ^ (n - (j + i)))) % 2 ^ n := by
-    have h_mod :
-      (2 ^ i • CosetFftDomainClass.subdomain_embed j k).val =
-        (2 ^ i *
-          (CosetFftDomainClass.subdomain_embed j k).val) % 2 ^ n := by
-      convert fin_nsmul_val _ _
-    by_cases hj : j < n
-    · simp_all only [CosetFftDomainClass.subdomain_embed, ge_iff_le, smul_dite, nsmul_zero]
-      split_ifs
-      · simp_all only [Fin.coe_ofNat_eq_mod, Nat.zero_mod, mul_zero]
-        linarith
-      · simp_all only [↓reduceDIte, pow_add, mul_assoc]
-        convert nat_mul_pow_mod (show j + i ≤ n from hsum) using 1
-        ring_nf
-    · have : n = j := by linarith
-      aesop
-        (add simp [CosetFftDomainClass.subdomain_embed, Nat.mod_one])
-  have h_subdomain :
-    (CosetFftDomainClass.subdomain_embed
-      (n := n) (j + i) ⟨k.val % 2 ^ (n - (j + i)),
-    Nat.mod_lt _ (by positivity)⟩).val =
-    2 ^ (j + i) * (k.val % 2 ^ (n - (j + i))) := by
-    by_cases hi : j + i ≥ n
-      <;> aesop
-            (add simp [CosetFftDomainClass.subdomain_embed, Nat.mod_one])
-            (add safe (by grind))
-  generalize_proofs at *
-  have h_eq :
-    2 ^ i • CosetFftDomainClass.subdomain_embed j k =
-      CosetFftDomainClass.subdomain_embed
-        (j + i) ⟨k.val % 2 ^ (n - (j + i)), by assumption⟩ := Fin.ext <| by
-      simpa [Nat.mod_eq_of_lt (show 2 ^ (j + i) * (k.val % 2 ^ (n - (j + i))) <
-        2 ^ n from lt_of_lt_of_le
-          (Nat.mul_lt_mul_of_pos_left ‹_› (pow_pos (by decide) _))
-          (by rw [← pow_add, Nat.add_sub_of_le hsum]))]
-      using h_mod.trans <| h_subdomain.symm ▸
-        Nat.mod_eq_of_lt
-          (show 2 ^ (j + i) * (k.val % 2 ^ (n - (j + i))) < 2 ^ n from
-            lt_of_lt_of_le
-              (Nat.mul_lt_mul_of_pos_left ‹_› (pow_pos (by decide) _))
-              (by rw [← pow_add, Nat.add_sub_of_le hsum]))
-  generalize_proofs at *
-  use Multiplicative.ofAdd ⟨k.val % 2 ^ (n - (j + i)), by assumption⟩
-  generalize_proofs at *
-  convert hx_pow.symm using 1
-  exact Eq.symm
-    (Mathlib.Tactic.CancelDenoms.derive_trans₂
-      rfl (congrArg Units.val (congrArg (mkSubgroupUnit ω) h_eq)) rfl)
+  obtain ⟨k, rfl⟩ := h
+  refine ⟨Multiplicative.ofAdd ⟨k.val % 2 ^ (n - (j + i)), Nat.mod_lt _ (by positivity)⟩, ?_⟩
+  exact (subdomain_eval_pow_core (ω := ω) (i := j) (j := i) hsum k).symm
 
 /-- If `x` lies in the original domain, then `x ^ 2 ^ i` lies in the `i`th subdomain. -/
 lemma pow_mem_subdomain_of_mem_subdomain_0 {i : ℕ} (hi : i ≤ n)
@@ -337,35 +312,7 @@ private lemma subdomain_eval_pow' {i j : ℕ} (hij : i + j ≤ n)
     (k : Fin (2 ^ (n - i))) :
     ((subdomain ω i) k) ^ (2 ^ j) =
       (subdomain ω (i + j)) ⟨k.val % 2 ^ (n - (i + j)), Nat.mod_lt _ (Nat.two_pow_pos _)⟩ := by
-  have h_subdomain_embedding :
-    2 ^ j • (CosetFftDomainClass.subdomain_embed (n := n) i k) =
-      CosetFftDomainClass.subdomain_embed (n := n) (i + j) ⟨k.val % 2 ^ (n - (i + j)),
-    Nat.mod_lt _ (by positivity)⟩ := by
-    all_goals generalize_proofs at *
-    have h_subdomain_embedding :
-      (2 ^ j • (CosetFftDomainClass.subdomain_embed (n := n) i k)).val =
-        (2 ^ (i + j) * (k.val % 2 ^ (n - (i + j)))) % 2 ^ n := by
-      rw [fin_nsmul_val]
-      by_cases hi : i < n
-      · simp_all only [CosetFftDomainClass.subdomain_embed, ge_iff_le]
-        grind +suggestions
-      · simp_all only [not_lt, CosetFftDomainClass.subdomain_embed, ge_iff_le, ↓reduceDIte,
-        Fin.coe_ofNat_eq_mod, Nat.zero_mod, mul_zero]
-        norm_num [show i = n by linarith, show j = 0 by linarith]
-    rw [←Fin.val_inj]
-    simp_all only
-      [CosetFftDomainClass.subdomain_embed, ge_iff_le, smul_dite, nsmul_zero]
-    split_ifs <;> simp_all +decide only [Nat.sub_eq_zero_of_le, pow_zero, Order.lt_one_iff,
-      mul_zero, Order.lt_two_iff, pow_pos, Nat.mod_eq_of_lt, Fin.val_eq_zero_iff, dite_eq_left_iff,
-      not_le, Fin.coe_ofNat_eq_mod]
-    rw [Nat.mod_eq_of_lt]
-    exact lt_of_lt_of_le
-      (Nat.mul_lt_mul_of_pos_left ‹_› (pow_pos (by decide) _))
-      (by rw [←pow_add, Nat.add_sub_of_le (by linarith)])
-  rw [subdomain_apply, subdomain_apply, mul_pow, mkSubgroupUnit_pow,
-    h_subdomain_embedding]
-  congr 1
-  rw [← pow_mul, ← pow_add]
+  exact subdomain_eval_pow_core hij k
 
 private lemma card_fin_filter_mod_eq {a j : ℕ} (hj : j ≤ a) (c : ℕ) (hc : c < 2 ^ (a - j)) :
   (Finset.univ.filter (fun k : Fin (2 ^ a) => k.val % 2 ^ (a - j) = c)).card = 2 ^ j := by

--- a/ArkLib/Data/Polynomial/FoldingPolynomial.lean
+++ b/ArkLib/Data/Polynomial/FoldingPolynomial.lean
@@ -127,6 +127,22 @@ private lemma folding_polynomial_def_base_case {q f : F[X]}
       simp [map_C, folding_polynomial_C_q])
   rw [folding_polynomial_eq_map_of_f_degree_lt_q_degree h]
 
+private lemma natDegree_div_eq_sub_of_degree_le {q f : F[X]}
+    (hq : q ≠ 0) (hdeg : q.degree ≤ f.degree) :
+    (f / q).natDegree = f.natDegree - q.natDegree := by
+  have hdiv : f / q ≠ 0 :=
+    mt (Polynomial.div_eq_zero_iff hq).mp (not_lt_of_ge hdeg)
+  have hadd := Polynomial.degree_add_div hq hdeg
+  rw [Polynomial.degree_eq_natDegree hq,
+    Polynomial.degree_eq_natDegree hdiv] at hadd
+  have hf : f ≠ 0 := by
+    intro hf
+    subst f
+    exact hq (Polynomial.degree_eq_bot.mp (bot_unique hdeg))
+  rw [Polynomial.degree_eq_natDegree hf] at hadd
+  norm_cast at hadd
+  omega
+
 private lemma folding_polynomial_aux_natDegree_fuel_is_enough {q f : F[X]} {fuel : ℕ}
   (h : f.natDegree ≤ fuel) :
   foldingPolynomialAux q f f.natDegree = foldingPolynomialAux q f fuel := by
@@ -224,11 +240,8 @@ private lemma folding_polynomial_def_ind_case {q f : F[X]}
               = foldingPolynomialAux q (f / q) (deg - 1) := by
             have h_deg : (f / q).natDegree ≤ deg - 1 := by
               have h_deg : (f / q).natDegree ≤ f.natDegree - q.natDegree := by
-                rw [Polynomial.div_def]
-                rw [Polynomial.natDegree_C_mul, Polynomial.natDegree_divByMonic]
-                · rw [Polynomial.natDegree_mul'] <;> aesop
-                · exact Polynomial.monic_mul_leadingCoeff_inv (by aesop)
-                · aesop
+                rw [natDegree_div_eq_sub_of_degree_le
+                  (Polynomial.ne_zero_of_degree_gt h₂) h₁]
               exact le_trans h_deg (Nat.sub_le_sub_right hdeg _)
                 |> le_trans
                 <| Nat.sub_le_sub_left (Polynomial.natDegree_pos_iff_degree_pos.mpr h₂) _
@@ -273,13 +286,12 @@ lemma eq_zero_of_folding_polynomial_eq_zero {q f : F[X]}
           refine
             ⟨Polynomial.natDegree (f / q),
             by {
-              have h_deg_f : f.natDegree = q.natDegree + (f / q).natDegree := by
-                rw [←Polynomial.natDegree_mul']
-                · rw [EuclideanDomain.mul_div_cancel'] <;> aesop
-                · aesop
-              linarith [
-                Polynomial.natDegree_pos_iff_degree_pos.mpr h₁.2.1,
-                Polynomial.natDegree_pos_iff_degree_pos.mpr h₁.2.2]
+              rw [natDegree_div_eq_sub_of_degree_le
+                (Polynomial.ne_zero_of_degree_gt h₁.2.2) h₁.1]
+              rw [← n]
+              exact Nat.sub_lt
+                (Polynomial.natDegree_pos_iff_degree_pos.mpr h₁.2.1)
+                (Polynomial.natDegree_pos_iff_degree_pos.mpr h₁.2.2)
             },
             f / q,
             by simp_all +decide,
@@ -348,20 +360,17 @@ lemma substitution_property_of_folding_polynomial {q f : F[X]} :
           (Polynomial.map q.compRingHom
             (foldingPolynomial q (f / q))) = f / q := by
         convert ih (Polynomial.natDegree (f / q)) _ rfl using 1
-        rw [←n, Polynomial.div_def]
-        rw [Polynomial.natDegree_C_mul, Polynomial.natDegree_divByMonic] <;> norm_num
-        · by_cases hq : q = 0
-            <;> simp_all only [not_or, not_lt, not_le, Polynomial.map_add, Polynomial.map_mul,
-              map_C, coe_compRingHom, X_comp, eval_add, eval_mul, eval_C, add_left_inj,
-              leadingCoeff_C, ne_eq, leadingCoeff_eq_zero, not_false_eq_true, mul_inv_cancel₀,
-              one_ne_zero, natDegree_mul',
-              natDegree_C, add_zero, degree_zero, not_lt_bot, bot_le, or_true, not_true_eq_false]
-          exact ⟨n.symm
-            ▸ Polynomial.natDegree_pos_iff_degree_pos.mpr
-              h_deg.2.1,
-            Polynomial.natDegree_pos_iff_degree_pos.mpr h_deg.2.2⟩
-        · exact Polynomial.monic_mul_leadingCoeff_inv (by aesop)
-        · aesop
+        have hqpos : 0 < q.degree :=
+          lt_of_not_ge fun h => h_deg (Or.inr (Or.inr h))
+        have hfpos : 0 < f.degree :=
+          lt_of_not_ge fun h => h_deg (Or.inr (Or.inl h))
+        have hqle : q.degree ≤ f.degree :=
+          le_of_not_gt fun h => h_deg (Or.inl h)
+        rw [←n, natDegree_div_eq_sub_of_degree_le
+          (Polynomial.ne_zero_of_degree_gt hqpos) hqle]
+        exact Nat.sub_lt
+          (Polynomial.natDegree_pos_iff_degree_pos.mpr hfpos)
+          (Polynomial.natDegree_pos_iff_degree_pos.mpr hqpos)
       rw [
         ‹Polynomial.eval Polynomial.X
           (Polynomial.map q.compRingHom
@@ -433,19 +442,12 @@ theorem folding_polynomial_deg_y_bound {q f : F[X]} (h : 0 < q.degree) :
     }) (by {
       apply lt_of_le_of_lt (Polynomial.natDegree_C_mul_le _ _)
       apply ih _ _ h rfl
-      rw [←n, Polynomial.div_def]
-      rw [
-        Polynomial.natDegree_C_mul,
-        Polynomial.natDegree_divByMonic]
-          <;> norm_num [
-            Polynomial.natDegree_mul',
-            Polynomial.natDegree_C, show q ≠ 0 by aesop]
-      · simp only [not_lt] at hq
-        exact
-          ⟨Polynomial.natDegree_pos_iff_degree_pos.mpr
-            (lt_of_lt_of_le h hq),
-            Polynomial.natDegree_pos_iff_degree_pos.mpr h⟩
-      · exact Polynomial.monic_mul_leadingCoeff_inv (by aesop)
+      have hqle : q.degree ≤ f.degree := le_of_not_gt hq
+      rw [←n, natDegree_div_eq_sub_of_degree_le
+        (Polynomial.ne_zero_of_degree_gt h) hqle]
+      exact Nat.sub_lt
+        (Polynomial.natDegree_pos_iff_degree_pos.mpr (lt_of_lt_of_le h hqle))
+        (Polynomial.natDegree_pos_iff_degree_pos.mpr h)
     }))
 
 /-- The degree of `foldingPolynomial` is less than `k` in the second variable,
@@ -542,9 +544,12 @@ theorem folding_polynomial_deg_x {q f : F[X]} :
           folding_polynomial_deg_x_base h₁
         have h_deg_zero : f.natDegree < q.natDegree := by
           by_cases hf : f = 0
-            <;> by_cases hq : q = 0
-            <;> simp_all +decide [Polynomial.degree_eq_natDegree]
-          aesop
+          · simp [hf, Polynomial.natDegree_pos_iff_degree_pos.mpr h]
+          · rcases h₁ with hlt | hle | hqle
+            · exact Polynomial.natDegree_lt_natDegree hf hlt
+            · rw [Polynomial.natDegree_eq_zero_iff_degree_le_zero.mpr hle]
+              exact Polynomial.natDegree_pos_iff_degree_pos.mpr h
+            · exact (not_lt_of_ge hqle h).elim
         rw [Nat.div_eq_of_lt] <;> aesop
       · have h_deg :
           degreeX (foldingPolynomial q f) = 1 + degreeX (foldingPolynomial q (f / q)) := by
@@ -552,11 +557,9 @@ theorem folding_polynomial_deg_x {q f : F[X]} :
           · exact le_of_not_gt fun h₂ ↦ h₁ <| Or.inl h₂
           · exact h
         have h_deg_f_div_q : (f / q).natDegree = f.natDegree - q.natDegree := by
-          rw [Polynomial.div_def]
-          rw [Polynomial.natDegree_C_mul, Polynomial.natDegree_divByMonic]
-          · rw [Polynomial.natDegree_mul'] <;> aesop
-          · exact Polynomial.monic_mul_leadingCoeff_inv (Polynomial.ne_zero_of_degree_gt h)
-          · aesop
+          exact natDegree_div_eq_sub_of_degree_le
+            (Polynomial.ne_zero_of_degree_gt h)
+            (le_of_not_gt fun h' => h₁ (Or.inl h'))
         rw [h_deg, ih _ _ h h_deg_f_div_q]
         · rw [←n, Nat.add_comm]
           rw [
@@ -787,18 +790,14 @@ lemma folded_poly_degree_bound {Q : F[X][Y]} {q : F[X]} {t : ℕ}
             Function.comp_apply, monic_X_pow, Monic.leadingCoeff, mul_one, leadingCoeff_eq_zero,
             not_false_eq_true, natDegree_mul', natDegree_comp, natDegree_pow, natDegree_X]
           by_contra h_contra
-          exact hij
-            (by nlinarith
-                [show Polynomial.natDegree (Q.coeff i)
-                    = Polynomial.natDegree (Q.coeff j)
-                      by nlinarith
-                        [show i < q.natDegree
-                          from lt_of_le_of_lt
-                          (Polynomial.le_natDegree_of_ne_zero (by aesop)) h_y,
-                          show j < q.natDegree
-                          from lt_of_le_of_lt
-                            (Polynomial.le_natDegree_of_ne_zero
-                              (by aesop)) h_y]])
+          have hiq : i < q.natDegree := lt_of_le_of_lt
+            (Polynomial.le_natDegree_of_ne_zero (by aesop)) h_y
+          have hjq : j < q.natDegree := lt_of_le_of_lt
+            (Polynomial.le_natDegree_of_ne_zero (by aesop)) h_y
+          have hcoeff : Polynomial.natDegree (Q.coeff i) =
+              Polynomial.natDegree (Q.coeff j) := by
+            nlinarith only [h_contra, hiq, hjq]
+          exact hij (by nlinarith only [h_contra, hcoeff])
     · aesop
   contrapose! h_x
   rw [h, folding_polynomial_deg_x]

--- a/ArkLib/Data/Polynomial/Indicator.lean
+++ b/ArkLib/Data/Polynomial/Indicator.lean
@@ -36,6 +36,14 @@ noncomputable def indicator (pos neg : Finset F) : F[X] :=
   Lagrange.interpolate (pos ∪ neg) id
     (fun x ↦ if x ∈ pos then 1 else 0)
 
+private lemma indicator_eval_of_mem_union {pos neg : Finset F} {x : F}
+    (hx : x ∈ pos ∪ neg) :
+    (indicator pos neg).eval x = if x ∈ pos then 1 else 0 := by
+  unfold indicator
+  simpa only [id_eq] using
+    Lagrange.eval_interpolate_at_node (fun y : F => if y ∈ pos then 1 else 0)
+      Function.injective_id.injOn hx
+
 /-- The indicator polynomial is a constant zero polynomial
   if the set `pos` is empty.
 
@@ -50,79 +58,44 @@ lemma indicator_eq_1_of_neg_empty_empty_of_pos_nonempty
   {pos : Finset F}
   (h_pos : pos.Nonempty) :
   indicator pos ∅ = 1 := by
-  unfold indicator
   rw [Finset.nonempty_iff_ne_empty] at h_pos
   apply Polynomial.eq_of_degree_sub_lt_of_eval_finset_eq (pos ∪ ∅) _ _
   · apply lt_of_le_of_lt (Polynomial.degree_sub_le _ _) (max_lt _ _)
-    · convert Lagrange.degree_interpolate_lt _ _
+    · unfold indicator
+      convert Lagrange.degree_interpolate_lt _ _
       aesop
     · simpa using Finset.card_pos.mpr (Finset.nonempty_of_ne_empty h_pos)
-  · have {x} {y} (hy : y ∈ pos.erase x) :
-      (x - y)⁻¹ * (x - y) = 1 :=
-        inv_mul_cancel₀ (sub_ne_zero_of_ne (by aesop))
-    aesop
-      (add simp
-        [Polynomial.eval_prod,
-          Finset.prod_eq_zero_iff,
-          Lagrange.basis,
-          Lagrange.basisDivisor,
-          Finset.prod_eq_one])
-      (add safe [(by rw
-        [Polynomial.eval_finsetSum,
-        Finset.sum_eq_single x])])
+  · intro x hx
+    have hxpos : x ∈ pos := by simpa using hx
+    have heval := indicator_eval_of_mem_union (pos := pos) (neg := ∅) hx
+    simpa [hxpos] using heval
 
 /-- If `pos` is non-empty then the indicator polynomial is the constant
   zero polynomial. -/
 lemma indicator_ne_zero_of_pos_nonempty {pos neg : Finset F}
   (h : pos.Nonempty) :
   indicator pos neg ≠ 0 := by
-  unfold indicator
-  intro contra
+  intro hzero
   obtain ⟨x, hx⟩ := h
-  have := congr_arg (Polynomial.eval x) contra
-  simp only [Lagrange.interpolate_apply, MonoidWithZeroHom.map_ite_one_zero, ite_mul, one_mul,
-    zero_mul, Finset.sum_ite_mem, Finset.union_inter_cancel_left, eval_zero] at this
-  rw [Polynomial.eval_finsetSum, Finset.sum_eq_single x] at this
-    <;> aesop
-    (add simp
-      [Lagrange.basis,
-       sub_eq_zero,
-       Finset.prod_eq_zero_iff,
-       Finset.mem_erase_of_ne_of_mem,
-       Finset.mem_union_left,
-       Lagrange.basisDivisor,
-       Polynomial.eval_prod])
-    (add safe (by apply Finset.prod_eq_zero))
+  have heval := indicator_eval_of_mem_union (neg := neg) (Finset.mem_union_left neg hx)
+  rw [if_pos hx, hzero, eval_zero] at heval
+  exact zero_ne_one heval
 
 /-- Indicator evaluated on an element of `pos` is equal to 1. -/
 lemma indicator_eq_1_on_pos {pos neg : Finset F} {x : F}
   (h_pos : x ∈ pos) :
   (indicator pos neg).eval x = 1 := by
-  unfold indicator
-  have {x} {y} (hy : y ∈ (pos ∪ neg).erase x) :
-    (x - y)⁻¹ * (x - y) = 1 :=
-      inv_mul_cancel₀ (sub_ne_zero_of_ne (by aesop))
-  rw [Polynomial.eval]
-  aesop
-      (add simp
-        [Polynomial.eval_prod,
-          Polynomial.eval₂_finsetSum,
-          Lagrange.basis,
-          Finset.prod_eq_zero_iff,
-          Lagrange.basis,
-          Lagrange.basisDivisor,
-          Finset.prod_eq_one])
-      (add safe [(by rw [Finset.sum_eq_single x])])
+  simpa [h_pos] using
+    indicator_eval_of_mem_union (neg := neg) (Finset.mem_union_left neg h_pos)
 
 /-- The indicator polynomial is zero on `neg \ pos`. -/
 lemma indicator_eq_0_on_neg_sub_pos {pos neg : Finset F} {x : F}
   (h_pos : x ∈ neg \ pos) :
   (indicator pos neg).eval x = 0 := by
-  have h_basis_zero : ∀ y ∈ pos, Polynomial.eval x (Lagrange.basis (pos ∪ neg) id y) = 0 := by
-    aesop
-      (add simp [Finset.mem_sdiff, Lagrange.basis, id_eq, eval_prod])
-      (add safe [(by rw [Finset.prod_eq_zero])])
-  aesop (add simp [indicator, Polynomial.eval_finsetSum, Finset.sum_eq_zero])
+  have hmem := Finset.mem_sdiff.mp h_pos
+  simpa [hmem.2] using
+    indicator_eval_of_mem_union (pos := pos) (neg := neg)
+      (Finset.mem_union_right pos hmem.1)
 
 /-- The degree of the indicator polynomial
   is less than `#(pos ∪ neg)`. -/

--- a/ArkLib/ProofSystem/Stir/Combine.lean
+++ b/ArkLib/ProofSystem/Stir/Combine.lean
@@ -330,7 +330,7 @@ private lemma combine_eq_flat'''
     simp only [block_start, Nat.succ_eq_add_one, block_size, sum_add_distrib, sum_const,
       smul_eq_mul, mul_comm, one_mul, add_tsub_cancel_left, mul_assoc, mul_left_comm,
       mul_eq_mul_left_iff]
-    rw [show filter _ _ = Finset.Iio i by aesop]
+    rw [show filter _ _ = Finset.Iio i by ext j; simp]
     aesop (add safe (by ring))
 
 omit [DecidableEq F] in

--- a/ArkLib/ProofSystem/Stir/Combine.lean
+++ b/ArkLib/ProofSystem/Stir/Combine.lean
@@ -287,7 +287,7 @@ private lemma combine_eq_flat''
       let k := l - block_start dstar degs i
       r ^ (i + ∑ j < i, (dstar - degs j)) *
         fs i x * (φ x * r) ^ k := by
-  aesop (add safe combine_eq_flat')
+  simpa only [ri] using combine_eq_flat' φ dstar r fs degs
 
 omit [DecidableEq F] in
 private lemma combine_eq_flat'''
@@ -344,14 +344,23 @@ private lemma combine_eq_flat_final
           let k := l - block_start dstar degs i
           fs i x * (φ x) ^ k) :=
   match m with
-  | 0 => by aesop (add simp Option.elim)
+  | 0 => by
+    have htotal : total_terms dstar degs = 0 := by simp [total_terms]
+    rw [combine_eq_flat, htotal]
+    simp [Option.elim]
+    rfl
   | Nat.succ m => by
     have h {l : Fin (total_terms dstar degs)} :
       Finset.max {j | block_start dstar degs j ≤ ↑l} =
         Finset.max' {j | block_start dstar degs j ≤ ↑l}
           block_start_filter_nonempty := by
-            aesop (add simp [Finset.max, Finset.max'])
-    aesop (add simp [Option.elim, combine_eq_flat'''])
+      aesop (add simp [Finset.max, Finset.max'])
+    rw [combine_eq_flat''' φ dstar r fs degs]
+    funext x
+    simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+    exact Finset.sum_congr rfl fun l _ ↦ by
+      rw [h]
+      rfl
 
 -- def DegCor
 

--- a/ArkLib/ProofSystem/Stir/Combine.lean
+++ b/ArkLib/ProofSystem/Stir/Combine.lean
@@ -457,9 +457,10 @@ lemma master_lemma
       exact WithBot.add_lt_add_right (by simp) (hv_deg i ⟨j, hj⟩)
     have hq_coincide :
       ∀ x ∈ S, q.eval (φ x) = (v i ⟨j + 1, h_fin⟩).eval (φ x) := by
-      aesop
-        (add simp [q])
-        (add safe (by ring_nf))
+      intro x hx
+      simp only [q, Polynomial.eval_mul, Polynomial.eval_X]
+      rw [hv_eval i ⟨j, hj⟩ x hx, hv_eval i ⟨j + 1, h_fin⟩ x hx]
+      ring
     have hq_coincide :=
       Polynomial.eq_of_eval_eq_degree
         (q := v i ⟨j + 1, h_fin⟩)
@@ -470,7 +471,7 @@ lemma master_lemma
           aesop
         ) (Finset.image φ S) (by {
           simp only [Nat.cast_id, ge_iff_le, Order.add_one_le_iff]
-          rw [Finset.card_image_of_injective _ (fun x y hxy ↦ by aesop)]
+          rw [Finset.card_image_of_injective _ φ.injective]
           have h : ↑(rate (code φ dstar)) + 1 / ↑(Fintype.card ι) < 1 - δ :=
             glorious_lemma
               (by simpa using hδLt)
@@ -490,7 +491,10 @@ lemma master_lemma
               hS_card
           norm_cast at h
         })
-        (by aesop)
+        (by
+          intro y hy
+          obtain ⟨x, hx, rfl⟩ := Finset.mem_image.mp hy
+          exact hq_coincide x hx)
     simp only [q] at hq_coincide
     rw [←hq_coincide] at ih
     simp only [Polynomial.degree_mul, Polynomial.degree_X, WithBot.coe_add, WithBot.coe_one] at ih
@@ -590,7 +594,7 @@ theorem combine_theorem
                 ext x
                 rw [Nat.sub_add_comm (hdegs x)]
               rw [show ∑ x, (dstar - degs x + 1) = total + 1 by
-                aesop (add simp [total_terms, block_size])]
+                simpa only [total_terms, block_size] using htotal]
               simp
             · exact lt_of_lt_of_le hProb <| le_of_eq <| by
                 congr
@@ -653,9 +657,9 @@ theorem combine_theorem
       have master_lemma :=
         @master_lemma _ _ _ _ hempty
           _ _ _ _ hdegs _
-          hδLt _ (by aesop) (v := v) (fs := fs)
-        (by aesop)
-        (by aesop)
+          hδLt _ hS_card (v := v) (fs := fs)
+          (fun i j => (hv i j).1)
+          (fun i j x hx => (hv i j).2 x hx)
       exists S
       simp only [ge_iff_le, hS_card, true_and]
       have hf : ∀ i, 0 < block_size dstar degs i := by simp [block_size]


### PR DESCRIPTION
## Summary

This PR aggressively refactors the Lean proofs behind ArkLib's remaining checking hotspots. It preserves the public mathematical surface while replacing broad proof search with shared structural lemmas, direct witnesses, closed-form identities, and tightly scoped arithmetic.

It now:

- materially reduces matched theorem elaboration time across STIR, coding-theory bounds, polynomial interpolation/folding, and coset-FFT subdomains;
- removes duplicated proof arguments by placing reusable private lemmas at their natural abstraction boundaries;
- keeps every directly measured changed module below 15 seconds in isolated target builds;
- makes no file splits, import broadening, resource-limit increases, executable-definition changes, or trust-boundary changes.

### Diff metadata

- Base: `112798ea47a74bd1ae8c3396cfd7837a28fcd164` (`main`)
- Head: `567853ba29770d1c0a0bec8e2b07d9030c08d818`
- Commits: 22
- Files changed: 19
- GitHub diff: 326 insertions, 338 deletions

## Motivation and measurement policy

The previous clean CI report still had a long tail of `ArkLib/Data` files between 20 and 34 seconds, plus STIR `Combine` at 34 seconds. Whole-build per-file wall times are useful but load-sensitive because Lake checks many files concurrently. The optimization metric in this PR is therefore matched direct elaboration of the actual declarations, with isolated target builds as a second check. File splitting does not count as an improvement.

Profiler A/B runs use the same source, dependencies, threshold, and local load where possible. The independent review gate repeated the security- and structure-sensitive measurements on quiet warmed runs.

## Selected theorem-level results

| Proof | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| STIR `master_lemma` | 8.660s | 3.259s | 62% |
| STIR `combine_theorem` | 9.850s | 5.053s | 49% |
| GS `numVars_eq_of_gt_one` | 10.769s | 4.918s | 54% |
| FRS radius arithmetic core | 8.182s | 2.589s | 68% |
| `rs_lambda_large_prime` | 5.317s | 2.532s | 52% |
| Johnson `sum_of_not_equals` consumer | 9.471s | 3.490s | 63% |
| Centers rounded-barrier core | 4.341s | 1.215s | 72% |
| Indicator nonzero / equals-one proofs | 3.734s / 3.642s | <0.010s / <0.010s | >99% |
| Folding substitution / `deg_x` | 1.469s / 2.638s | 0.185s / 1.200s | 87% / 55% |
| Coset subdomain composition | 3.392s | 0.335s | 90% |
| `pow_mem_of_mem` | 3.329s | <0.100s | >97% |
| private subdomain power evaluation | 4.110s | 0.671s shared core + <0.100s wrapper | >81% |
| Johnson-CA numeric setup | 3.205s | 1.324s | 59% |
| Entropy shell / second-moment arithmetic | 1.530s / 1.529s | 0.585s / 0.561s | 62% / 63% |
| `errorBound_ge_const` | 3.170s | 1.744s | 45% |

Representative isolated target-build times after the changes are: STIR `Combine` 7.2s, GS `Basic` 12s, `Frs` 9.8s, `UniqueDecoding` 6.4s, `AffineSpaces` 12s, Johnson lemmas 7.0s, `Subfield` 4.3s, `SubspaceDesign` 4.0s, `Entropy` 4.4s, `CS25` 5.1s, `WeightedAgreement` 4.5s, `Indicator` 1.6s, `FoldingPolynomial` 3.1s, and Coset FFT `Subdomain` 4.7s.

## Structural proof changes

### STIR composition

- Replaces broad flattening and image-witness searches with explicit interval extensionality and direct witnesses.
- Makes the master-polynomial evaluation recurrence explicit.
- Invokes the master lemma with named degree/evaluation projections instead of asking global automation to reconstruct them.

### Coding-theory bounds

- Uses the closed-form range sum in Guruswami–Sudan variable counting.
- Replaces nonlinear search with the exact ordered-field lemmas needed in FRS, unique decoding, weighted agreement, Reed–Solomon asymptotics, entropy, subfield, CS25, BCHKS25, and divergence bounds.
- Constructs Johnson and Johnson-CA pair/triple witnesses directly.
- Makes affine-space filter and subspace-design kernel equalities explicit.
- Refactors the Centers moment/barrier proof around monotone multiplication and direct ring identities.

### Polynomial and domain structure

- Replaces four bespoke indicator interpolation proofs with one private Lagrange-node evaluation lemma.
- Establishes one private quotient `natDegree` identity and reuses it across five folding-polynomial proofs.
- Generalizes the private subdomain-index composition lemma, so public `subdomain_comp` becomes a direct rewrite rather than a four-way `aesop`/ring search.
- Shares one subdomain power-evaluation core between evaluation and membership, eliminating two duplicated multi-second proofs.

## Modules profiled without forced churn

The sprint also directly profiled `Folding`, `AHIV22`, Johnson `Basic`, `Family`, `Powers`, `Pigeonhole`, DG25 `MainResults`, Berlekamp–Welch `Condition`, `Errors`, affine-line `GoodCoeffs`, `KKH26Asymptotic`, and BCIKS20 `Guruswami`. Their current maximum declarations were already below 15 seconds (generally below 5 seconds), so no cosmetic changes were retained.

`ArkLib/Data` contains no active `maxHeartbeats`, `maxRecDepth`, or synthesis-heartbeat override. The only matching line is a commented historical `maxRecDepth` line in `Hash/Poseidon2.lean`.

## Public API, compatibility, and trust

- Public theorem statements are source-identical to `main`; `Bi_biUnion_F2i` is only line-reflowed.
- Executable and public definitions are unchanged.
- New/generalized helpers are private.
- No imports or `set_option` declarations changed.
- No `sorry`, `admit`, axiom, `unsafe`, `native_decide`, or resource-budget escape hatch was added.
- Existing admitted/transitively admitted results remain exactly where they were; this PR does not route new proofs through them.
- Principal changed theorems retain their previous axiom sets. The clean results use only `propext`, `Classical.choice`, and `Quot.sound`; pre-existing `sorryAx` dependencies remain pre-existing.

## Validation at `567853ba`

Passed locally on the exact head:

- `./scripts/validate.sh --axioms`;
- full `lake build` and compiled runtime checks;
- umbrella-import, docs-integrity, and knowledge-base checks;
- axiom-sweep fixture matrix;
- full ArkLib axiom regression sweep: 10,942 declarations across 418 modules, 314 `sorryAx`-tainted, zero non-standard-axiom-tainted, and no regression;
- `git diff --check`;
- direct builds of all changed modules plus downstream Coset FFT/FRI consumers.

Independent `review-lean-formalization` gate: **approved with no P0, P1, P2, or P3 findings**. It checked public statement identity, edge cases in subdomain composition/powering, polynomial-degree reasoning, arithmetic direction, trust, and downstream consumers.

GitHub CI is fully green on the exact head:

- clean and warm project builds;
- native/runtime build;
- axiom-sweep fixture test and report-only sweep;
- validation wrapper;
- blueprint/documentation build;
- Docs Integrity, Library File Imports, trailing whitespace, and PR summary.

### CI timing artifact and absolute-threshold limitation

The final `ubuntu-latest` timing job was globally slower than the selected #823 baseline:

| Measurement | #823 baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| Clean build | 666.52s | 992.44s | +49% |
| Warm rebuild | 2.68s | 3.20s | +19% |
| Native build | 19.33s | 33.17s | +72% |
| Validation wrapper | 6.11s | 9.14s | +50% |

The broad slowdown also inflated unchanged files, so raw per-file values from these two jobs are not a controlled A/B. For example, unchanged `GCXK25` moved from 14s to 34s and unchanged `AHIV22` from 21s to 34s, while the heavily refactored STIR `Combine` still improved from 34s to 29s despite the slower runner.

Accordingly, this run proves that the full CI/build/trust path is green, but it does **not** certify the absolute “every clean-CI file below 20s” target on a comparable runner. The durable result of this PR is the controlled theorem-level reductions and isolated-module results above, all of which are below 15s. A future clean timing run on comparable hardware is still needed to evaluate the absolute whole-build threshold without the runner-load confounder.

## Reviewer map

Suggested review order:

1. `ArkLib/ProofSystem/Stir/Combine.lean` — explicit flattening and master witnesses.
2. `ArkLib/Data/Domain/CosetFftDomain/Subdomain.lean` — shared evaluation core and index-composition boundary cases.
3. `ArkLib/Data/Polynomial/Indicator.lean` and `FoldingPolynomial.lean` — reusable interpolation and degree identities.
4. `ArkLib/Data/CodingTheory/JohnsonBound/Lemmas.lean`, `CapacityBounds/JohnsonCa.lean`, and `LargeAlphabet/Centers.lean` — direct combinatorial witnesses and barrier arithmetic.
5. Remaining coding-theory files — scoped arithmetic and filter/kernel proof reductions.
