### PR TITLE
ci: make build timing comparisons attributable

### DIFF
--- a/.github/workflows/build-timing-report.yml
+++ b/.github/workflows/build-timing-report.yml
@@ -58,6 +58,20 @@ jobs:
               pull_number: pullNumber,
             });
             const pullRequest = pullRequestResponse.data;
+            const runPullRequest = run.pull_requests?.find(
+              candidate => candidate.number === pullRequest.number
+            );
+
+            // A workflow_run reporter can start after a newer commit has been pushed. Never let
+            // the older artifact overwrite the comment while masquerading as the current head.
+            if (pullRequest.head.sha !== run.head_sha) {
+              core.info(
+                `Skipping stale CI run ${run.id}: it measured ${run.head_sha}, ` +
+                `but PR #${pullRequest.number} is now at ${pullRequest.head.sha}.`
+              );
+              core.setOutput('should-report', 'false');
+              return;
+            }
 
             const artifactsResponse = await github.rest.actions.listWorkflowRunArtifacts({
               owner,
@@ -78,16 +92,19 @@ jobs:
             core.setOutput('artifact-name', artifactName);
             core.setOutput('pr-number', String(pullRequest.number));
             core.setOutput('head-ref', pullRequest.head.ref);
-            core.setOutput('head-sha', pullRequest.head.sha);
-            core.setOutput('base-ref', pullRequest.base.ref);
-            core.setOutput('base-sha', pullRequest.base.sha);
+            core.setOutput('head-sha', run.head_sha);
+            // workflow_run preserves the base that produced GitHub's measured merge checkout;
+            // the live PR base may already have advanced by the time this reporter starts.
+            core.setOutput('base-ref', runPullRequest?.base?.ref || pullRequest.base.ref);
+            core.setOutput('base-sha', runPullRequest?.base?.sha || pullRequest.base.sha);
             core.setOutput('source-subject', run.display_title || '');
 
       - name: Check out reporting scripts
         if: steps.timing-context.outputs.should-report == 'true'
         uses: actions/checkout@v7
         with:
-          ref: ${{ steps.timing-context.outputs.base-ref }}
+          # Execute only the reporter committed at the exact trusted base measured below.
+          ref: ${{ steps.timing-context.outputs.base-sha }}
 
       - name: Download current timing artifact
         if: steps.timing-context.outputs.should-report == 'true'
@@ -108,9 +125,6 @@ jobs:
             const artifactName = '${{ steps.timing-context.outputs.artifact-name }}';
             const workflowName = 'CI';
             const currentRunId = Number('${{ github.event.workflow_run.id }}');
-            const currentSha = '${{ steps.timing-context.outputs.head-sha }}';
-            const pullNumber = Number('${{ steps.timing-context.outputs.pr-number }}');
-            const headRef = '${{ steps.timing-context.outputs.head-ref }}';
             const baseRef = '${{ steps.timing-context.outputs.base-ref }}';
             const baseSha = '${{ steps.timing-context.outputs.base-sha }}';
 
@@ -138,29 +152,6 @@ jobs:
               return null;
             }
 
-            const prRunsResponse = await github.rest.actions.listWorkflowRunsForRepo({
-              owner,
-              repo,
-              event: 'pull_request',
-              branch: headRef,
-              status: 'completed',
-              per_page: 100,
-            });
-            const previousPrCandidates = prRunsResponse.data.workflow_runs.filter(candidateRun => {
-              if (candidateRun.head_sha === currentSha) {
-                return false;
-              }
-              const prs = candidateRun.pull_requests || [];
-              return prs.length === 0 || prs.some(pr => pr.number === pullNumber);
-            });
-            const previousPrRun = await firstRunWithArtifact(previousPrCandidates);
-            if (previousPrRun) {
-              core.setOutput('run-id', String(previousPrRun.id));
-              core.setOutput('sha', previousPrRun.head_sha);
-              core.setOutput('label', 'the previous successful PR update');
-              return;
-            }
-
             const baseRunsResponse = await github.rest.actions.listWorkflowRunsForRepo({
               owner,
               repo,
@@ -175,23 +166,17 @@ jobs:
             const exactBaseRun = await firstRunWithArtifact(
               baseCandidates.filter(candidateRun => candidateRun.head_sha === baseSha)
             );
-            const baseRun = exactBaseRun ?? await firstRunWithArtifact(
-              baseCandidates.filter(candidateRun => candidateRun.head_sha !== baseSha)
-            );
-            if (baseRun) {
-              const isExactBase = baseRun.head_sha === baseSha;
-              core.setOutput('run-id', String(baseRun.id));
-              core.setOutput('sha', baseRun.head_sha);
-              core.setOutput(
-                'label',
-                isExactBase
-                  ? `current base of \`${baseRef}\``
-                  : `the latest successful \`${baseRef}\` run`
-              );
+            if (exactBaseRun) {
+              core.setOutput('run-id', String(exactBaseRun.id));
+              core.setOutput('sha', exactBaseRun.head_sha);
+              core.setOutput('label', `exact PR base on \`${baseRef}\``);
               return;
             }
 
-            core.info('No comparison baseline artifact found.');
+            core.info(
+              `No successful CI timing artifact exists for exact base ${baseSha}; ` +
+              'the report will not substitute another commit.'
+            );
             core.setOutput('run-id', '');
             core.setOutput('sha', '');
             core.setOutput('label', '');
@@ -220,7 +205,7 @@ jobs:
           BUILD_TIMING_TEST_NAME: Validation wrapper
           BUILD_TIMING_TEST_COMMAND: ./scripts/validate.sh
           BUILD_TIMING_NATIVE_NAME: Native build
-          BUILD_TIMING_NATIVE_COMMAND: lake build toyproblem-runtime
+          BUILD_TIMING_NATIVE_COMMAND: lake build toyproblem-runtime hachi-runtime
         run: |
           baseline_dir="${{ runner.temp }}/build-timing-baseline"
           if [ -f "$baseline_dir/results.jsonl" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
 
@@ -59,9 +59,10 @@ jobs:
           echo "BUILD_TIMING_LOG_DIR=$RUNNER_TEMP/build-timing-logs" >> "$GITHUB_ENV"
           echo "BUILD_TIMING_ARTIFACT_DIR=$RUNNER_TEMP/build-timing-artifact" >> "$GITHUB_ENV"
           echo "BUILD_TIMING_ARTIFACT_NAME=arklib-build-timing-data" >> "$GITHUB_ENV"
+          echo "BUILD_TIMING_METADATA_PATH=$RUNNER_TEMP/build-timing-artifact/metadata.json" >> "$GITHUB_ENV"
           echo "BUILD_TIMING_REPORT=$RUNNER_TEMP/build-timing.md" >> "$GITHUB_ENV"
           echo "SOURCE_TRUST_REPORT=$RUNNER_TEMP/source-trust.json" >> "$GITHUB_ENV"
-          echo "BUILD_TIMING_SOURCE_SHA=$GITHUB_SHA" >> "$GITHUB_ENV"
+          echo "BUILD_TIMING_SOURCE_SHA=${{ github.event.pull_request.head.sha || github.sha }}" >> "$GITHUB_ENV"
           echo "BUILD_TIMING_SOURCE_BRANCH=${{ github.head_ref || github.ref_name }}" >> "$GITHUB_ENV"
           echo "BUILD_TIMING_TEST_NAME=Validation wrapper" >> "$GITHUB_ENV"
           echo "BUILD_TIMING_TEST_COMMAND=./scripts/validate.sh" >> "$GITHUB_ENV"
@@ -202,9 +203,20 @@ jobs:
 
       - name: Prepare timing artifact
         if: always()
+        env:
+          BUILD_TIMING_RUN_ID: ${{ github.run_id }}
+          BUILD_TIMING_RUN_ATTEMPT: ${{ github.run_attempt }}
+          BUILD_TIMING_EVENT: ${{ github.event_name }}
+          BUILD_TIMING_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BUILD_TIMING_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
+          BUILD_TIMING_REF: ${{ github.head_ref || github.ref_name }}
+          BUILD_TIMING_CACHE_EXACT_HIT: ${{ steps.lake-cache.outputs.cache-hit }}
+          BUILD_TIMING_CACHE_PRIMARY_KEY: ${{ steps.lake-cache.outputs.cache-primary-key }}
+          BUILD_TIMING_CACHE_MATCHED_KEY: ${{ steps.lake-cache.outputs.cache-matched-key }}
         run: |
           rm -rf "$BUILD_TIMING_ARTIFACT_DIR"
           mkdir -p "$BUILD_TIMING_ARTIFACT_DIR"
+          python3 scripts/build_timing_metadata.py "$BUILD_TIMING_METADATA_PATH"
           if [ -f "$BUILD_TIMING_RESULTS" ]; then
             cp "$BUILD_TIMING_RESULTS" "$BUILD_TIMING_ARTIFACT_DIR/results.jsonl"
           fi

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -256,3 +256,15 @@ Read the rows in that order, because they share one tree and each leaves it warm
 A row whose measurement could not be taken renders as `measurement failed`, not as a missing row.
 Per-target times are printed with the precision Lake reported (`22`, `3.5`, `0.770`); Lake emits
 whole seconds above 10s, so those figures are not accurate to two decimals.
+
+For PRs, the trusted reporter compares only with a successful timing artifact whose push SHA is
+the PR's exact measured base. If that artifact is unavailable or expired, the report says so and
+shows current measurements without inventing a substitute baseline. A previous PR update answers a
+different question and is therefore not used as the regression baseline.
+
+Timing artifacts include the PR head, actual measured checkout (normally GitHub's synthetic PR
+merge commit), exact base, dependency-manifest hash, exact/fallback cache state, and runner
+image/version. Reports show both wall time and CPU work (`user + sys`). Movement in both suggests
+changed compilation work or runner speed; wall-only movement more often indicates scheduling or I/O
+contention. These diagnostics improve attribution, but one hosted-runner sample is still not a
+performance verdict. Per-file rows are leads to remeasure, not blocking regression claims.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,8 @@ This directory contains various utility scripts for the ArkLib project.
 - **`validate.sh`** - Recommended convenience wrapper for routine local validation
 - **`build-project.sh`** - Compile-only helper (`lake build`)
 - **`build_timing_report.sh`** - CI timing/report helper for clean builds, warm rebuilds, the native build, and the validation wrapper
+- **`build_timing_metadata.py`** - Versioned attribution metadata writer/validator for timing artifacts
+- **`test-build-timing-report.sh`** - Deterministic report, metadata, and workflow-policy fixtures
 - **`update-lib.sh`** - Update ArkLib.lean with all imports from source files
 - **`check-imports.sh`** - Reject blanket package-root imports and check whether `ArkLib.lean` is
   up to date with all tracked source modules
@@ -199,8 +201,11 @@ python3 scripts/source-trust-audit.py --base-ref origin/main --json /tmp/source-
 
 Helper used by CI to measure and render build timings for clean builds, warm
 rebuilds, the native build, and the `./scripts/validate.sh` path. The CI workflow uploads
-timing-data artifacts so PR runs can compare against a previously recorded
-baseline without rerunning that baseline in the same job. This supports
+timing-data artifacts so PR runs can compare against the successful push run for the PR's exact
+base SHA without rerunning that base in the same job. It never silently substitutes a previous PR
+update or a different `main` commit when the exact artifact is unavailable. Each artifact also
+records the measured checkout, PR head/base, dependency-manifest hash, cache provenance, and runner
+image; the report shows wall time beside `user + sys` CPU work. This supports
 [`../.github/workflows/ci.yml`](../.github/workflows/ci.yml).
 
 The four measurements share one tree and run in order, so each leaves it warmer than the last.
@@ -209,6 +214,9 @@ The four measurements share one tree and run in order, so each leaves it warmer 
 and billing it separately keeps the validation wrapper's row comparable across dependency bumps.
 Any new compiled executable run by `validate.sh` has to be added to that command as well. See
 [`../docs/wiki/quickstart.md`](../docs/wiki/quickstart.md) for how to read the rows.
+
+`./scripts/test-build-timing-report.sh` exercises metadata validation, exact-base/missing-base
+rendering, CPU deltas, native-command ownership, and the stale-run guard in the trusted reporter.
 
 ## Requirements
 

--- a/scripts/build_timing_metadata.py
+++ b/scripts/build_timing_metadata.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Write and validate attribution metadata for ArkLib build-timing artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import re
+import subprocess
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+class MetadataError(ValueError):
+    """Raised when timing metadata is malformed or uses an unsupported schema."""
+
+
+def _optional_string(value: str | None) -> str | None:
+    return value if value else None
+
+
+def _optional_sha(value: str | None, field: str) -> str | None:
+    value = _optional_string(value)
+    if value is not None and not SHA_PATTERN.fullmatch(value):
+        raise MetadataError(f"{field} must be a 40-character lowercase Git SHA")
+    return value
+
+
+def _parse_optional_bool(value: str | None) -> bool | None:
+    if not value:
+        return None
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    raise MetadataError("BUILD_TIMING_CACHE_EXACT_HIT must be true, false, or empty")
+
+
+def _positive_int(value: str | int | None, field: str, *, optional: bool = False) -> int | None:
+    if value is None and optional:
+        return None
+    if isinstance(value, bool):
+        raise MetadataError(f"{field} must be a positive integer")
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as error:
+        raise MetadataError(f"{field} must be a positive integer") from error
+    if parsed <= 0:
+        raise MetadataError(f"{field} must be a positive integer")
+    return parsed
+
+
+def _string(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not value:
+        raise MetadataError(f"{field} must be a non-empty string")
+    return value
+
+
+def _mapping(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MetadataError(f"{field} must be an object")
+    return value
+
+
+def _checkout_sha() -> str:
+    supplied = os.environ.get("BUILD_TIMING_CHECKOUT_SHA")
+    if supplied:
+        return supplied
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _manifest_sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_metadata() -> dict[str, Any]:
+    manifest_path = pathlib.Path(os.environ.get("BUILD_TIMING_MANIFEST", "lake-manifest.json"))
+    if not manifest_path.is_file():
+        raise MetadataError(f"dependency manifest not found: {manifest_path}")
+
+    metadata = {
+        "schema_version": SCHEMA_VERSION,
+        "run": {
+            "id": _positive_int(os.environ.get("BUILD_TIMING_RUN_ID"), "run.id"),
+            "attempt": _positive_int(
+                os.environ.get("BUILD_TIMING_RUN_ATTEMPT"), "run.attempt"
+            ),
+            "event": _string(os.environ.get("BUILD_TIMING_EVENT"), "run.event"),
+        },
+        "git": {
+            "head_sha": _optional_sha(os.environ.get("BUILD_TIMING_HEAD_SHA"), "git.head_sha"),
+            "checkout_sha": _optional_sha(_checkout_sha(), "git.checkout_sha"),
+            "base_sha": _optional_sha(os.environ.get("BUILD_TIMING_BASE_SHA"), "git.base_sha"),
+            "ref": _string(os.environ.get("BUILD_TIMING_REF"), "git.ref"),
+        },
+        "dependencies": {
+            "lake_manifest_sha256": _manifest_sha256(manifest_path),
+        },
+        "cache": {
+            "primary_key": _optional_string(os.environ.get("BUILD_TIMING_CACHE_PRIMARY_KEY")),
+            "matched_key": _optional_string(os.environ.get("BUILD_TIMING_CACHE_MATCHED_KEY")),
+            "exact_hit": _parse_optional_bool(os.environ.get("BUILD_TIMING_CACHE_EXACT_HIT")),
+        },
+        "runner": {
+            "os": _string(os.environ.get("RUNNER_OS"), "runner.os"),
+            "arch": _string(os.environ.get("RUNNER_ARCH"), "runner.arch"),
+            "image_os": _optional_string(os.environ.get("ImageOS")),
+            "image_version": _optional_string(os.environ.get("ImageVersion")),
+            "cores": os.cpu_count(),
+        },
+    }
+    return validate_metadata(metadata)
+
+
+def validate_metadata(value: Any) -> dict[str, Any]:
+    root = _mapping(value, "metadata")
+    if root.get("schema_version") != SCHEMA_VERSION:
+        raise MetadataError(
+            f"unsupported timing metadata schema {root.get('schema_version')!r}; "
+            f"expected {SCHEMA_VERSION}"
+        )
+
+    run = _mapping(root.get("run"), "run")
+    git = _mapping(root.get("git"), "git")
+    dependencies = _mapping(root.get("dependencies"), "dependencies")
+    cache = _mapping(root.get("cache"), "cache")
+    runner = _mapping(root.get("runner"), "runner")
+
+    _positive_int(run.get("id"), "run.id")
+    _positive_int(run.get("attempt"), "run.attempt")
+    _string(run.get("event"), "run.event")
+    _optional_sha(git.get("head_sha"), "git.head_sha")
+    _optional_sha(git.get("checkout_sha"), "git.checkout_sha")
+    _optional_sha(git.get("base_sha"), "git.base_sha")
+    _string(git.get("ref"), "git.ref")
+
+    manifest_hash = _string(
+        dependencies.get("lake_manifest_sha256"), "dependencies.lake_manifest_sha256"
+    )
+    if manifest_hash is None or not re.fullmatch(r"[0-9a-f]{64}", manifest_hash):
+        raise MetadataError("dependencies.lake_manifest_sha256 must be a SHA-256 digest")
+
+    for field in ("primary_key", "matched_key"):
+        if cache.get(field) is not None:
+            _string(cache.get(field), f"cache.{field}")
+    if cache.get("exact_hit") is not None and not isinstance(cache.get("exact_hit"), bool):
+        raise MetadataError("cache.exact_hit must be true, false, or null")
+
+    _string(runner.get("os"), "runner.os")
+    _string(runner.get("arch"), "runner.arch")
+    for field in ("image_os", "image_version"):
+        if runner.get(field) is not None:
+            _string(runner.get(field), f"runner.{field}")
+    _positive_int(runner.get("cores"), "runner.cores", optional=True)
+    return root
+
+
+def load_metadata(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise MetadataError(f"cannot read timing metadata: {error}") from error
+    return validate_metadata(value)
+
+
+def write_metadata(path: pathlib.Path) -> None:
+    metadata = build_metadata()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=pathlib.Path, help="metadata JSON output path")
+    args = parser.parse_args()
+    try:
+        write_metadata(args.output)
+    except (MetadataError, OSError, subprocess.CalledProcessError) as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_timing_report.sh
+++ b/scripts/build_timing_report.sh
@@ -122,6 +122,9 @@ import pathlib
 import re
 import sys
 
+sys.path.insert(0, str(pathlib.Path("scripts").resolve()))
+from build_timing_metadata import MetadataError, load_metadata
+
 results_path = pathlib.Path(sys.argv[1])
 baseline_dir = pathlib.Path(sys.argv[2]) if len(sys.argv) > 2 and sys.argv[2] else None
 test_path_name = os.environ.get("BUILD_TIMING_TEST_NAME", "Validation wrapper")
@@ -203,6 +206,70 @@ def seconds(record: dict | None) -> str:
     return "n/a" if not measured(record) else fmt(record["real"])
 
 
+def cpu_seconds(record: dict | None) -> float | None:
+    if record is None or not measured(record):
+        return None
+    return record["user"] + record["sys"]
+
+
+def fmt_change(current: float, baseline: float) -> str:
+    delta = current - baseline
+    if baseline == 0:
+        return fmt_delta(delta)
+    return f"{fmt_delta(delta)} ({delta / baseline:+.1%})"
+
+
+def read_metadata(path: pathlib.Path) -> tuple[dict | None, str | None]:
+    if not path.exists():
+        return None, "metadata.json is absent (legacy artifact)"
+    try:
+        return load_metadata(path), None
+    except MetadataError as error:
+        return None, str(error)
+
+
+def abbrev_sha(value: str | None) -> str:
+    return value[:7] if value else "unknown"
+
+
+def cache_summary(metadata: dict | None) -> str:
+    if metadata is None:
+        return "unknown"
+    cache = metadata["cache"]
+    if cache["exact_hit"] is True:
+        return "exact hit"
+    if cache["matched_key"]:
+        return "fallback restore"
+    if cache["exact_hit"] is False:
+        return "miss"
+    if cache["primary_key"]:
+        return "miss"
+    return "unknown"
+
+
+def cache_key(metadata: dict | None) -> str:
+    if metadata is None:
+        return "unknown"
+    cache = metadata["cache"]
+    return cache["matched_key"] or cache["primary_key"] or "unknown"
+
+
+def manifest_summary(metadata: dict | None) -> str:
+    if metadata is None:
+        return "unknown"
+    return metadata["dependencies"]["lake_manifest_sha256"][:12]
+
+
+def runner_summary(metadata: dict | None) -> str:
+    if metadata is None:
+        return "unknown"
+    runner = metadata["runner"]
+    image = runner["image_os"] or runner["os"]
+    version = f" {runner['image_version']}" if runner["image_version"] else ""
+    cores = f", {runner['cores']} cores" if runner["cores"] else ""
+    return f"{image}{version}, {runner['arch']}{cores}"
+
+
 def module_to_source_path(target: str) -> str | None:
     # Lake captions are facet-qualified (`Mod:c.o`, `Mod:dynlib`); only the module part maps to
     # a source file, and the facet has to stay visible or native and olean rows collide.
@@ -280,6 +347,17 @@ def target_key(entry: dict) -> str:
 current_records = load_records(results_path)
 baseline_records = load_records(baseline_dir / "results.jsonl") if baseline_dir else {}
 
+current_metadata_path_env = os.environ.get("BUILD_TIMING_METADATA_PATH")
+current_metadata_path = (
+    pathlib.Path(current_metadata_path_env)
+    if current_metadata_path_env
+    else results_path.parent / "metadata.json"
+)
+current_metadata, current_metadata_error = read_metadata(current_metadata_path)
+baseline_metadata, baseline_metadata_error = (
+    read_metadata(baseline_dir / "metadata.json") if baseline_dir else (None, None)
+)
+
 current_log_dir = os.environ.get("BUILD_TIMING_LOG_DIR")
 current_log_path = pathlib.Path(current_log_dir) / "clean_build.log" if current_log_dir else None
 current_clean_build_targets = extract_clean_build_targets(current_log_path)
@@ -303,11 +381,23 @@ if source_sha:
         commit_ref = f"[`{short_sha}`](https://github.com/{source_repo}/commit/{source_sha})"
     else:
         commit_ref = f"`{short_sha}`"
-    print(f"- Commit: {commit_ref}")
+    source_label = (
+        "PR head"
+        if current_metadata and current_metadata["run"]["event"] == "pull_request"
+        else "Source head"
+    )
+    print(f"- {source_label}: {commit_ref}")
 if source_subject:
     print(f"- Message: {md_text(source_subject)}")
 if source_branch:
     print(f"- Ref: {md_code(source_branch)}")
+if current_metadata:
+    checkout_sha = current_metadata["git"]["checkout_sha"]
+    head_sha = current_metadata["git"]["head_sha"]
+    print(
+        f"- Measured checkout: `{abbrev_sha(checkout_sha)}` "
+        f"(workflow head `{abbrev_sha(head_sha)}`)."
+    )
 if baseline_records:
     if baseline_sha:
         baseline_short_sha = baseline_sha[:7]
@@ -323,7 +413,33 @@ if baseline_records:
             print(f"- Comparison baseline: {baseline_commit_ref}.")
     elif baseline_label:
         print(f"- Comparison baseline: {md_text(baseline_label)}.")
-print("- Measured on `ubuntu-latest` with `/usr/bin/time -p`.")
+else:
+    print("- Comparison baseline: exact-base timing artifact unavailable; no substitute was used.")
+print(f"- Runner: current {md_code(runner_summary(current_metadata))}.")
+print(
+    f"- Dependency cache: current **{md_text(cache_summary(current_metadata))}** "
+    f"({md_code(cache_key(current_metadata))}); manifest {md_code(manifest_summary(current_metadata))}."
+)
+if baseline_records:
+    print(
+        f"- Baseline environment: runner {md_code(runner_summary(baseline_metadata))}; "
+        f"dependency cache **{md_text(cache_summary(baseline_metadata))}** "
+        f"({md_code(cache_key(baseline_metadata))}); manifest "
+        f"{md_code(manifest_summary(baseline_metadata))}."
+    )
+if current_metadata_error:
+    print(f"- Attribution note: current {md_text(current_metadata_error)}.")
+if baseline_records and baseline_metadata_error:
+    print(f"- Attribution note: baseline {md_text(baseline_metadata_error)}.")
+if current_metadata and baseline_metadata:
+    current_manifest = current_metadata["dependencies"]["lake_manifest_sha256"]
+    baseline_manifest = baseline_metadata["dependencies"]["lake_manifest_sha256"]
+    if current_manifest != baseline_manifest:
+        print("- Comparability warning: current and baseline dependency manifests differ.")
+if current_metadata:
+    print("- Measured on the pinned `ubuntu-24.04` runner with `/usr/bin/time -p`.")
+else:
+    print("- Measured with `/usr/bin/time -p`; runner pin unavailable for this legacy artifact.")
 print(
     "- Commands: "
     + "; ".join(
@@ -345,8 +461,11 @@ if not current_records:
     sys.exit(0)
 
 if baseline_records:
-    print("| Measurement | Baseline (s) | Current (s) | Delta (s) | Status |")
-    print("| --- | ---: | ---: | ---: | --- |")
+    print(
+        "| Measurement | Base wall (s) | Current wall (s) | Wall change | "
+        "Base CPU (s) | Current CPU (s) | CPU change | Status |"
+    )
+    print("| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |")
     for label in ordered_labels:
         baseline_record = baseline_records.get(label)
         current_record = current_records.get(label)
@@ -360,22 +479,41 @@ if baseline_records:
             and measured(baseline_record)
             and measured(current_record)
         )
-        delta = (
-            fmt_delta(current_record["real"] - baseline_record["real"]) if comparable else "-"
+        wall_change = (
+            fmt_change(current_record["real"], baseline_record["real"]) if comparable else "-"
+        )
+        baseline_cpu = cpu_seconds(baseline_record)
+        current_cpu = cpu_seconds(current_record)
+        cpu_change = (
+            fmt_change(current_cpu, baseline_cpu)
+            if baseline_cpu is not None and current_cpu is not None
+            else "-"
         )
         current_status = status(current_record) if current_record else "-"
         print(
-            f"| {display[label]['name']} | {baseline_time} | {current_time} | {delta} | "
+            f"| {display[label]['name']} | {baseline_time} | {current_time} | {wall_change} | "
+            f"{fmt(baseline_cpu) if baseline_cpu is not None else '-'} | "
+            f"{fmt(current_cpu) if current_cpu is not None else '-'} | {cpu_change} | "
             f"{current_status} |"
         )
 else:
-    print("| Measurement | Wall (s) | Status |")
-    print("| --- | ---: | --- |")
+    print("| Measurement | Wall (s) | CPU work (s) | Status |")
+    print("| --- | ---: | ---: | --- |")
     for label in ordered_labels:
         if label not in current_records:
             continue
         record = current_records[label]
-        print(f"| {display[label]['name']} | {seconds(record)} | {status(record)} |")
+        cpu = cpu_seconds(record)
+        print(
+            f"| {display[label]['name']} | {seconds(record)} | "
+            f"{fmt(cpu) if cpu is not None else '-'} | {status(record)} |"
+        )
+
+print()
+print(
+    "CPU work is `user + sys`. Compare it with wall time to distinguish changed compilation "
+    "work from runner scheduling noise; neither metric is a standalone performance verdict."
+)
 
 clean = current_records.get("clean_build")
 warm = current_records.get("warm_rebuild")

--- a/scripts/test-build-timing-report.sh
+++ b/scripts/test-build-timing-report.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+fixture_tmp="$(mktemp -d)"
+trap 'rm -rf "$fixture_tmp"' EXIT
+
+current_dir="$fixture_tmp/current"
+base_dir="$fixture_tmp/base"
+empty_dir="$fixture_tmp/empty"
+mkdir -p "$current_dir" "$base_dir" "$empty_dir"
+
+python3 - "$current_dir" "$base_dir" <<'PY'
+import json
+import pathlib
+import sys
+
+current_dir = pathlib.Path(sys.argv[1])
+base_dir = pathlib.Path(sys.argv[2])
+
+records = {
+    current_dir: [
+        {"label": "clean_build", "real": 90.0, "user": 70.0, "sys": 10.0,
+         "exit_code": 0, "measured": True},
+        {"label": "warm_rebuild", "real": 2.0, "user": 1.2, "sys": 0.3,
+         "exit_code": 0, "measured": True},
+        {"label": "native_build", "real": 20.0, "user": 35.0, "sys": 5.0,
+         "exit_code": 0, "measured": True},
+        {"label": "test_path", "real": 8.0, "user": 6.0, "sys": 1.0,
+         "exit_code": 0, "measured": True},
+    ],
+    base_dir: [
+        {"label": "clean_build", "real": 100.0, "user": 75.0, "sys": 15.0,
+         "exit_code": 0, "measured": True},
+        {"label": "warm_rebuild", "real": 2.5, "user": 1.3, "sys": 0.4,
+         "exit_code": 0, "measured": True},
+        {"label": "native_build", "real": 18.0, "user": 31.0, "sys": 4.0,
+         "exit_code": 0, "measured": True},
+        {"label": "test_path", "real": 7.0, "user": 5.0, "sys": 1.0,
+         "exit_code": 0, "measured": True},
+    ],
+}
+
+for directory, rows in records.items():
+    (directory / "results.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
+    (directory / "clean_build.log").write_text(
+        "✔ [1/2] Built ArkLib.Fast (1.0s)\n"
+        "✔ [2/2] Built ArkLib.Slow (12s)\n",
+        encoding="utf-8",
+    )
+
+def metadata(*, run_id, head, checkout, base, exact_hit, matched_key, image_version):
+    return {
+        "schema_version": 1,
+        "run": {"id": run_id, "attempt": 1, "event": "pull_request"},
+        "git": {"head_sha": head, "checkout_sha": checkout, "base_sha": base,
+                "ref": "feature|timing"},
+        "dependencies": {"lake_manifest_sha256": "1" * 64},
+        "cache": {"primary_key": "primary", "matched_key": matched_key,
+                  "exact_hit": exact_hit},
+        "runner": {"os": "Linux", "arch": "X64", "image_os": "ubuntu24",
+                   "image_version": image_version, "cores": 4},
+    }
+
+(current_dir / "metadata.json").write_text(
+    json.dumps(metadata(run_id=2, head="a" * 40, checkout="b" * 40, base="c" * 40,
+                        exact_hit=True, matched_key="primary", image_version="20260820.1")),
+    encoding="utf-8",
+)
+(base_dir / "metadata.json").write_text(
+    json.dumps(metadata(run_id=1, head="c" * 40, checkout="c" * 40, base="d" * 40,
+                        exact_hit=False, matched_key="fallback", image_version="20260813.1")),
+    encoding="utf-8",
+)
+PY
+
+report="$fixture_tmp/report.md"
+BUILD_TIMING_LOG_DIR="$current_dir" \
+BUILD_TIMING_SOURCE_SHA="$(printf 'a%.0s' {1..40})" \
+BUILD_TIMING_SOURCE_SUBJECT='timing <report>' \
+BUILD_TIMING_SOURCE_BRANCH='feature|timing' \
+BUILD_TIMING_BASELINE_SHA="$(printf 'c%.0s' {1..40})" \
+BUILD_TIMING_BASELINE_LABEL='exact PR base on `main`' \
+BUILD_TIMING_NATIVE_COMMAND='lake build toyproblem-runtime hachi-runtime' \
+  bash scripts/build_timing_report.sh render "$current_dir/results.jsonl" "$base_dir" > "$report"
+
+grep -Fq -- '- PR head: `aaaaaaa`' "$report"
+grep -Fq -- '- Measured checkout: `bbbbbbb` (workflow head `aaaaaaa`).' "$report"
+grep -Fq -- '- Ref: <code>feature&#124;timing</code>' "$report"
+grep -Fq -- 'Dependency cache: current **exact hit**' "$report"
+grep -Fq -- 'dependency cache **fallback restore**' "$report"
+grep -Fq -- '| Clean build | 100.00 | 90.00 | -10.00 (-10.0%) | 90.00 | 80.00 | -10.00 (-11.1%) | ok |' "$report"
+grep -Fq -- 'native build `lake build toyproblem-runtime hachi-runtime`' "$report"
+grep -Fq -- '| 12 | 12 | +0 | <code>ArkLib/Slow.lean</code> |' "$report"
+
+BUILD_TIMING_LOG_DIR="$current_dir" \
+  bash scripts/build_timing_report.sh render "$current_dir/results.jsonl" "$empty_dir" \
+  > "$fixture_tmp/no-base.md"
+grep -Fq -- 'exact-base timing artifact unavailable; no substitute was used' \
+  "$fixture_tmp/no-base.md"
+
+python3 - "$current_dir/metadata.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.write_text(json.dumps({"schema_version": 99}), encoding="utf-8")
+PY
+BUILD_TIMING_LOG_DIR="$current_dir" \
+  bash scripts/build_timing_report.sh render "$current_dir/results.jsonl" "$base_dir" \
+  > "$fixture_tmp/wrong-schema.md"
+grep -Fq -- 'unsupported timing metadata schema 99; expected 1' \
+  "$fixture_tmp/wrong-schema.md"
+
+python3 - "$current_dir/metadata.json" <<'PY'
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_text("{not-json\n", encoding="utf-8")
+PY
+BUILD_TIMING_LOG_DIR="$current_dir" \
+  bash scripts/build_timing_report.sh render "$current_dir/results.jsonl" "$base_dir" \
+  > "$fixture_tmp/malformed.md"
+grep -Fq -- 'cannot read timing metadata' "$fixture_tmp/malformed.md"
+grep -Fq -- 'runner pin unavailable for this legacy artifact' "$fixture_tmp/malformed.md"
+
+written_metadata="$fixture_tmp/written-metadata.json"
+BUILD_TIMING_RUN_ID=7 \
+BUILD_TIMING_RUN_ATTEMPT=2 \
+BUILD_TIMING_EVENT=pull_request \
+BUILD_TIMING_HEAD_SHA="$(printf 'e%.0s' {1..40})" \
+BUILD_TIMING_CHECKOUT_SHA="$(printf 'f%.0s' {1..40})" \
+BUILD_TIMING_BASE_SHA="$(printf '1%.0s' {1..40})" \
+BUILD_TIMING_REF=feature/timing \
+BUILD_TIMING_CACHE_EXACT_HIT=false \
+BUILD_TIMING_CACHE_PRIMARY_KEY=primary \
+BUILD_TIMING_CACHE_MATCHED_KEY=fallback \
+RUNNER_OS=Linux \
+RUNNER_ARCH=X64 \
+ImageOS=ubuntu24 \
+ImageVersion=20260820.1 \
+  python3 scripts/build_timing_metadata.py "$written_metadata"
+python3 - "$written_metadata" <<'PY'
+import pathlib
+import sys
+
+sys.path.insert(0, "scripts")
+from build_timing_metadata import load_metadata
+
+metadata = load_metadata(pathlib.Path(sys.argv[1]))
+assert metadata["run"] == {"attempt": 2, "event": "pull_request", "id": 7}
+assert metadata["cache"]["exact_hit"] is False
+assert metadata["cache"]["matched_key"] == "fallback"
+PY
+
+grep -Fq 'pullRequest.head.sha !== run.head_sha' .github/workflows/build-timing-report.yml
+grep -Fq 'runPullRequest?.base?.sha || pullRequest.base.sha' \
+  .github/workflows/build-timing-report.yml
+grep -Fq 'BUILD_TIMING_NATIVE_COMMAND: lake build toyproblem-runtime hachi-runtime' \
+  .github/workflows/build-timing-report.yml
+if grep -Fq 'the previous successful PR update' .github/workflows/build-timing-report.yml; then
+  echo 'reporter must not silently use a moving previous-PR baseline' >&2
+  exit 1
+fi
+
+echo 'Build timing report fixtures passed.'

--- a/scripts/test-build-timing-report.sh
+++ b/scripts/test-build-timing-report.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
+# The workflow exports the production artifact path globally. Fixtures must resolve metadata next
+# to their synthetic results instead of accidentally reading that workflow-owned file.
+unset BUILD_TIMING_METADATA_PATH
+
 fixture_tmp="$(mktemp -d)"
 trap 'rm -rf "$fixture_tmp"' EXIT
 

--- a/scripts/test-build-timing-report.sh
+++ b/scripts/test-build-timing-report.sh
@@ -8,7 +8,7 @@ cd "$repo_root"
 # instead of accidentally reading workflow state that is absent in a developer shell.
 while IFS='=' read -r variable _; do
   case "$variable" in
-    BUILD_TIMING_*) unset "$variable" ;;
+    BUILD_TIMING_* | GITHUB_REF_NAME | GITHUB_REPOSITORY) unset "$variable" ;;
   esac
 done < <(env)
 

--- a/scripts/test-build-timing-report.sh
+++ b/scripts/test-build-timing-report.sh
@@ -4,12 +4,29 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-# The workflow exports the production artifact path globally. Fixtures must resolve metadata next
-# to their synthetic results instead of accidentally reading that workflow-owned file.
-unset BUILD_TIMING_METADATA_PATH
+# The workflow exports production report inputs globally. Fixtures must own every report input
+# instead of accidentally reading workflow state that is absent in a developer shell.
+while IFS='=' read -r variable _; do
+  case "$variable" in
+    BUILD_TIMING_*) unset "$variable" ;;
+  esac
+done < <(env)
 
 fixture_tmp="$(mktemp -d)"
 trap 'rm -rf "$fixture_tmp"' EXIT
+
+on_error() {
+  status=$?
+  echo "Build timing report fixture failed at line ${BASH_LINENO[0]}." >&2
+  for report_file in "$fixture_tmp"/*.md; do
+    if [ -f "$report_file" ]; then
+      echo "--- $report_file" >&2
+      sed -n '1,220p' "$report_file" >&2
+    fi
+  done
+  exit "$status"
+}
+trap on_error ERR
 
 current_dir="$fixture_tmp/current"
 base_dir="$fixture_tmp/base"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -22,6 +22,7 @@ Default checks:
   - lake exe hachi-runtime
   - fail on non-`sorry` warnings under ArkLib/Data/
   - ./scripts/check-imports.sh
+  - ./scripts/test-build-timing-report.sh
   - python3 ./scripts/check-docs-integrity.py
   - python3 ./scripts/kb/lint.py
 
@@ -89,6 +90,10 @@ lake exe hachi-runtime
 echo ""
 echo "# Checking umbrella imports"
 ./scripts/check-imports.sh
+
+echo ""
+echo "# Testing build timing report fixtures"
+./scripts/test-build-timing-report.sh
 
 echo ""
 echo "# Checking docs integrity"


### PR DESCRIPTION
## Summary

This PR makes ArkLib's build-timing report attributable enough to support focused optimization decisions without adding more CI builds.

It:

- compares a PR only with a successful timing artifact for its exact measured base SHA;
- rejects stale completed runs before they can overwrite the current PR comment;
- records the measured checkout, head/base SHAs, dependency-manifest hash, cache provenance, and runner image/version;
- reports CPU work (`user + sys`) alongside wall time, so scheduler/I/O noise is easier to distinguish from changed compilation work;
- pins the measured build to `ubuntu-24.04` and fixes the native-build command label to include both runtime executables; and
- adds deterministic fixtures to the routine validation path.

This follows #814, which established the timing and trust workflow extended here. GitHub restacked these four unique commits onto `main` after #814 merged.

### Diff metadata

- Base: `5a9626d331d713c7e74efa7e3d93b7d0ec9c4dc2` (`main`)
- Head: `8ea8a04612f8778ff22e131e9c04a842f83041a3`
- Commits: 4
- Files changed: 8
- Diff: 612 insertions, 59 deletions

## Motivation

The existing report could present a prior PR update or the latest successful `main` run as a baseline even when that run measured a different source tree. A delayed `workflow_run` could also upsert a comment after a newer head had been pushed. Finally, the artifact did not say which merge checkout, dependency manifest, cache restore, or runner image produced its numbers.

That made fluctuations difficult to classify and made a single wall-time delta look more authoritative than it was. Repeating builds or adding a second baseline build would improve statistics, but would also increase CI runtime substantially. This round first fixes identity and comparability at effectively zero additional build cost.

## Data flow

```mermaid
flowchart LR
    A[Unprivileged PR CI] -->|results, logs, validated metadata| B[Timing artifact]
    C[Exact successful base push] -->|matching-SHA artifact only| D[Trusted workflow_run reporter]
    B --> D
    D -->|stale-head check and escaped rendering| E[Single PR comment]
```

## Change-surface overview

| Area | Before | After |
|---|---|---|
| Baseline | Previous PR update, exact base, or latest base-branch run | Exact measured base SHA only; otherwise explicitly unavailable |
| Run identity | Displayed the live PR head | Records PR head, workflow head, actual checkout, and exact base |
| Variance clues | Wall time only | Wall time plus CPU work, runner image/version, cache provenance, and manifest hash |
| Runner | Moving `ubuntu-latest` label | Pinned `ubuntu-24.04` build runner |
| Native row | Label named only `toyproblem-runtime` | Label matches both `toyproblem-runtime` and `hachi-runtime` |
| Regression coverage | No dedicated renderer/metadata fixture | Deterministic fixtures run under `./scripts/validate.sh` |

## Implementation

`scripts/build_timing_metadata.py` owns schema-versioned artifact metadata and validates types, SHAs, hashes, cache state, and runner fields. `.github/workflows/ci.yml` writes that metadata next to the existing timing results and logs.

The trusted reporter now derives the comparison identity from the immutable completed workflow run, checks that its head still equals the live PR head, and checks out reporting code at the exact trusted base SHA. Baseline discovery accepts only a successful `push` CI artifact whose `head_sha` equals the measured PR base. It does not silently substitute another commit.

`scripts/build_timing_report.sh` treats legacy or malformed metadata as unavailable attribution rather than executable input or a rendering failure. Reports include wall and CPU deltas, cache classification, manifest identity, checkout identity, runner identity, and an explicit comparability warning when dependency manifests differ.

## Trust and security boundary

- No permissions are added. PR CI remains read-only; only the base-branch `workflow_run` reporter has PR-comment permission.
- The privileged reporter continues to execute scripts checked out from the trusted base, now pinned to the exact measured base commit rather than a moving branch ref.
- The PR-produced artifact is treated as data. Metadata is JSON-decoded, schema/type validated, and Markdown/HTML escaped before rendering; it is never sourced or executed.
- A stale run cannot overwrite the rolling comment after the PR head changes.
- This does not weaken the source-trust audit, kernel axiom sweep, runtime checks, import discipline, or any existing required check.

## Validation completed at `8ea8a046`

The exact committed head passed:

- `LAKE_ARTIFACT_CACHE=false LAKE_NO_CACHE=true ./scripts/validate.sh`;
- full Lean project build and the `ArkLib/Data` non-`sorry` warning gate;
- toy-problem and nonrecursive-Hachi compiled runtime checks;
- blanket-import and umbrella-import checks;
- build-timing metadata/report fixtures, including exact/fallback cache rendering, missing exact baseline, malformed and wrong-schema metadata, native command ownership, Markdown escaping, and stale-run policy assertions;
- fixture isolation from the inherited `BUILD_TIMING_*`, `GITHUB_REPOSITORY`, and `GITHUB_REF_NAME` workflow inputs, with failure diagnostics that print the exact fixture line and generated reports;
- documentation integrity and knowledge-base lint;
- workflow YAML parsing, Python compilation, shell syntax checks, and `git diff --check`; and
- rendering against the real legacy timing artifacts from #814.

## Deliberately deferred

This PR does not add repeated builds, medians/MAD, historical storage, performance-failure thresholds, lower Lake parallelism, or self-hosted runners. Those options add runtime, operating cost, or policy risk and should be evaluated after the cleaner signal has accumulated. A single hosted-runner sample remains diagnostic, not a blocking performance verdict.

## Reviewer map

Suggested order:

1. `.github/workflows/build-timing-report.yml` — immutable run identity, stale-run rejection, and exact-base selection.
2. `.github/workflows/ci.yml` — runner pin and artifact metadata production.
3. `scripts/build_timing_metadata.py` — metadata schema and validation boundary.
4. `scripts/build_timing_report.sh` — attribution and wall/CPU rendering.
5. `scripts/test-build-timing-report.sh` and `scripts/validate.sh` — regression coverage.
6. `scripts/README.md` and `docs/wiki/quickstart.md` — operating and interpretation guidance.
