### PR TITLE
fix(ci): diff the KB gate against the merge base, not the base tip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,7 @@ jobs:
           )
         run: |
           changed="$(git diff --name-only \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}" \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
             -- docs/kb/_generated)"
           if [ -n "$changed" ]; then
             echo "Do not commit docs/kb/_generated files in feature PRs."


### PR DESCRIPTION
The 'Reject generated KB updates in PRs' gate used a two-dot diff base.sha..head.sha, so any PR whose base branch had since received a KB refresh (e.g. #788, #817, #820) failed the build job without Lean ever running, listing main's own docs/kb/_generated changes as if the PR had committed them. A three-dot diff compares against the merge base and only flags files the PR itself touched.