### PR TITLE
lint: tighten non-Data proof hotspots

### DIFF
--- a/ArkLib/OracleReduction/Composition/Sequential/Append.lean
+++ b/ArkLib/OracleReduction/Composition/Sequential/Append.lean
@@ -82,7 +82,9 @@ def Prover.append (P₁ : Prover oSpec Stmt₁ Wit₁ Stmt₂ Wit₂ pSpec₁)
 
   /- The combined prover's input function is the first prover's input function, except for when the
   first protocol is empty, in which case it is the second prover's input function -/
-  input := fun ctxIn => by simp; exact P₁.input ctxIn
+  input := fun ctxIn => by
+    simp only [Function.comp_apply, Fin.cast_zero, Fin.append_zero_of_succ_left]
+    exact P₁.input ctxIn
 
   /- The combined prover sends messages according to the round index `i` as follows:
   - if `i < m`, then it sends the message & updates the state as the first prover
@@ -94,19 +96,25 @@ def Prover.append (P₁ : Prover oSpec Stmt₁ Wit₁ Stmt₂ Wit₂ pSpec₁)
       Fin.cast, Fin.castLT, Fin.succ, Fin.castSucc] at hDir state ⊢
     by_cases hi : i < m
     · haveI : i < m + 1 := by omega
-      simp [hi, Fin.vappend_left_of_lt] at hDir ⊢
-      simp [this] at state
+      simp only [hi, Fin.vappend_left_of_lt, Order.lt_add_one_iff, Order.add_one_le_iff,
+        ↓reduceDIte] at hDir ⊢
+      simp only [this, ↓reduceDIte] at state
       exact P₁.sendMessage ⟨⟨i, hi⟩, hDir⟩ state
     · by_cases hi' : i = m
-      · simp [hi', Fin.vappend_right_of_not_lt] at hDir state ⊢
+      · simp only [hi', lt_self_iff_false, not_false_eq_true,
+          Fin.vappend_right_of_not_lt, tsub_self,
+          lt_add_iff_pos_right, Order.lt_one_iff, ↓reduceDIte, zero_add,
+          eq_rec_constant] at hDir state ⊢
         exact (do
           let ctxIn₂ ← P₁.output state
           letI state₂ := P₂.input ctxIn₂
           P₂.sendMessage ⟨⟨0, by omega⟩, hDir⟩ state₂)
       · haveI hi1 : ¬ i < m + 1 := by omega
         haveI hi2 : i - (m + 1) + 1 = i - m := by omega
-        simp [hi, Fin.vappend_right_of_not_lt] at hDir ⊢
-        simp [hi1] at state
+        simp only [hi, not_false_eq_true, Fin.vappend_right_of_not_lt,
+          Order.lt_add_one_iff, Order.add_one_le_iff, ↓reduceDIte,
+          Nat.reduceSubDiff, eq_rec_constant] at hDir ⊢
+        simp only [hi1, ↓reduceDIte, eq_rec_constant] at state
         exact P₂.sendMessage ⟨⟨i - m, by omega⟩, hDir⟩ (dcast (by simp [hi2]) state)
 
   /- Receiving challenges is implemented essentially the same as sending messages, modulo the
@@ -116,19 +124,25 @@ def Prover.append (P₁ : Prover oSpec Stmt₁ Wit₁ Stmt₂ Wit₂ pSpec₁)
       Fin.cast, Fin.castLT, Fin.succ, Fin.castSucc] at hDir state ⊢
     by_cases hi : i < m
     · haveI : i < m + 1 := by omega
-      simp [hi, Fin.vappend_left_of_lt] at hDir ⊢
-      simp [this] at state
+      simp only [hi, Fin.vappend_left_of_lt, Order.lt_add_one_iff, Order.add_one_le_iff,
+        ↓reduceDIte] at hDir ⊢
+      simp only [this, ↓reduceDIte] at state
       exact P₁.receiveChallenge ⟨⟨i, hi⟩, hDir⟩ state
     · by_cases hi' : i = m
-      · simp [hi', Fin.vappend_right_of_not_lt] at hDir state ⊢
+      · simp only [hi', lt_self_iff_false, not_false_eq_true,
+          Fin.vappend_right_of_not_lt, tsub_self,
+          lt_add_iff_pos_right, Order.lt_one_iff, ↓reduceDIte, zero_add,
+          eq_rec_constant] at hDir state ⊢
         exact (do
           let ctxIn₂ ← P₁.output state
           letI state₂ := P₂.input ctxIn₂
           P₂.receiveChallenge ⟨⟨0, by omega⟩, hDir⟩ state₂)
       · haveI hi1 : ¬ i < m + 1 := by omega
         haveI hi2 : i - (m + 1) + 1 = i - m := by omega
-        simp [hi, Fin.vappend_right_of_not_lt] at hDir ⊢
-        simp [hi1] at state
+        simp only [hi, not_false_eq_true, Fin.vappend_right_of_not_lt,
+          Order.lt_add_one_iff, Order.add_one_le_iff, ↓reduceDIte,
+          Nat.reduceSubDiff, eq_rec_constant] at hDir ⊢
+        simp only [hi1, ↓reduceDIte, eq_rec_constant] at state
         exact P₂.receiveChallenge ⟨⟨i - m, by omega⟩, hDir⟩ (dcast (by simp [hi2]) state)
 
   /- The combined prover's output function has two cases:
@@ -138,13 +152,15 @@ def Prover.append (P₁ : Prover oSpec Stmt₁ Wit₁ Stmt₂ Wit₂ pSpec₁)
   output := fun state => by
     dsimp [Fin.append, Fin.addCases, Fin.tail, Fin.cast, Fin.last, Fin.subNat] at state
     by_cases hn : n = 0
-    · simp [hn] at state
+    · simp only [hn, add_zero, lt_add_iff_pos_right, Order.lt_one_iff,
+        ↓reduceDIte] at state
       exact (do
         let ctxIn₂ ← P₁.output state
         letI state₂ := P₂.input ctxIn₂
         P₂.output (dcast (by simp [hn]) state₂))
     · haveI : m + n - (m + 1) + 1 = n := by omega
-      simp [hn] at state
+      simp only [Order.lt_add_one_iff, add_le_iff_nonpos_right,
+        nonpos_iff_eq_zero, hn, ↓reduceDIte, eq_rec_constant] at state
       exact P₂.output (dcast (by simp [this, Fin.last]) state)
 
 /-- Composition of verifiers. Return the conjunction of the decisions of the two verifiers. -/
@@ -499,7 +515,9 @@ lemma OracleVerifier.append_toVerifier
     show Challenges.snd transcript.challenges = transcript.snd.challenges from rfl,
     show Messages.fst transcript.messages = transcript.fst.messages from rfl,
     show Messages.snd transcript.messages = transcript.snd.messages from rfl]
-  simp [OptionT.run_bind, Option.elimM, Function.comp_def]
+  simp only [MessageIdx, Message, OptionT.run_bind, Option.elimM, map_bind,
+    OptionT.mk_bind, OptionT.run_monadLift, monadLift_self, OptionT.run_mk,
+    bind_map_left, Option.elim_some, Option.elim_map, Function.comp_def]
   rw [show
     OptionT.run (simulateQ (OracleInterface.simOracle2 oSpec oStmt transcript.fst.messages)
       (V₁.verify stmt transcript.fst.challenges) :
@@ -575,7 +593,9 @@ def RoundByRound.append
       Extractor.RoundByRound oSpec Stmt₁ Wit₁ Wit₃ (pSpec₁ ++ₚ pSpec₂)
         (Fin.append (m := m + 1) WitMid₁ (Fin.tail WitMid₂) ∘ Fin.cast (by omega)) where
   eqIn := by
-    simp [Fin.append, Fin.addCases, Fin.castLT]
+    simp only [Fin.append, Function.comp_apply, Fin.addCases, Fin.cast_zero,
+      Fin.coe_ofNat_eq_mod, Nat.zero_mod, lt_add_iff_pos_left,
+      Order.lt_add_one_iff, zero_le, ↓reduceDIte, Fin.castLT, Fin.zero_eta]
     exact E₁.eqIn
   extractMid := fun idx stmt₁ tr h => by
     dsimp [Fin.append, Fin.addCases, Fin.tail, Fin.castLT, Fin.cast] at h ⊢
@@ -614,7 +634,7 @@ def StateFunction.append
     -- the first state fn on the first protocol's transcript, and the second state fn on the
     -- remaining transcript.
       have hm : min roundIdx.val m = m := min_eq_right_of_lt (by omega)
-      let transcript₁ : pSpec₁.FullTranscript := fun i => transcript.fst ⟨i, by simpa [hm]⟩
+      let transcript₁ : pSpec₁.FullTranscript := fun i => transcript.fst ⟨i, by simp [hm]⟩
       S₁ ⟨m, by omega⟩ stmt₁ transcript₁ ∧
       S₂ ⟨roundIdx - m, by omega⟩ (verify stmt₁ transcript₁)
         (by simpa [h] using transcript.snd)

--- a/ArkLib/OracleReduction/LiftContext/Reduction.lean
+++ b/ArkLib/OracleReduction/LiftContext/Reduction.lean
@@ -224,8 +224,7 @@ theorem liftContext_processRound
   simp only [bind_pure_comp]
   congr 1; funext ⟨tr, ps, outerStmtIn', outerWitIn'⟩
   simp only [pure_bind]
-  split <;> simp [Functor.map_map, Function.comp, liftM_map, map_bind,
-    bind_assoc, pure_bind, bind_map_left, bind_pure_comp]
+  split <;> simp [Functor.map_map, liftM_map, map_bind]
 
 
 theorem liftContext_runToRound
@@ -309,9 +308,11 @@ theorem liftContext_run
         return ⟨⟨fullTranscript, lens.lift (outerStmtIn, outerWitIn) innerCtxOut⟩ ,
                 lens.stmt.lift outerStmtIn verInnerStmtOut⟩ := by
   unfold run
-  simp [liftContext, Prover.liftContext_run, Verifier.liftContext, Verifier.run, Function.uncurry]
+  simp only [ChallengeIdx, Challenge, liftContext, Verifier.liftContext, bind_pure_comp,
+    Prover.liftContext_run, Function.uncurry, liftM_map, Verifier.run, OptionT.run_map,
+    bind_map_left, map_bind, Functor.map_map]
   congr 1; funext ⟨_, _⟩; congr 1; funext a_1
-  simp [Functor.map_map, Function.comp]
+  simp
   cases a_1 <;> simp [Option.getM, map_pure]
 
 theorem liftContext_runWithLog
@@ -408,7 +409,11 @@ theorem liftContext_soundness [Inhabited InnerStmtOut]
   unfold soundness Reduction.run at h ⊢
   -- Note: there is no distinction between `Outer` and `Inner` here
   intro WitIn WitOut outerWitIn outerP outerStmtIn hOuterStmtIn
-  simp at h ⊢
+  simp only [ChallengeIdx, Challenge, QueryImpl.addLift_def,
+    PFunctor.Handler.liftTarget_self, bind_pure_comp, OptionT.run_bind,
+    OptionT.run_monadLift, monadLift_self, OptionT.run_map, Option.elimM_map,
+    Option.elim_some, simulateQ_bind, StateT.run'_eq, StateT.run_bind, map_bind,
+    OptionT.mk_bind] at h ⊢
   have innerP : Prover oSpec InnerStmtIn WitIn InnerStmtOut WitOut pSpec := {
     PrvState := outerP.PrvState
     input := fun _ => outerP.input (outerStmtIn, outerWitIn)
@@ -454,7 +459,10 @@ theorem liftContext_knowledgeSoundness [Inhabited InnerStmtOut] [Inhabited Inner
   obtain ⟨E, h'⟩ := h
   refine ⟨E.liftContext ⟨stmtLens, witLens⟩, ?_⟩
   intro outerStmtIn outerWitIn outerP
-  simp [Extractor.Straightline.liftContext]
+  simp only [ChallengeIdx, Challenge, QueryImpl.addLift_def,
+    PFunctor.Handler.liftTarget_self, Extractor.Straightline.liftContext,
+    bind_pure_comp, OptionT.run_map, liftM_map, Functor.map_map, OptionT.run_bind,
+    StateT.run'_eq, OptionT.mk_bind, Option.mem_def, Prod.mk.eta]
   let innerP : Prover oSpec InnerStmtIn InnerWitIn InnerStmtOut InnerWitOut pSpec :=
     {
       PrvState := outerP.PrvState
@@ -467,9 +475,14 @@ theorem liftContext_knowledgeSoundness [Inhabited InnerStmtOut] [Inhabited Inner
     }
   have h_innerP_input {innerStmtIn} {innerWitIn} :
       innerP.input (innerStmtIn, innerWitIn) = outerP.input (outerStmtIn, outerWitIn) := rfl
-  simp at h'
+  simp only [ChallengeIdx, Challenge, QueryImpl.addLift_def,
+    PFunctor.Handler.liftTarget_self, bind_pure_comp, OptionT.run_bind,
+    OptionT.run_map, StateT.run'_eq, OptionT.mk_bind, Option.mem_def, Prod.mk.eta] at h'
   have hR := h' (stmtLens.proj outerStmtIn) default innerP
-  simp [Reduction.runWithLog, Verifier.liftContext, Verifier.run] at hR ⊢
+  simp only [Reduction.runWithLog, ChallengeIdx, Challenge, run, bind_pure_comp,
+    OptionT.run_bind, OptionT.run_monadLift, monadLift_self, OptionT.run_map,
+    Option.elimM_map, Option.elim_some, Option.elimM_bind, simulateQ_bind,
+    StateT.run_bind, map_bind, OptionT.mk_bind, liftContext, ge_iff_le] at hR ⊢
   have h_innerP_runWithLog {innerStmtIn} {innerWitIn} :
       innerP.runWithLog innerStmtIn innerWitIn
       = do
@@ -499,7 +512,10 @@ theorem liftContext_rbr_soundness [Inhabited InnerStmtOut]
       (V.liftContext lens).rbrSoundness init impl outerLangIn outerLangOut rbrSoundnessError := by
   unfold rbrSoundness at h ⊢
   obtain ⟨stF, h⟩ := h
-  simp at h ⊢
+  simp only [ChallengeIdx, Challenge, QueryImpl.addLift_def,
+    PFunctor.Handler.liftTarget_self, HasQuery.instOfMonadLift_query, bind_pure_comp,
+    simulateQ_bind, simulateQ_map, StateT.run'_eq, StateT.run_bind, StateT.run_map,
+    map_bind, Functor.map_map, Subtype.forall] at h ⊢
   refine ⟨stF.liftContext lens (lensSound := lensSound), ?_⟩
   intro outerStmtIn hOuterStmtIn WitIn WitOut witIn outerP roundIdx hDir
   have innerP : Prover oSpec InnerStmtIn WitIn InnerStmtOut WitOut pSpec := {

--- a/ArkLib/ProofSystem/Binius/BinaryBasefold/Prelude.lean
+++ b/ArkLib/ProofSystem/Binius/BinaryBasefold/Prelude.lean
@@ -31,9 +31,10 @@ section Preliminaries
 NOTE : we can prove strict equality given `g` being an equivalence instead of injection.
 -/
 theorem hammingDist_le_of_outer_comp_injective {ι₁ ι₂ : Type*} [Fintype ι₁] [Fintype ι₂]
-    {β : ι₂ → Type*} [∀ i, DecidableEq (β i)] [DecidableEq ι₂]
+    {β : ι₂ → Type*} [∀ i, DecidableEq (β i)]
     (x y : ∀ i, β i) (g : ι₁ → ι₂) (hg : Function.Injective g) :
     hammingDist (fun i => x (g i)) (fun i => y (g i)) ≤ hammingDist x y := by
+  classical
   -- Let D₂ be the set of disagreeing indices for x and y.
   let D₂ := Finset.filter (fun i₂ => x i₂ ≠ y i₂) Finset.univ
   -- The Hamming distance of the composed functions is the card of the preimage of D₂.
@@ -49,32 +50,10 @@ theorem hammingDist_le_of_outer_comp_injective {ι₁ ι₂ : Type*} [Fintype ι
     ext i₁
     -- Now `simp` can easily unfold `mem_filter` and `mem_preimage` and see they are equivalent.
     simp only [ne_eq, mem_filter, mem_univ, true_and, mem_preimage, D₂]
-
   -- Now, rewrite the goal using `preimage`.
   rw [h_preimage]
-  set D₁ := D₂.preimage g (by exact hg.injOn)
-  -- ⊢ #D₁ ≤ #D₂
-  -- Step 1 : The size of a set is at most the size of its image under an injective function.
-  have h_card_le_image : D₁.card ≤ (D₁.image g).card := by
-    -- This follows directly from the fact that `g` is injective on the set D₁.
-    apply Finset.card_le_card_of_injOn (f := g)
-    · -- Goal 1 : Prove that `g` maps `D₁` to `D₁.image g`. This is true by definition of image.
-      have res := Set.mapsTo_image (f := g) (s := D₁)
-      convert res
-      simp only [coe_image]
-      -- (D₁.image g : Set ι₂)
-    · -- Goal 2 : Prove that `g` is injective on the set `D₁`.
-      -- This is true because our main hypothesis `hg` states that `g` is injective everywhere.
-      exact Function.Injective.injOn hg
-
-  -- Step 2 : The image of the preimage of a set is always a subset of the original set.
-  have h_image_subset : D₁.image g ⊆ D₂ := by
-    simp [D₁, Finset.image_preimage]
-
-  -- Step 3 : By combining these two facts, we get our result.
-  -- |D₁| ≤ |image g(D₁)| (from Step 1)
-  -- and |image g(D₁)| ≤ |D₂| (since it's a subset)
-  exact h_card_le_image.trans (Finset.card_le_card h_image_subset)
+  rw [Finset.card_preimage]
+  exact Finset.card_filter_le _ _
 
 variable {L : Type} [CommRing L] (ℓ : ℕ) [NeZero ℓ]
 
@@ -191,7 +170,6 @@ noncomputable def qMap_total_fiber
     -- fun (k : 𝔽q) =>
     let basis_y := sDomain_basis 𝔽q β h_ℓ_add_R_rate (i := ⟨i+steps,by omega⟩) (by omega)
     let y_coeffs : Fin (ℓ + 𝓡 - (↑i + steps)) →₀ 𝔽q := basis_y.repr y
-
     let basis_x := sDomain_basis 𝔽q β h_ℓ_add_R_rate ⟨i, by omega⟩ (by simp only; omega)
     exact fun elementIdx => by
       let x_coeffs : Fin (ℓ + 𝓡 - i) → 𝔽q := fun j =>
@@ -279,7 +257,6 @@ lemma qMap_total_fiber_one_level_eq (i : Fin ℓ) (h_i_add_1 : i.val + 1 ≤ ℓ
     (y := y) (k := k) (j := j)
   simp only [h_repr_x, Finsupp.coe_add, Pi.add_apply]
   simp only [fiber_coeff, lt_one_iff, reducePow, Fin2ToF2, Fin.isValue]
-
   by_cases hj : j = ⟨0, by omega⟩
   · simp only [hj, ↓reduceDIte, Fin.isValue, Finsupp.single_eq_same]
     by_cases hk : k = 0
@@ -537,7 +514,7 @@ theorem card_qMap_total_fiber (i : Fin ℓ) (steps : ℕ) (h_i_add_steps : i.val
       conv_lhs => rw [Nat.getBit_of_lt_two_pow]
       conv_rhs => rw [Nat.getBit_of_lt_two_pow]
       simp only [h_k, ↓reduceIte]
-omit [CharP L 2] [NeZero ℓ] in
+omit [CharP L 2] [DecidableEq 𝔽q] [NeZero ℓ] in
 /-- The images of `qMap_total_fiber` over distinct quotient points `y₁ ≠ y₂` are
 disjoint -/
 theorem qMap_total_fiber_disjoint
@@ -550,6 +527,7 @@ theorem qMap_total_fiber_disjoint
     ((qMap_total_fiber 𝔽q β (i := ⟨i, by omega⟩) (steps := steps)
       (h_i_add_steps := fin_ℓ_steps_lt_ℓ_add_R i steps h_i_add_steps) y₂ '' Set.univ).toFinset)
     := by
+  classical
  -- Proof by contradiction. Assume the intersection is non-empty.
   rw [Finset.disjoint_iff_inter_eq_empty]
   by_contra h_nonempty
@@ -583,29 +561,24 @@ theorem qMap_total_fiber_disjoint
     -- ⊢ `∃ (k : Fin (2 ^ steps)), k ∈ Set.univ ∧ qMap_total_fiber ... y₁ k = x`.
     rcases hx₁ with ⟨k, _, h_eq⟩
     use k; exact h_eq.symm
-
   have h_exists_k₂ : ∃ k, x = qMap_total_fiber 𝔽q β (i := ⟨i, by omega⟩) (steps := steps)
       (h_i_add_steps := by apply Nat.lt_add_of_pos_right_of_le; omega) y₂ k := by
     rw [Set.mem_toFinset] at hx₂
     rw [Set.mem_image] at hx₂ -- Set.mem_image gives us t an index that maps to x
     rcases hx₂ with ⟨k, _, h_eq⟩
     use k; exact h_eq.symm
-
   have h_y₁_eq_quotient_x : y₁ =
       iteratedQuotientMap 𝔽q β h_ℓ_add_R_rate
         (i := ⟨i, by omega⟩) (destIdx := ⟨i.val + steps, by omega⟩) (k := steps)
         (h_destIdx := by simp) (h_destIdx_le := h_i_add_steps) x := by
     apply generates_quotient_point_if_is_fiber_of_y (hx_is_fiber := by exact h_exists_k₁)
-
   have h_y₂_eq_quotient_x : y₂ =
       iteratedQuotientMap 𝔽q β h_ℓ_add_R_rate
         (i := ⟨i, by omega⟩) (destIdx := ⟨i.val + steps, by omega⟩) (k := steps)
         (h_destIdx := by simp) (h_destIdx_le := h_i_add_steps) x := by
     apply generates_quotient_point_if_is_fiber_of_y (hx_is_fiber := by exact h_exists_k₂)
-
   let kQuotientIndex := pointToIterateQuotientIndex (i := ⟨i, by omega⟩) (steps := steps)
     (h_i_add_steps := by omega) (x := x)
-
   -- Since `x` is in the fiber of `y₁`, applying the forward map to `x` yields `y₁`.
   have h_map_x_eq_y₁ : iteratedQuotientMap 𝔽q β h_ℓ_add_R_rate
       (i := ⟨i, by omega⟩) (destIdx := ⟨i.val + steps, by omega⟩) (k := steps)
@@ -618,7 +591,6 @@ theorem qMap_total_fiber_disjoint
       exact h_res.symm
     rw [hx₁]
     exact iteratedQuotientMap_of_qMap_total_fiber_eq_self y₁ kQuotientIndex
-
   -- Similarly, since `x` is in the fiber of `y₂`, applying the forward map yields `y₂`.
   have h_map_x_eq_y₂ : iteratedQuotientMap 𝔽q β h_ℓ_add_R_rate
       (i := ⟨i, by omega⟩) (destIdx := ⟨i.val + steps, by omega⟩) (k := steps)
@@ -631,7 +603,6 @@ theorem qMap_total_fiber_disjoint
       exact h_res.symm
     rw [hx₂]
     exact iteratedQuotientMap_of_qMap_total_fiber_eq_self y₂ kQuotientIndex
-
   exact hy_ne (h_map_x_eq_y₁.symm.trans h_map_x_eq_y₂)
 
 /-- Single-step fold : Given `f : S⁽ⁱ⁾ → L` and challenge `r`, produce `S⁽ⁱ⁺¹⁾ → L`, where
@@ -694,6 +665,7 @@ def iterated_fold (i : Fin r) (steps : Fin (ℓ + 1)) (h_i_add_steps : i.val + s
     have fSucc : α ⟨i.succ, by omega⟩ := fold_step i accF
     fSucc) (init := f)
 
+omit [DecidableEq 𝔽q] in
 /--
 Transitivity of iterated_fold : folding for `steps₁` and then for `steps₂`
 equals folding for `steps₁ + steps₂` with concatenated challenges.
@@ -770,7 +742,6 @@ def fiberEvaluationMapping (i : Fin r) (steps : ℕ) (h_i_add_steps : i.val + st
   -- Get the fiber points
   let fiberMap := qMap_total_fiber 𝔽q β (i := i) (steps := steps)
     (h_i_add_steps := h_i_add_steps) (y := y)
-
   -- Evaluate f at each fiber point
   fun idx => f (fiberMap idx)
 
@@ -811,6 +782,7 @@ def localized_fold_eval (i : Fin ℓ) (steps : ℕ) (h_i_add_steps : i + steps �
     exact localized_fold_matrix_form 𝔽q β (i := i) steps h_i_add_steps r_challenges y
       fiber_eval_mapping
 
+omit [DecidableEq 𝔽q] in
 /-- **Lemma 4.9.** The iterated fold equals the localized fold evaluation via matmul form -/
 theorem iterated_fold_eq_matrix_form (i : Fin ℓ) (steps : ℕ) (h_i_add_steps : i + steps ≤ ℓ)
     (f : (sDomain 𝔽q β h_ℓ_add_R_rate) ⟨i, by omega⟩ → L)
@@ -825,7 +797,7 @@ theorem iterated_fold_eq_matrix_form (i : Fin ℓ) (steps : ℕ) (h_i_add_steps 
       r_challenges (y := ⟨y, by exact Submodule.coe_mem y⟩) := by
   sorry
 
-omit [CharP L 2] [NeZero ℓ] in
+omit [CharP L 2] [DecidableEq 𝔽q] [NeZero ℓ] in
 /-- Lemma 4.13 : if f⁽ⁱ⁾ is evaluation of P⁽ⁱ⁾(X) over S⁽ⁱ⁾, then fold(f⁽ⁱ⁾, r_chal)
   is evaluation of P⁽ⁱ⁺¹⁾(X) over S⁽ⁱ⁺¹⁾. At level `i = ℓ`, we have P⁽ˡ⁾ =
 -/
@@ -833,7 +805,7 @@ theorem fold_advances_evaluation_poly
   (i : Fin (ℓ)) (h_i_succ_lt : i + 1 < ℓ + 𝓡)
   (coeffs : Fin (2 ^ (ℓ - ↑i)) → L) (r_chal : L) :
   let P_i : L[X] := intermediateEvaluationPoly 𝔽q β h_ℓ_add_R_rate
-    (i := ⟨i, by omega⟩) (h_i := by simp only [Fin.val_mk]; omega) coeffs
+    (i := ⟨i, by omega⟩) (h_i := by simp only; omega) coeffs
   let f_i := fun (x : (sDomain 𝔽q β h_ℓ_add_R_rate)
       ⟨i, by exact Nat.lt_trans (n := i) (k := r) (m := ℓ) (h₁ := by omega) (by omega)⟩) =>
     P_i.eval (x.val : L)
@@ -850,9 +822,10 @@ theorem fold_advances_evaluation_poly
     ⟩)
   let P_i_plus_1 :=
     intermediateEvaluationPoly 𝔽q β h_ℓ_add_R_rate
-      (i := ⟨i + 1, by omega⟩) (h_i := by simp only [Fin.val_mk]; omega) new_coeffs
+      (i := ⟨i + 1, by omega⟩) (h_i := by simp only; omega) new_coeffs
   ∀ (y : (sDomain 𝔽q β h_ℓ_add_R_rate)
     ⟨i+1, by omega⟩), f_i_plus_1 y = P_i_plus_1.eval y.val := by
+  classical
   simp only
   intro y
   set fiberMap := qMap_total_fiber 𝔽q β (i := ⟨i, by omega⟩) (steps := 1)
@@ -860,7 +833,7 @@ theorem fold_advances_evaluation_poly
   set x₀ := fiberMap 0
   set x₁ := fiberMap 1
   set P_i := intermediateEvaluationPoly 𝔽q β h_ℓ_add_R_rate
-    (i := ⟨i, by omega⟩) (h_i := by simp only [Fin.val_mk]; omega) coeffs
+    (i := ⟨i, by omega⟩) (h_i := by simp only; omega) coeffs
   set new_coeffs := fun j : Fin (2^(ℓ - (i + 1))) =>
     (1 - r_chal) * (coeffs ⟨j.val * 2, by
       have h : j.val * 2 < 2^(ℓ - (i + 1)) * 2 := by omega
@@ -878,10 +851,10 @@ theorem fold_advances_evaluation_poly
       · omega
     ⟩)
   have h_eval_qMap_x₀ : (AdditiveNTT.qMap 𝔽q β ⟨i, by omega⟩
-      (by simp only [Fin.val_mk]; omega)).eval x₀.val = y := by
+      (by simp only; omega)).eval x₀.val = y := by
     have h := iteratedQuotientMap_k_eq_1_is_qMap 𝔽q β h_ℓ_add_R_rate
       (i := ⟨i, by omega⟩) (destIdx := ⟨i + 1, by omega⟩)
-      (h_destIdx := by simp) (h_destIdx_le := by simp only [Fin.val_mk]; omega) x₀
+      (h_destIdx := by simp) (h_destIdx_le := by simp only; omega) x₀
     simp only [Subtype.ext_iff] at h
     rw [h.symm]
     have h_res := is_fiber_iff_generates_quotient_point 𝔽q β i (steps := 1) (by omega)
@@ -889,10 +862,10 @@ theorem fold_advances_evaluation_poly
     rw [h_res]
     -- exact qMap_eval_fiber_eq_self ⟦L⟧ ⟨i + 1, by omega⟩ (by simp only; omega) h_i_succ_lt y 0
   have h_eval_qMap_x₁ : (AdditiveNTT.qMap 𝔽q β ⟨i, by omega⟩
-      (by simp only [Fin.val_mk]; omega)).eval x₁.val = y := by
+      (by simp only; omega)).eval x₁.val = y := by
     have h := iteratedQuotientMap_k_eq_1_is_qMap 𝔽q β h_ℓ_add_R_rate
       (i := ⟨i, by omega⟩) (destIdx := ⟨i + 1, by omega⟩)
-      (h_destIdx := by simp) (h_destIdx_le := by simp only [Fin.val_mk]; omega) x₁
+      (h_destIdx := by simp) (h_destIdx_le := by simp only; omega) x₁
     simp only [Subtype.ext_iff] at h
     rw [h.symm]
     have h_res := is_fiber_iff_generates_quotient_point 𝔽q β i (steps := 1) (by omega)
@@ -903,7 +876,6 @@ theorem fold_advances_evaluation_poly
   have hx₁ := qMap_total_fiber_basis_sum_repr 𝔽q β i (steps := 1)
     (h_i_add_steps := by omega) y 1
   simp only [Fin.isValue] at hx₀ hx₁
-
   have h_fiber_diff : x₁.val - x₀.val = 1 := by
     simp only [Fin.isValue, x₁, x₀, fiberMap]
     rw [hx₁, hx₀]
@@ -948,7 +920,7 @@ theorem fold_advances_evaluation_poly
     simp only [mem_univ, congr_eqRec, Fin.val_succ, Nat.add_eq_zero_iff, one_ne_zero, and_false,
       ↓reduceDIte, add_tsub_cancel_right, Fin.eta, imp_self, implies_true]
   set P_i_plus_1 := intermediateEvaluationPoly 𝔽q β h_ℓ_add_R_rate
-    (i := ⟨i + 1, by omega⟩) (h_i := by simp only [Fin.val_mk]; omega) new_coeffs
+    (i := ⟨i + 1, by omega⟩) (h_i := by simp only; omega) new_coeffs
   -- Set up the even and odd refinement polynomials
   set P₀_coeffs := fun j : Fin (2^(ℓ - (i + 1))) => coeffs ⟨j.val * 2, by
     have h1 : ℓ - (i + 1) + 1 = ℓ - i := by omega
@@ -961,17 +933,17 @@ theorem fold_advances_evaluation_poly
     have h3 : 2^(ℓ - (i + 1)) * 2 = 2^(ℓ - (i + 1) + 1) := by rw [pow_succ]
     rw [← h2, ← h3]; omega⟩
   set P₀ := evenRefinement 𝔽q β h_ℓ_add_R_rate
-    (i := ⟨i, by omega⟩) (h_i := by simp only [Fin.val_mk]; omega) coeffs
+    (i := ⟨i, by omega⟩) (h_i := by simp only; omega) coeffs
   set P₁ := oddRefinement 𝔽q β h_ℓ_add_R_rate
-    (i := ⟨i, by omega⟩) (h_i := by simp only [Fin.val_mk]; omega) coeffs
+    (i := ⟨i, by omega⟩) (h_i := by simp only; omega) coeffs
   have h_P_i_eval := evaluation_poly_split_identity 𝔽q β h_ℓ_add_R_rate
-    (i := ⟨i, by omega⟩) (h_i := by simp only [Fin.val_mk]; omega) coeffs
+    (i := ⟨i, by omega⟩) (h_i := by simp only; omega) coeffs
   -- Equation 39 : P^(i)(X) = P₀^(i+1)(q^(i)(X)) + X · P₁^(i+1)(q^(i)(X))
   have h_equation_39_x₀ : P_i.eval x₀.val = P₀.eval y.val + x₀.val * P₁.eval y.val := by
-    simp only [h_P_i_eval, Fin.eta, Polynomial.eval_add, eval_comp,
+    simp only [h_P_i_eval, Polynomial.eval_add, eval_comp,
       h_eval_qMap_x₀, Polynomial.eval_mul, Polynomial.eval_X, P_i, P₀, P₁]
   have h_equation_39_x₁ : P_i.eval x₁.val = P₀.eval y.val + x₁.val * P₁.eval y.val := by
-    simp only [h_P_i_eval, Fin.eta, Polynomial.eval_add, eval_comp,
+    simp only [h_P_i_eval, Polynomial.eval_add, eval_comp,
       h_eval_qMap_x₁, Polynomial.eval_mul, Polynomial.eval_X, P_i, P₀, P₁]
   set f_i := fun (x : (sDomain 𝔽q β h_ℓ_add_R_rate) ⟨i, by omega⟩) => P_i.eval (x.val : L)
   set f_i_plus_1 := fold (i := ⟨i, by omega⟩) (h_i := by omega) (f := f_i) (r_chal := r_chal)
@@ -1216,7 +1188,7 @@ def uniqueClosestCodeword
     -- Get the closest polynomial
     obtain ⟨p, hp_deg_lt, hp_eval⟩ : ∃ p, p ∈ Polynomial.degreeLT L k ∧
       (fun (x : sDomain 𝔽q β h_ℓ_add_R_rate (i := ⟨i, by omega⟩)) ↦ p.eval (↑x)) = g_closest := by
-      simp only [Fin.eta, BBF_Code, ReedSolomon.code, ReedSolomon.evalOnPoints, Function.Embedding.coeFn_mk,
+      simp only [Fin.eta, BBF_Code, ReedSolomon.code, ReedSolomon.evalOnPoints,
         Submodule.mem_map, LinearMap.coe_mk, AddHom.coe_mk, C_i] at hg_mem
       rcases hg_mem with ⟨p_witness, hp_prop, hp_eq⟩
       exact ⟨p_witness, by simpa [k] using hp_prop, hp_eq⟩
@@ -1288,7 +1260,7 @@ def uniqueClosestCodeword
   let p : L[X] := berlekamp_welch_result.get (Option.ne_none_iff_isSome.mp h_ne_none)
   exact fun x => p.eval x.val
 
-omit [CharP L 2] [NeZero ℓ] in
+omit [CharP L 2] [DecidableEq 𝔽q] [NeZero ℓ] in
 /-- if `d⁽ⁱ⁾(f⁽ⁱ⁾, C⁽ⁱ⁾) < d_{ᵢ₊steps} / 2` (fiberwise distance),
 then `d(f⁽ⁱ⁾, C⁽ⁱ⁾) < dᵢ/2` (regular code distance) -/
 theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (steps : ℕ)
@@ -1297,6 +1269,7 @@ theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (step
   (h_fw_dist_lt : fiberwiseClose 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
     (i := i) (steps := steps) (h_i_add_steps := h_i_add_steps) (f := f)) :
   hammingClose 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ⟨i, by omega⟩ f := by
+  classical
   unfold fiberwiseClose at h_fw_dist_lt
   unfold hammingClose
   -- 2 * Δ₀(f, ↑(BBF_Code 𝔽q β ⟨↑i, ⋯⟩)) < ↑(BBF_CodeDistance ℓ 𝓡 ⟨↑i, ⋯⟩)
@@ -1305,7 +1278,6 @@ theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (step
   let d_H := Code.distFromCode f C_i
   let d_i := BBF_CodeDistance ℓ 𝓡 (⟨i, by omega⟩)
   let d_i_plus_steps := BBF_CodeDistance ℓ 𝓡 ⟨i.val + steps, by omega⟩
-
   have h_d_i_gt_0 : d_i > 0 := by
     dsimp [d_i, BBF_CodeDistance] -- ⊢ 2 ^ (ℓ + 𝓡 - ↑i) - 2 ^ (ℓ - ↑i) + 1 > 0
     have h_exp_lt : ℓ - i.val < ℓ + 𝓡 - i.val := by
@@ -1314,11 +1286,9 @@ theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (step
     have h_pow_lt : 2 ^ (ℓ - i.val) < 2 ^ (ℓ + 𝓡 - i.val) := by
       exact Nat.pow_lt_pow_right (by norm_num) h_exp_lt
     omega
-
   have h_C_i_nonempty : Nonempty C_i := by
     simp only [nonempty_subtype, C_i]
     exact Submodule.nonempty (BBF_Code 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ⟨i.val, by omega⟩)
-
   -- 1. Relate Hamming distance `d_H` to fiber-wise distance `d_fw`.
   obtain ⟨g', h_g'_mem, h_g'_min_card⟩ : ∃ g' ∈ C_i, d_fw
     = (fiberwiseDisagreementSet 𝔽q β i steps h_i_add_steps f g').ncard := by
@@ -1328,19 +1298,15 @@ theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (step
     -- The code `C_i` (a submodule) is non-empty, so `S` is also non-empty.
     have hS_nonempty : S.Nonempty := by
       refine Set.image_nonempty.mpr ?_
-
       exact Set.univ_nonempty
     -- For a non-empty set of natural numbers, `sInf` is an element of the set.
     have h_sInf_mem : sInf S ∈ S := Nat.sInf_mem hS_nonempty
-    -- By definition, `d_fw = sInf S`.
-    unfold d_fw at h_sInf_mem
     -- Since `sInf S` is in the image set `S`, there must be an element `g_subtype` in the domain
     -- (`C_i`) that maps to it. This `g_subtype` is the codeword we're looking for.
     rw [Set.mem_image] at h_sInf_mem
     rcases h_sInf_mem with ⟨g_subtype, _, h_eq⟩
     -- Extract the codeword and its membership proof.
     exact ⟨g_subtype.val, g_subtype.property, by exact id (Eq.symm h_eq)⟩
-
   -- The Hamming distance to any codeword `g'` is bounded by `d_fw * 2 ^ steps`.
   have h_dist_le_fw_dist_times_fiber_size : (hammingDist f g' : ℕ∞) ≤ d_fw * 2 ^ steps := by
     -- This proves `dist f g' ≤ (fiberwiseDisagreementSet ... f g').ncard * 2 ^ steps`
@@ -1356,9 +1322,7 @@ theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (step
     -- Y_bad is the set of quotient points y that THERE EXISTS a bad fiber point x
     set Y_bad := fiberwiseDisagreementSet 𝔽q β i steps h_i_add_steps f g'
     simp only at * -- simplify domain indices everywhere
-
     -- ⊢ #ΔH ≤ Y_bad.ncard * 2 ^ steps
-
     have hFinType_Y_bad : Fintype Y_bad := by exact Fintype.ofFinite ↑Y_bad
     -- Every point of disagreement `x` must belong to a fiber over some `y` in `Y_bad`,
     -- BY DEFINITION of `Y_bad`. Therefore, `ΔH` is a subset of the union of the fibers
@@ -1380,8 +1344,7 @@ theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (step
       have h_elemenet_Y_bad : y_of_x ∈ Y_bad.toFinset := by
         -- ⊢ y ∈ Y_bad.toFinset
         rw [Set.mem_toFinset]
-        simp only [fiberwiseDisagreementSet, iteratedQuotientMap, ne_eq, Subtype.exists,
-          mem_filter, mem_univ, true_and, Y_bad]
+        simp only [fiberwiseDisagreementSet, iteratedQuotientMap, ne_eq, Subtype.exists, Y_bad]
         -- one bad fiber point of y_of_x is x itself
         let X := x.val
         have h_X_in_source : X ∈ sDomain 𝔽q β h_ℓ_add_R_rate (i := ⟨i, by omega⟩) := by
@@ -1399,7 +1362,6 @@ theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (step
         simp only [h_forward_iterated_qmap, Subtype.coe_eta, h_eval_diff,
           not_false_eq_true, and_self]
       simp only [h_elemenet_Y_bad, true_and]
-
       set qMapFiber := qMap_total_fiber 𝔽q β (i := ⟨i, by omega⟩) (steps := steps)
         (h_i_add_steps := by apply Nat.lt_add_of_pos_right_of_le; omega) (y := y_of_x)
       simp only [coe_univ, Set.image_univ, Set.toFinset_range, mem_image, mem_univ, true_and]
@@ -1430,8 +1392,7 @@ theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (step
         simp only [coe_univ, Set.image_univ, Fintype.card_ofFinset, hy_card_fiber_of_y]
       rw [Finset.sum_congr rfl h_card_fiber_of_each_y]
       -- ⊢ ∑ x ∈ Y_bad.toFinset, 2 ^ steps ≤ Y_bad.encard.toNat * 2 ^ steps
-      simp only [sum_const, Set.toFinset_card, smul_eq_mul, ofNat_pos, pow_pos,
-        _root_.mul_le_mul_right, ge_iff_le]
+      simp only [sum_const, Set.toFinset_card, smul_eq_mul, ge_iff_le]
       conv_rhs => rw [←_root_.Nat.card_coe_set_eq] -- convert .ncard back to .card
       -- ⊢ Fintype.card ↑Y_bad ≤ Nat.card ↑Y_bad
       simp only [card_eq_fintype_card, le_refl]
@@ -1441,7 +1402,6 @@ theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (step
         (h_i_add_steps := by omega) (y₁ := y₁) (y₂ := y₂) (hy_ne := hy_ne)
       simp only [Function.onFun, coe_univ]
       exact h_disjoint
-
   -- The minimum distance `d_H` is bounded by the distance to this specific `g'`.
   have h_dist_bridge : d_H ≤ d_fw * 2 ^ steps := by
     -- exact h_dist_le_fw_dist_times_fiber_size
@@ -1453,13 +1413,11 @@ theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (step
       apply sInf_le
       use g'
     · exact h_dist_le_fw_dist_times_fiber_size
-
   -- 2. Use the premise : `2 * d_fw < d_{i+steps}`.
   -- As a `Nat` inequality, this is equivalent to `2 * d_fw ≤ d_{i+steps} - 1`.
   have h_fw_bound : 2 * d_fw ≤ d_i_plus_steps - 1 := by
     -- Convert the ENat inequality to a Nat inequality using `a < b ↔ a + 1 ≤ b`.
     exact Nat.le_of_lt_succ (WithTop.coe_lt_coe.1 h_fw_dist_lt)
-
   -- 3. The Algebraic Identity.
   -- The core of the proof is the identity : `(d_{i+steps} - 1) * 2 ^ steps = d_i - 1`.
   have h_algebraic_identity : (d_i_plus_steps - 1) * 2 ^ steps = d_i - 1 := by
@@ -1472,18 +1430,15 @@ theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (step
       rw [Nat.sub_add_eq_sub_sub_rev (h1 := by omega) (h2 := by omega),
         Nat.add_sub_cancel (n := i) (m := steps)]
     rw [h1, h2]
-
   -- 4. Conclusion : Chain the inequalities to prove `2 * d_H < d_i`.
   -- We know `d_H` is finite, since `C_i` is nonempty.
   have h_dH_ne_top : d_H ≠ ⊤ := by
     simp only [ne_eq, d_H]
     rw [Code.distFromCode_eq_top_iff_empty f C_i]
     exact Set.nonempty_iff_ne_empty'.mp h_C_i_nonempty
-
   -- We can now work with the `Nat` value of `d_H`.
   let d_H_nat := ENat.toNat d_H
   have h_dH_eq : d_H = d_H_nat := (ENat.natCast_toNat h_dH_ne_top).symm
-
   -- The calculation is now done entirely in `Nat`.
   have h_final_inequality : 2 * d_H_nat ≤ d_i - 1 := by
     have h_bridge_nat : d_H_nat ≤ d_fw * 2 ^ steps := by
@@ -1494,7 +1449,6 @@ theorem fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius (i : Fin ℓ) (step
       _ = (2 * d_fw) * 2 ^ steps := by rw [mul_assoc]
       _ ≤ (d_i_plus_steps - 1) * 2 ^ steps := by gcongr;
       _ = d_i - 1 := h_algebraic_identity
-
   simp only [d_H, d_H_nat] at h_dH_eq
   -- This final line is equivalent to the goal statement.
   rw [h_dH_eq]
@@ -1583,7 +1537,6 @@ def foldingBadEvent (i : Fin ℓ) (steps : ℕ) [NeZero steps] (h_i_add_steps : 
     -- This happens if the random challenges are unlucky.
     let h_dist_curr_lt := fiberwise_dist_lt_imp_dist_lt_unique_decoding_radius 𝔽q β
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := i) (steps := steps) h_i_add_steps f_i h_is_close
-
     let f_bar_i := uniqueClosestCodeword 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
       (i := ⟨i, by omega⟩) (h_i := by apply Nat.lt_add_of_pos_right_of_le; omega) f_i
       h_dist_curr_lt
@@ -1593,7 +1546,6 @@ def foldingBadEvent (i : Fin ℓ) (steps : ℕ) [NeZero steps] (h_i_add_steps : 
     let folded_f_bar_i := iterated_fold 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
       (steps := ⟨steps, by omega⟩) (i := ⟨i, by omega⟩)
       (h_i_add_steps := by apply Nat.lt_add_of_pos_right_of_le; omega) f_bar_i challenges
-
     let fiberwise_disagreements := fiberwiseDisagreementSet 𝔽q β i steps h_i_add_steps
       f_i f_bar_i
     let folded_disagreements := disagreementSet 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) i steps

--- a/ArkLib/ProofSystem/Fri/Spec/SingleRound.lean
+++ b/ArkLib/ProofSystem/Fri/Spec/SingleRound.lean
@@ -239,7 +239,9 @@ namespace FoldPhase
 --     (x₀ : F) : Prop :=
 --   ∀ s₀ : evalDomain D x (∑ j' ∈ (List.take j.1 (List.finRange (k + 1))).toFinset, s j'),
 --       let queries :
---           List (evalDomain D x (∑ j' ∈ (List.take j.1 (List.finRange (k + 1))).toFinset, s j')) :=
+--           List
+--             (evalDomain D x
+--               (∑ j' ∈ (List.take j.1 (List.finRange (k + 1))).toFinset, s j')) :=
 --             List.map
 --               (
 --                 fun r =>
@@ -271,7 +273,7 @@ namespace FoldPhase
 
 /- The FRI non-final folding round input relation, with proximity parameter `δ`, f
    for the `i`th round. -/
-def inputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
+def inputRelation (cond : ∑ i, (s i).1 ≤ n) (δ : ℝ≥0) :
     Set
       (
         (Statement F i.castSucc × (∀ j, OracleStatement s ω i.castSucc j)) ×
@@ -280,7 +282,7 @@ def inputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
 
 /- The FRI non-final folding round output relation, with proximity parameter `δ`,
    for the `i`th round. -/
-def outputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
+def outputRelation (cond : ∑ i, (s i).1 ≤ n) (δ : ℝ≥0) :
     Set
       (
         (Statement F i.succ × (∀ j, OracleStatement s ω i.succ j)) ×
@@ -324,7 +326,7 @@ instance {i : Fin k} : ∀ j, Inhabited ((pSpec s (ω := ω) i).Challenge j) := 
         | zero => simp at hj
         | succ j2 => exact j2.elim0
   subst h_j_eq_0
-  simpa [pSpec, Challenge] using (inferInstance : Inhabited F)
+  simpa [Challenge] using (inferInstance : Inhabited F)
 
 noncomputable instance {i : Fin k} : ∀ j, Fintype ((pSpec s (ω := ω) i).Challenge j) := by
   intro j
@@ -484,7 +486,7 @@ namespace FinalFoldPhase
 
 /- Input relation for the final folding round. This is currently sorried out, to be filled in later.
 -/
-def inputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
+def inputRelation (cond : ∑ i, (s i).1 ≤ n) (δ : ℝ≥0) :
     Set
       (
         (
@@ -496,7 +498,7 @@ def inputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
 
 /- Output relation for the final folding round. This is currently sorried out, to be filled in
 later. -/
-def outputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
+def outputRelation (cond : ∑ i, (s i).1 ≤ n) (δ : ℝ≥0) :
     Set
       (
         (FinalStatement F k × ∀ j, FinalOracleStatement s ω j) ×
@@ -527,7 +529,7 @@ instance : ∀ j, Inhabited ((pSpec F).Challenge j) := by
     | zero => rfl
     | succ j1 =>
         cases j1 using Fin.cases with
-        | zero => simp [pSpec] at hj
+        | zero => simp at hj
         | succ j2 => exact j2.elim0
   subst h_j_eq_0
   simpa [pSpec, Challenge] using (inferInstance : Inhabited F)
@@ -646,11 +648,17 @@ def finalFoldVerifier :
         have jEq : j = Fin.last (k + 1) := Fin.ext (by simpa using h)
         subst j
         unfold instOracleInterfaceMessagePSpec finalOracleStatementInterface
-        simp [OracleInterface.instDefault, readThe, MonadReader.read,
-          MonadReaderOf.read, ReaderT.read]
+        simp only [Fin.val_last, finRangeTo, ↓reduceDIte, read,
+          readThe, MonadReaderOf.read, ReaderT.read, cast_cast, bind_pure_comp,
+          Fin.vcons_fin_zero, Nat.reduceAdd, Fin.isValue, Message,
+          OracleInterface.instDefault]
         congr 1
-        all_goals try simp [FinalOracleStatement]
+        case e_1 =>
+          simp only [FinalOracleStatement, Fin.val_last, ↓reduceIte, Fin.isValue,
+            Fin.vcons_one]
+        case e_2 => simp only [↓reduceIte]
         case e_3 =>
+          simp only [FinalOracleStatement, Fin.val_last, finRangeTo, Fin.isValue]
           congr 1
           case e_1 => simp
           case e_2 => simp
@@ -667,12 +675,16 @@ def finalFoldVerifier :
             exact (cast_heq _ st).trans hst
       · simp only
         unfold instOracleInterfaceOracleStatement finalOracleStatementInterface
-        simp [h, OracleInterface.instFunction, OracleContext.ofFunction,
-          readThe, MonadReader.read, MonadReaderOf.read, ReaderT.read]
+        simp only [h, finRangeTo, ↓reduceDIte, read, readThe, MonadReaderOf.read,
+          ReaderT.read, bind_pure_comp, Fin.val_last, OracleInterface.instFunction,
+          OracleContext.ofFunction]
         congr 1
-        all_goals try simp [FinalOracleStatement, h]
-        case e_1 => rfl
+        case e_1 =>
+          simp only [FinalOracleStatement, h, ↓reduceIte, finRangeTo]
+          rfl
+        case e_2 => simp only [h, ↓reduceIte]
         case e_3 =>
+          simp only [FinalOracleStatement, finRangeTo]
           congr 1
           case e_1 => simp [h]
           case e_2 =>
@@ -721,7 +733,7 @@ namespace QueryRound
 variable (l : ℕ) [NeZero l]
 
 /- Input/Output relations for the query round of the FRI protocol -/
-def inputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
+def inputRelation (cond : ∑ i, (s i).1 ≤ n) (δ : ℝ≥0) :
     Set
       (
         (FinalStatement F k × ∀ j, FinalOracleStatement s ω j) ×
@@ -729,7 +741,7 @@ def inputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
       )
   := FinalFoldPhase.outputRelation s d cond δ
 
-def outputRelation (cond : ∑ i, (s i).1 ≤ n) [DecidableEq F] (δ : ℝ≥0) :
+def outputRelation (cond : ∑ i, (s i).1 ≤ n) (δ : ℝ≥0) :
     Set
       (
         (FinalStatement F k × ∀ j, FinalOracleStatement s ω j) ×
@@ -818,8 +830,7 @@ def queryCodeword (k : ℕ) (s : Fin (k + 1) → ℕ+) {i : Fin (k + 1)}
         ⟨⟨i.1, by omega⟩,
           cast (by
             unfold OracleInterface.Query finalOracleStatementInterface
-            simp only [Fin.mk.injEq, Nat.reduceAdd, Fin.isValue, Nat.ne_of_lt i.2,
-              ↓reduceIte]
+            simp only [Nat.ne_of_lt i.2, ↓reduceIte]
             congr 3) w⟩)))
 
 /- Used by the verifier to fetch the polynomial sent in final folding round. -/
@@ -837,7 +848,7 @@ def getConst (k : ℕ) (s : Fin (k + 1) → ℕ+) :
 open CosetFftDomain in
 open FftDomain in
 open CosetFftDomainClass in
-def queryVerifier (k_le_n : (∑ j', (s j').1) ≤ n) (l : ℕ) [DecidableEq F] :
+def queryVerifier (k_le_n : (∑ j', (s j').1) ≤ n) (l : ℕ) :
   OracleVerifier []ₒ
     (FinalStatement F k) (FinalOracleStatement s ω)
     (FinalStatement F k) (FinalOracleStatement s ω)
@@ -855,9 +866,10 @@ def queryVerifier (k_le_n : (∑ j', (s j').1) ≤ n) (l : ℕ) [DecidableEq F] 
                     (ω.subdomain
                       (∑ j' ∈ finRangeTo _ i.1, (s j').1)).toFinset :=
                     ⟨s₀ ^ (2 ^ (∑ j' ∈ finRangeTo _ i.1, (s j').1)),
-                      CosetFftDomainClass.pow_mem_subdomain_of_mem_subdomain_0_toFinset (Nat.le_trans
-                      (Finset.sum_le_sum_of_subset (t := Finset.univ) (by simp))
-                      (k_le_n)) s₀.2⟩
+                      CosetFftDomainClass.pow_mem_subdomain_of_mem_subdomain_0_toFinset
+                        (Nat.le_trans
+                          (Finset.sum_le_sum_of_subset (t := Finset.univ) (by simp))
+                          k_le_n) s₀.2⟩
                   let queries :
                     List (
                       ω.subdomain
@@ -874,8 +886,8 @@ def queryVerifier (k_le_n : (∑ j', (s j').1) ≤ n) (l : ℕ) [DecidableEq F] 
                                 rw [Nat.le_sub_iff_add_le (by {
                                   exact Nat.le_trans (m := ∑ j', ↑(s j'))
                                     (by {
-                                      apply Finset.single_le_sum (f := fun i ↦ (s i : ℕ)) (by simp) (by simp)
-
+                                      apply Finset.single_le_sum (f := fun i ↦ (s i : ℕ))
+                                        (by simp) (by simp)
                                     }) k_le_n
                                 })]
                                 trans (∑ j' ∈ finRangeTo (k + 1) (↑i + 1), ↑(s j'))
@@ -928,7 +940,7 @@ def queryVerifier (k_le_n : (∑ j', (s j').1) ≤ n) (l : ℕ) [DecidableEq F] 
     outputInterface_heq := by intros _; rfl }
 
 /- Query round oracle reduction. -/
-def queryOracleReduction [DecidableEq F] :
+def queryOracleReduction :
   OracleReduction []ₒ
     (FinalStatement F k) (FinalOracleStatement s ω) (Witness F s d (Fin.last (k + 1)))
     (FinalStatement F k) (FinalOracleStatement s ω) (Witness F s d (Fin.last (k + 1)))

--- a/ArkLib/ProofSystem/Sumcheck/Spec/SingleRound.lean
+++ b/ArkLib/ProofSystem/Sumcheck/Spec/SingleRound.lean
@@ -312,7 +312,8 @@ variable [SampleableType R]
 theorem oracleReduction_perfectCompleteness :
     (oracleReduction R deg oSpec).perfectCompleteness init impl
       (inputRelation R deg D) (outputRelation R deg) := by
-  simp [oracleReduction]
+  simp only [StmtIn, StmtOut, oracleReduction, StmtAfterRandomQuery, Nat.reduceAdd,
+    Nat.add_zero, Fin.vcons_fin_zero, StmtAfterCheckClaim, StmtAfterSendClaim]
   refine OracleReduction.append_perfectCompleteness
     (rel₂ := relationAfterRandomQuery R deg)
     ((((oracleReduction.sendClaim R deg oSpec).append
@@ -331,7 +332,7 @@ theorem oracleReduction_perfectCompleteness :
       · sorry
       · sorry
     · sorry
-  · simp [oracleReduction.reduceClaim]
+  · simp only [StmtAfterRandomQuery, StmtOut, oracleReduction.reduceClaim, id_eq]
     refine ReduceClaim.oracleReduction_completeness _ _ ?_
     sorry
 
@@ -462,19 +463,18 @@ open scoped NNReal
 --   · simp; exact default
 --   · simp; exact default
 
+omit [SampleableType R] in
 theorem oracleVerifier_eq_verifier :
     (oracleVerifier R deg D oSpec).toVerifier = verifier R deg D oSpec := by
   ext ⟨target, oStmt⟩ transcript
   simp only [OracleVerifier.toVerifier, verifier, oracleVerifier, pSpec,
     OracleInterface.simOracle2,
     QueryImpl.addLift_def,
-    QueryImpl.add_apply_inl, QueryImpl.add_apply_inr, QueryImpl.liftTarget_apply,
-    OptionT.run, OptionT.mk, OptionT.lift, OptionT.run_bind, OptionT.run_pure, OptionT.run_mk,
-    OracleComp.liftComp_bind, OracleComp.liftComp_pure, OracleComp.liftComp_query,
-    OracleComp.liftComp_map, OracleComp.liftComp_seq,
+    OptionT.run, OptionT.mk, OptionT.lift,
+    OracleComp.liftComp_query,
     OracleQuery.cont_query, OracleQuery.input_query,
-    pure_bind, bind_pure_comp, bind_assoc, map_pure, id_map, Functor.map_id, Function.comp,
-    FullTranscript.challenges, FullTranscript.messages]
+    bind_pure_comp, id_map,
+    FullTranscript.challenges]
   -- Push simulateQ through the outer bind (mapM >>= rest)
   erw [simulateQ_bind]
   -- Each oracle query in mapM resolves to pure evaluation
@@ -491,16 +491,9 @@ theorem oracleVerifier_eq_verifier :
     (fun i => (transcript.messages default).1.eval (D i))
     (Vector.finRange m)
     (by
-      intro i; simp only [impl,
-        simulateQ_map, simulateQ_bind, simulateQ_pure, simulateQ_query,
-        QueryImpl.addLift_def,
-        QueryImpl.add_apply_inl, QueryImpl.add_apply_inr, QueryImpl.liftTarget_apply,
-        QueryImpl.simulateQ_add_liftComp_right, QueryImpl.simulateQ_add_liftComp_left,
-        OracleComp.liftComp_bind, OracleComp.liftComp_pure, OracleComp.liftComp_query,
-        OracleComp.liftComp_map,
+      intro i; simp only [impl, OracleComp.liftComp_query,
         OracleQuery.cont_query, OracleQuery.input_query,
-        OracleInterface.simOracle0, OracleInterface.answer,
-        pure_bind, bind_pure_comp, map_pure, Function.comp, id_map]
+        id_map]
       -- The query goes through SubSpec lifts; each liftM = liftComp (lift ...)
       -- After simulateQ, the message oracle answers with transcript.messages
       rfl)
@@ -523,18 +516,13 @@ theorem oracleVerifier_eq_verifier :
   split_ifs with h1 h2
   · -- Both true: resolve newTarget query
     erw [simulateQ_bind]
-    simp only [OracleComp.liftComp_bind, OracleComp.liftComp_pure, OracleComp.liftComp_query,
-      QueryImpl.simulateQ_add_liftComp_right,
-      simulateQ_query, OracleQuery.cont_query, OracleQuery.input_query,
-      QueryImpl.add_apply_inl, QueryImpl.add_apply_inr, QueryImpl.liftTarget_apply,
-      OracleInterface.simOracle0, OracleInterface.answer,
-      pure_bind, bind_pure_comp, map_pure, Function.comp,
-      simulateQ_map, simulateQ_pure]
+    simp only [map_pure, Function.comp, simulateQ_map]
     rfl
   · exfalso; simp only [FullTranscript.messages, pSpec] at *; tauto
   · exfalso; simp only [FullTranscript.messages, pSpec] at *; tauto
   · rfl
 
+omit [SampleableType R] in
 /-- The oracle reduction is equivalent to the non-oracle reduction -/
 theorem oracleReduction_eq_reduction :
     (oracleReduction R deg D oSpec).toReduction = reduction R deg D oSpec := by
@@ -562,20 +550,20 @@ theorem reduction_perfectCompleteness :
   -- 1. Unfold reduction and expand pSpec to resolve directions
   simp only [reduction, Reduction.run, Prover.run, Verifier.run, prover, verifier,
     Prover.runToRound, Prover.processRound, Fin.induction_two, pSpec,
-    bind_pure_comp, Functor.map_map, Function.comp]
+    bind_pure_comp]
   -- 2. Resolve round 0 direction (P_to_V)
   split <;> rename_i hDir0
   · exact absurd hDir0 (by decide)
-  try simp only [pure_bind, map_pure, Functor.map_map, Function.comp, bind_pure_comp]
+  try simp only [pure_bind]
   -- 3. Resolve round 1 direction (V_to_P)
   split <;> rename_i hDir1
   swap
   · exact absurd hDir1 (by decide)
   -- 4. Inline pure computations via liftComp_pure, evaluate transcript access, resolve guard
   simp only [MonadLift.monadLift, liftM, monadLift, MonadLiftT.monadLift,
-    OracleComp.liftComp_pure, pure_bind, map_pure, Functor.map_map, Function.comp,
-    bind_pure_comp, Transcript.concat, Fin.snoc_last, Fin.snoc_castSucc,
-    guard, if_pos hValid, optionT_lift_eq_map, OptionT.mk]
+    OracleComp.liftComp_pure, pure_bind, map_pure,
+    bind_pure_comp, Transcript.concat,
+    guard, optionT_lift_eq_map, OptionT.mk]
   -- 5. After full simplification, the computation should be OptionT-free
   -- Prove Pr[event | comp] ≥ 1
   rw [ge_iff_le, one_le_probEvent_iff, probEvent_eq_one_iff]
@@ -632,7 +620,7 @@ theorem reduction_perfectCompleteness :
       obtain ⟨⟨inner_val, s_inner⟩, hinner, heq_c⟩ := hchal
       obtain ⟨rfl, rfl⟩ := Prod.mk.inj heq_c
       simp only [QueryImpl.addLift_def,
-        QueryImpl.simulateQ_add_liftComp_right, QueryImpl.simulateQ_add_liftComp_left] at hinner
+        QueryImpl.simulateQ_add_liftComp_right] at hinner
       erw [simulateQ_query] at hinner
       erw [StateT.run_map] at hinner
       simp only [support_map, Set.mem_image] at hinner
@@ -642,25 +630,17 @@ theorem reduction_perfectCompleteness :
       simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff] at hval
       obtain ⟨rfl, rfl⟩ := Prod.mk.inj hval
       -- Now decompose hval2
-      simp only [QueryImpl.addLift_def, QueryImpl.liftTarget_apply,
-        QueryImpl.add_apply_inl, QueryImpl.add_apply_inr,
-        simulateQ_query, simulateQ_pure, simulateQ_bind, simulateQ_map,
-        QueryImpl.simulateQ_add_liftComp_right, QueryImpl.simulateQ_add_liftComp_left,
-        OracleComp.liftComp_map, OracleComp.liftComp_pure,
-        pure_bind, map_pure, Functor.map_map, Function.comp,
-        OracleQuery.cont, OracleQuery.input_query,
-        StateT.run_bind, StateT.run_map, StateT.run_pure,
-        support_map, support_pure, Set.mem_singleton_iff, Set.mem_image,
-        Prod.mk.injEq, Option.some.injEq, Fin.snoc] at hval2
+      simp only [QueryImpl.addLift_def, OracleQuery.cont, OracleQuery.input_query,
+        Fin.snoc] at hval2
       norm_num at hval2
       rw [Finset.sum_map] at hValid
-      simp only [apply_ite, simulateQ_ite, OptionT.run_pure] at hval2
+      simp only [apply_ite] at hval2
       erw [if_pos hValid] at hval2
       erw [simulateQ_pure] at hval2
       simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff] at hval2
       simp at hval2
     · -- val2 = some out: getM succeeds, final map wraps in some, contradicts none
-      simp only [Option.getM, pure_bind] at hs
+      simp only [Option.getM] at hs
       erw [simulateQ_pure] at hs
       simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff] at hs
       exact absurd (congr_arg Prod.fst hs) (by simp)
@@ -698,12 +678,12 @@ theorem reduction_perfectCompleteness :
     dsimp only [] at hx_rest
     rcases val2 with _ | ⟨out⟩
     · -- val2 = none: getM fails, produces none, but x is some — contradiction
-      simp only [Option.getM, pure_bind] at hx_rest
+      simp only [Option.getM] at hx_rest
       erw [simulateQ_pure] at hx_rest
       simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff] at hx_rest
       exact absurd (congr_arg Prod.fst hx_rest) (by simp)
     · -- val2 = some out: getM succeeds, x is concrete
-      simp only [Option.getM, pure_bind] at hx_rest
+      simp only [Option.getM] at hx_rest
       erw [simulateQ_pure] at hx_rest
       simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff] at hx_rest
       obtain ⟨rfl, rfl⟩ := hx_rest
@@ -718,7 +698,7 @@ theorem reduction_perfectCompleteness :
       obtain ⟨⟨inner_val, s_inner⟩, hinner, heq_c⟩ := hchal
       obtain ⟨rfl, rfl⟩ := Prod.mk.inj heq_c
       simp only [QueryImpl.addLift_def,
-        QueryImpl.simulateQ_add_liftComp_right, QueryImpl.simulateQ_add_liftComp_left] at hinner
+        QueryImpl.simulateQ_add_liftComp_right] at hinner
       erw [simulateQ_query] at hinner
       erw [StateT.run_map] at hinner
       simp only [support_map, Set.mem_image] at hinner
@@ -728,19 +708,11 @@ theorem reduction_perfectCompleteness :
       simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff] at hval
       obtain ⟨rfl, rfl⟩ := Prod.mk.inj hval
       -- Decompose hval2: resolve guard
-      simp only [QueryImpl.addLift_def, QueryImpl.liftTarget_apply,
-        QueryImpl.add_apply_inl, QueryImpl.add_apply_inr,
-        simulateQ_query, simulateQ_pure, simulateQ_bind, simulateQ_map,
-        QueryImpl.simulateQ_add_liftComp_right, QueryImpl.simulateQ_add_liftComp_left,
-        OracleComp.liftComp_map, OracleComp.liftComp_pure,
-        pure_bind, map_pure, Functor.map_map, Function.comp,
-        OracleQuery.cont, OracleQuery.input_query,
-        StateT.run_bind, StateT.run_map, StateT.run_pure,
-        support_map, support_pure, Set.mem_singleton_iff, Set.mem_image,
-        Prod.mk.injEq, Option.some.injEq, Fin.snoc] at hval2
+      simp only [QueryImpl.addLift_def, OracleQuery.cont, OracleQuery.input_query,
+        Fin.snoc] at hval2
       norm_num at hval2
       rw [Finset.sum_map] at hValid
-      simp only [apply_ite, simulateQ_ite, OptionT.run_pure] at hval2
+      simp only [apply_ite] at hval2
       erw [if_pos hValid] at hval2
       erw [simulateQ_pure] at hval2
       simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff] at hval2
@@ -823,7 +795,7 @@ def oStmtLens (i : Fin n) : OracleStatement.Lens
   toFunA := fun ⟨⟨target, challenges⟩, oStmt⟩ =>
     ⟨target, fun _ => projectedRoundPolynomial R n deg D i challenges (oStmt ())⟩
 
-  toFunB := fun ⟨⟨_oldTarget, challenges⟩, oStmt⟩ ⟨⟨newTarget, chal⟩, oStmt'⟩ =>
+  toFunB := fun ⟨⟨_oldTarget, challenges⟩, oStmt⟩ ⟨⟨newTarget, chal⟩, _⟩ =>
     ⟨⟨newTarget, Fin.snoc challenges chal⟩, oStmt⟩
 
 /-- Query the multivariate sum-check input oracle at one point. -/
@@ -837,8 +809,7 @@ theorem simulateQ_queryRoundInput (oStmt : ∀ j, OracleStatement R n deg j)
     (point : Fin n → R) :
     simulateQ (OracleInterface.simOracle0 (OracleStatement R n deg) oStmt)
         (queryRoundInput R n deg point) = pure ((oStmt ()).val.eval point) := by
-  simp only [queryRoundInput, simulateQ_query, OracleQuery.input_query,
-    OracleQuery.cont_query, OracleInterface.simOracle0, QueryImpl.liftTarget_apply]
+  simp only [queryRoundInput]
   rfl
 
 /-- Query implementation of `projectedRoundPolynomial`.  A univariate
@@ -874,9 +845,9 @@ theorem simulateProjectedRoundPolynomial_eq (i : Fin n)
   | n + 1 =>
       change _ = Polynomial.eval r
         (projectedRoundPolynomial R (n + 1) deg D i stmt.challenges (oStmt ())).val
-      simp only [simulateProjectedRoundPolynomial, h, simulateQ_bind,
+      simp only [simulateProjectedRoundPolynomial, simulateQ_bind,
         simulateQ_list_mapM, simulateQ_queryRoundInput, List.mapM_pure,
-        pure_bind, simulateQ_pure]
+        pure_bind]
       change
         (List.map (fun x => (oStmt ()).val.eval <|
             Fin.insertNth i r
@@ -922,8 +893,7 @@ def oStmtExecutableLens (i : Fin n) : OracleStatement.ExecutableLens
     intro outerOStmt innerOStmt q
     rcases q with ⟨u, point⟩
     rcases u with ⟨⟩
-    simp only [simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query,
-      QueryImpl.add_apply_inl, OracleInterface.simOracle0, QueryImpl.liftTarget_apply]
+    simp only [simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query]
     rfl
 
 @[simp]
@@ -946,8 +916,7 @@ def liftOutputSimulation {ι : Type} (oSpec : OracleSpec ι) :
     rcases q with ⟨u, point⟩
     rcases u with ⟨⟩
     simp only [simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query,
-      OracleInterface.simOracle2, QueryImpl.add_apply_inr, QueryImpl.add_apply_inl,
-      QueryImpl.liftTarget_apply]
+      OracleInterface.simOracle2]
     rfl
 
 def liftContextOutput {ι : Type} (oSpec : OracleSpec ι)
@@ -1045,14 +1014,16 @@ instance oCtxLens_complete :
         (oCtxLens R n deg D i).toContext)
 where
   proj_complete := by
-    simp [relationRound, Simple.inputRelation]
+    simp only [relationRound, Fin.val_castSucc, Set.mem_ofPred_eq, Simple.StmtIn,
+      Simple.OStmtIn, Simple.inputRelation, sum_map, Simple.StmtOut, Simple.OStmtOut,
+      oCtxLens, forall_const, Prod.forall]
     unfold oStmtLens
     unfold projectedRoundPolynomial
     induction n with
     | zero => exact Fin.elim0 i
     | succ n ih =>
       intro stmt oStmt hRelIn
-      simp [← hRelIn]
+      simp only [← hRelIn]
       simp_rw [Polynomial.eval_finsetSum]
       simp_rw [← eval_eq_eval_mv_eval_finSuccEquivNth]
       -- Remaining: ∑ a ∈ D, ∑ y ∈ D^(n-i), eval (insertNth i a (append c y ∘ cast)) p
@@ -1061,7 +1032,9 @@ where
       --        (2) piFinset cons decomposition for D^(n+1-i) ↔ D × D^(n-i)
       sorry
   lift_complete := by
-    simp [relationRound]
+    simp only [Simple.StmtOut, Simple.OStmtOut, Simple.StmtIn, Simple.OStmtIn,
+      oCtxLens, relationRound, Fin.val_castSucc, Set.mem_ofPred_eq, Fin.val_succ,
+      Prod.forall]
     unfold compatContext oStmtLens
     -- simp
     -- induction n with
@@ -1082,7 +1055,9 @@ instance extractorLens_rbr_knowledge_soundness :
     --   Simple.oracleVerifier_eq_verifier, Simple.verifier, Verifier.run]
     sorry
   lift_knowledgeSound := by
-    simp [relationRound, Simple.inputRelation, Statement.Lens.proj]
+    simp only [Simple.StmtIn, Simple.OStmtIn, Simple.inputRelation, sum_map,
+      Statement.Lens.proj, Simple.StmtOut, Simple.OStmtOut, Set.mem_ofPred_eq,
+      relationRound, Fin.val_castSucc, forall_const, Prod.forall]
     unfold oStmtLens
     unfold projectedRoundPolynomial
     induction n with
@@ -1261,13 +1236,15 @@ def verifier (i : Fin n) : Verifier oSpec
     pure ⟨⟨p_i.eval r_i, Fin.snoc challenges r_i⟩, oStmt⟩
 
 -- /-- The oracle verifier for the `i`-th round, where `i < n + 1` -/
--- def oracleVerifier --[Inhabited ((i : (pSpec R deg).MessageIdx) × OracleInterface.Query ((pSpec R deg).Message i))]
+-- def oracleVerifier
+--     --[Inhabited
+--       ((i : (pSpec R deg).MessageIdx) × OracleInterface.Query ((pSpec R deg).Message i))]
 --     (i : Fin n) : OracleVerifier oSpec
 --     (StatementRound R n i.castSucc) (OracleStatement R n deg)
 --     (StatementRound R n i.succ) (OracleStatement R n deg) (pSpec R deg) where
 --   -- Queries for the evaluations of the polynomial at all points in `D`,
 --   -- plus one query for the evaluation at the challenge `r_i`
---   -- Check that the sum of the evaluations equals the target, and updates the statement accordingly
+--   -- Check that the evaluation sum equals the target, then update the statement accordingly.
 --   -- (the new target is the evaluation of the polynomial at the challenge `r_i`)
 --   verify := fun ⟨target, challenges⟩ chal => do
 --     let evals : List R ← (List.finRange m).mapM


### PR DESCRIPTION
## Summary

This PR makes five non-`Data` proof hotspots linter-clean by replacing broad or oversized simplification calls with exact proof dependencies, removing redundant typeclass parameters, and simplifying one cardinality proof.

It does not disable or suppress any linter. It adds no `sorry`, changes no protocol relation, transcript shape, verifier decision, or runtime behavior.

### Diff metadata

- Base: `5a9626d331d713c7e74efa7e3d93b7d0ec9c4dc2` (`main`)
- Head: `02f51d8af6d10b0b58b7804423b429051ccaf0de`
- Commits: 1
- Files changed: 5
- Diff: 174 insertions, 197 deletions

## Motivation and profiling diagnosis

The clean-build report at the merged performance-round head showed 9 non-`Data` modules above 20 seconds and 15 above 15 seconds. Sequential source checks with cached imports told a different story: all 15 candidates checked below 7 seconds.

| Module | CI clean build | Sequential source check |
|---|---:|---:|
| `Binius.BinaryBasefold.Prelude` | 30s | 6.32s |
| `Stir.Combine` | 29s | 5.32s |
| `LiftContext.Reduction` | 29s | 4.55s |
| `KZG.FunctionBinding.EvaluationBindingConflict` | 27s | 4.81s |
| `Sumcheck.Domain` | 26s | 4.68s |
| `Security.RoundByRound` | 23s | 5.74s |
| `Sumcheck.Spec.SingleRound` | 22s | 4.74s |
| `ToyProblem.SoundnessBounds` | 21s | 4.33s |
| `Fri.Spec.SingleRound` | 21s | 6.06s |
| `KZG.Binding` | 20s | 4.48s |
| `ToyProblem.Spec.General` | 19s | 4.82s |
| `Sequential.Append` | 18s | 3.74s |
| `Hachi.ZeroCheck.Constraints` | 17s | 3.77s |
| `TranscriptTree.Composition` | 16s | 3.92s |
| `KZG.FunctionBinding.DegreeConflict` | 16s | 4.11s |

The CI runner was about 49% slower globally than the preceding reference run, so these large per-module CI numbers are primarily parallel contention/load amplification rather than 20–30 second intrinsic proofs. The durable local opportunity was concentrated linter and elaboration debt in five of the reported modules.

## Change-surface overview

| Area | Before | After |
|---|---|---|
| Simplification proofs | Broad `simp` and oversized `simp only` lists | Exact lemma sets generated and verified against current `main` |
| FRI instances | Duplicate `[DecidableEq F]` parameters | One canonical section instance |
| Binius decidability | Unused decidability assumptions leaked into theorem types | Local classical reasoning; weaker public assumptions |
| Binius cardinality proof | Preimage → image → subset detour | Direct `Finset.card_preimage` / `card_filter_le` proof |
| Style lint | Empty proof-command lines and long lines | Source formatted to the active repository lint rules |
| Linter policy | Existing findings | Zero findings in the five targeted files, with no exceptions or suppressions |

## Implementation

### Exact simplification dependencies

`Sumcheck.Spec.SingleRound`, `Fri.Spec.SingleRound`, `LiftContext.Reduction`, and `Sequential.Append` now state the precise rewrite lemmas their proofs use. This removes unused simp arguments and flexible-tactic search while making proof maintenance explicit.

The lists were regenerated after rebasing onto current `main`; the full clean dependency build caught and removed stale simp names from the pre-merge worktree.

### Binius proof and API cleanup

`hammingDist_le_of_outer_comp_injective` no longer requires `[DecidableEq ι₂]`. Its proof now uses local classical reasoning and directly bounds the preimage cardinality through `Finset.card_preimage` and `Finset.card_filter_le`.

Five other Binius results no longer leak unused `[DecidableEq 𝔽q]` assumptions into their theorem types. The change weakens prerequisites rather than strengthening them.

### FRI instance discipline

Eight declarations had an explicit `[DecidableEq F]` parameter while the surrounding section already supplied the same instance. The duplicate parameters are removed. Internal call sites all compile; external callers using fully explicit `@...` application may need to remove the redundant instance argument.

## Trust and security

- No linter is disabled locally or globally.
- No axiom, `sorry`, native implementation, or trust gate is added or weakened.
- No prover/verifier computation, oracle materialization, challenge flow, transcript format, or security relation is changed.
- The full dependency build validates downstream users after the public typeclass-parameter cleanup.
- Existing `sorry` declarations remain unchanged and are reported honestly by the normal validation path.

## Validation completed at `02f51d8a`

Passed locally:

- `lake build`
- `./scripts/validate.sh`
- `bash scripts/lintWhitespace.sh`
- direct `lake env lean` checks for all five changed files
- targeted built-in lint for all five changed modules: zero text or environment findings in the target files

The targeted `lake lint --builtin-only ...` command still exits nonzero because it also traverses imported modules with pre-existing warnings. The five requested target files themselves produce zero findings.

CI checks for this PR are pending at publication time.

## Remaining linter work

The current full build contains 369 unique non-`sorry` findings outside this PR. The largest coherent follow-up groups are:

1. `ProofSystem/BatchedFri/Security.lean` — 53
2. `ProofSystem/Binius/FRIBinius/CoreInteractionPhase.lean` — 44
3. `ProofSystem/Binius/BinaryBasefold/CoreInteractionPhase.lean` — 33
4. `ProofSystem/Binius/BinaryBasefold/Steps.lean` — 23
5. `ProofSystem/RingSwitching/Packing/{SumcheckPhase,General}.lean` — 18 each
6. `OracleReduction/Composition/Sequential/General.lean` — 16
7. `OracleReduction/ProtocolSpec/SeqCompose.lean` — 12

These should be handled as separate coherent proof/API cleanups rather than hidden with lint exceptions.

## Reviewer map

Suggested review order:

1. `ArkLib/ProofSystem/Binius/BinaryBasefold/Prelude.lean` — theorem assumptions and direct cardinality proof
2. `ArkLib/ProofSystem/Fri/Spec/SingleRound.lean` — redundant instance removal and HEq proof simplification
3. `ArkLib/ProofSystem/Sumcheck/Spec/SingleRound.lean` — largest simp-dependency reduction
4. `ArkLib/OracleReduction/LiftContext/Reduction.lean` — exact security-proof simplifiers
5. `ArkLib/OracleReduction/Composition/Sequential/Append.lean` — exact sequential-composition simplifiers
