### PR TITLE
lint: remove proof-system hotspot debt

### DIFF
--- a/ArkLib/ProofSystem/BatchedFri/Security.lean
+++ b/ArkLib/ProofSystem/BatchedFri/Security.lean
@@ -35,7 +35,7 @@ section Fri
 open OracleComp OracleSpec ProtocolSpec ReedSolomon Domain
 open NNReal Finset Function ProbabilityTheory
 
-variable {𝔽 : Type} [NonBinaryField 𝔽] [Fintype 𝔽] [DecidableEq 𝔽] [Nontrivial 𝔽]
+variable {𝔽 : Type} [NonBinaryField 𝔽] [Fintype 𝔽] [DecidableEq 𝔽]
 variable (n : ℕ)
 variable (g : 𝔽ˣ) {k : ℕ}
 variable (s : Fin (k + 1) → ℕ+) (d : ℕ+)
@@ -133,17 +133,15 @@ noncomputable def fin_equiv_coset (s₀ : evalDomainSigma s ω ↑i)
   apply And.intro
   · intros a b h
     have h := congr_arg (fun x ↦ (x.1.1 : 𝔽)) h
-    simp only [cosetEnum', cosetEnum, finRangeTo.eq_1] at h
     have hs₀_ne : (s₀ : 𝔽) ≠ 0 := CosetFftDomainClass.ne_zero_dep s₀
     have h := mul_left_cancel₀ hs₀_ne h
     have h := FftDomain.injective h
     exact Fin.ext (by simpa using h)
   · rintro ⟨⟨y, h'⟩, h⟩
-    simp only [finRangeTo.eq_1, Subtype.mk.injEq]
     simp only [cosetG, k_le_n, ↓reduceDIte] at h
     obtain ⟨a, -, ha⟩ := Finset.mem_image.mp h
     have ha := congr_arg Subtype.val ha
-    simp only [finRangeTo.eq_1, cosetEnum] at ha
+    simp only [cosetEnum] at ha
     exact ⟨a, by aesop⟩
 
 @[instance_reducible]
@@ -170,8 +168,7 @@ def invertibleDomain (s₀ : evalDomainSigma s ω ↑i) : Invertible (VDM n s s�
       apply this
       rw [sub_eq_zero] at contra
       unfold cosetEnum at contra
-      simp only [Nat.succ_eq_add_one, finRangeTo, Fin.ofNat_eq_cast, Fin.val_natCast,
-        Set.mem_ofPred_eq, mul_eq_mul_left_iff] at contra
+      simp only [finRangeTo, mul_eq_mul_left_iff] at contra
       rcases contra with contra | contra
       · have h := FftDomain.injective contra
         simp only [Fin.mk.injEq] at h
@@ -179,8 +176,7 @@ def invertibleDomain (s₀ : evalDomainSigma s ω ↑i) : Invertible (VDM n s s�
         exact (symm h)
       · rcases s₀ with ⟨s₀, hs₀⟩
         subst contra
-        simp only [Nat.succ_eq_add_one, finRangeTo.eq_1, Fin.ofNat_eq_cast, Fin.val_natCast,
-          evalDomainSigma] at hs₀
+        simp only [evalDomainSigma] at hs₀
         rw [CosetFftDomainClass.mem_toFinset_iff_mem] at hs₀
         have hs₀ := CosetFftDomainClass.not_zero_mem hs₀
         simp at hs₀
@@ -216,35 +212,34 @@ noncomputable def f_succ'
     ∃ s₀ : (ω.subdomain (∑ j' ∈ finRangeTo _ (i.1), (s j').1)).toFinset,
       s₀.1 ^ (2 ^ (s i).1) = s₀'.1 := by
     rcases s₀' with ⟨s₀', hs₀'⟩
-    simp only [Fin.val_natCast]
     simp only [evalDomainSigma] at hs₀'
     rw [CosetFftDomain.mem_toFinset_iff_mem] at hs₀'
     rw [CosetFftDomainClass.mem_subdomain_of_eq_vals
       (ω := ω)
       (j := (∑ j' ∈ finRangeTo (k + 1) ↑i, (s j').1 + (s i).1))
-      (by {
+      (by
         rw [←sum_finRangeTo_add_one]
         rfl
-    })] at hs₀'
+      )] at hs₀'
     have h := CosetFftDomainClass.root_exists (ω := ω)
       (i := (∑ j' ∈ finRangeTo (k + 1) ↑i, ↑(s j')))
       (j := (s i).1)
-      (by {
+      (by
         trans (∑ j' ∈ finRangeTo _ (i.1 + 1), (s j').1)
-        rw [sum_finRangeTo_add_one]
-        rfl
-        apply (swap le_trans) k_le_n
-        apply Finset.sum_le_sum_of_subset (by simp)
-      })
+        · rw [sum_finRangeTo_add_one]
+          rfl
+        · apply (swap le_trans) k_le_n
+          apply Finset.sum_le_sum_of_subset (by simp))
       hs₀'
     rcases h with ⟨y, ⟨h1, h2⟩⟩
-    exists ⟨y, by {
+    exists ⟨y, by
       rw [CosetFftDomain.mem_toFinset_iff_mem]
       exact h1
-    }⟩
+    ⟩
   let s₀ := Classical.choose this
   (pows z _ *ᵥ VDMInv n s s₀ k_le_n *ᵥ Finset.restrict (cosetG n s s₀) f) ()
 
+omit [Fintype 𝔽] in
 /-- This theorem asserts that given an appropriate codeword,
   `f` of an appropriate Reed-Solomon code, the result of honestly folding the corresponding
   polynomial is then itself a member of the next Reed-Solomon code.
@@ -276,7 +271,6 @@ def Fₛ {ι : Type} [Fintype ι] {t : ℕ} (f : Fin t.succ → (ι → 𝔽)) :
   f 0 +ᵥ affineSpan 𝔽 (Finset.univ.image (f ∘ Fin.succ))
 
 noncomputable def correlated_agreement_density {ι : Type} [Fintype ι]
-  [Fintype 𝔽]
   (Fₛ : AffineSubspace 𝔽 (ι → 𝔽)) (V : Submodule 𝔽 (ι → 𝔽)) : ℝ :=
   haveI : Fintype Fₛ.carrier := Set.Finite.fintype (Set.toFinite _)
   haveI : Fintype V.carrier := Set.Finite.fintype (Set.toFinite _)
@@ -344,6 +338,7 @@ instance {l : ℕ} : ([(Spec.QueryRound.pSpec l (ω := ω)).Message]ₒ).Fintype
 noncomputable instance {l : ℕ} : IsUniformSpec ([(Spec.QueryRound.pSpec l (ω := ω)).Message]ₒ) :=
   IsUniformSpec.ofFintypeInhabited _
 
+omit [Fintype 𝔽] in
 open ENNReal in
 noncomputable def εC
     (𝔽 : Type) [Fintype 𝔽] (n : ℕ) {k : ℕ} (s : Fin (k + 1) → ℕ+) (m : ℕ) (ρ_sqrt : ℝ≥0) : ℝ≥0∞ :=
@@ -354,7 +349,8 @@ noncomputable def εC
 
 private abbrev fullChallengeProtocol (t l : ℕ) (ω : SmoothCosetFftDomain n 𝔽) :=
   (BatchedFri.Spec.BatchingRound.batchSpec 𝔽 t) ++ₚ
-    (Spec.pSpecFold k (ω := ω) s ++ₚ Spec.FinalFoldPhase.pSpec 𝔽 ++ₚ Spec.QueryRound.pSpec l (ω := ω))
+    (Spec.pSpecFold k (ω := ω) s ++ₚ Spec.FinalFoldPhase.pSpec 𝔽 ++ₚ
+      Spec.QueryRound.pSpec l (ω := ω))
 
 noncomputable instance {t l : ℕ} {ω : SmoothCosetFftDomain n 𝔽} :
     ∀ j,
@@ -758,7 +754,8 @@ lemma fri_soundness
           OracleReduction.run () f ()
             ⟨
               prov,
-              (BatchedFri.Spec.batchedFRIreduction (ω := ω) (n := n) k s d domain_size_cond l t).verifier
+              (BatchedFri.Spec.batchedFRIreduction
+                (ω := ω) (n := n) k s d domain_size_cond l t).verifier
             ⟩
         ] > εC 𝔽 n s m ρ_sqrt + α ^ l) →
       Code.jointAgreement

--- a/ArkLib/ProofSystem/Binius/BinaryBasefold/CoreInteractionPhase.lean
+++ b/ArkLib/ProofSystem/Binius/BinaryBasefold/CoreInteractionPhase.lean
@@ -151,7 +151,7 @@ theorem foldRelayOracleVerifier_rbrKnowledgeSoundness
           (h_ℓ_add_R_rate := h_ℓ_add_R_rate) i)
         relayKnowledgeError ∘ ChallengeIdx.sumEquiv.symm) by
       convert h using 1
-      all_goals first | rfl | (funext m; fin_cases m <;> rfl)
+      all_goals first | rfl | (funext m; fin_cases m; rfl)
   exact OracleVerifier.append_rbrKnowledgeSoundness _ _
       (foldOracleVerifier_rbrKnowledgeSoundness (mp := mp) 𝔽q β i)
       (relayOracleVerifier_rbrKnowledgeSoundness 𝔽q β i hNCR)
@@ -244,9 +244,8 @@ theorem foldCommitOracleVerifier_rbrKnowledgeSoundness
       exfalso
       have hv := m.1.isLt
       have hp := m.2
-      simp only [ProtocolSpec.append, Fin.vappend_eq_append, Fin.append, Fin.addCases,
-        Direction.not_P_to_V_eq_V_to_P] at hp
-      split at hp <;> simp_all <;> omega
+      simp only [ProtocolSpec.append, Fin.vappend_eq_append, Fin.append, Fin.addCases] at hp
+      split at hp <;> simp_all
   rw [herr]
   exact OracleVerifier.append_rbrKnowledgeSoundness _ _
       (foldOracleVerifier_rbrKnowledgeSoundness (mp := mp) 𝔽q β i)
@@ -295,7 +294,6 @@ def nonLastBlockOracleVerifier (bIdx : Fin (ℓ / ϑ - 1)) :=
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
       (i := ⟨bIdx * ϑ + (ϑ - 1), h1⟩)
       (hCR := isCommitmentRoundOfNonLastBlock (𝓡:=𝓡) (r:=r) bIdx)
-
   let nonLastBlockOracleVerifier :=
     OracleVerifier.append (oSpec:=[]ₒ)
       (Stmt₁:=Statement (L := L) (ℓ := ℓ) Context ⟨bIdx * ϑ, by
@@ -318,17 +316,17 @@ def nonLastBlockOracleVerifier (bIdx : Fin (ℓ / ϑ - 1)) :=
             apply bIdx_mul_ϑ_add_i_lt_ℓ_succ⟩
           (d := mp.degCombinator + 1))
       (V₁:=by
-        simp [stmt, oStmt, Nat.zero_mod] at firstFoldRelayRoundsOracleVerifier
+        simp only [Fin.coe_ofNat_eq_mod, Nat.zero_mod, add_zero, Nat.add_zero, Fin.val_last,
+          stmt, oStmt] at firstFoldRelayRoundsOracleVerifier
         exact firstFoldRelayRoundsOracleVerifier
       )
       (V₂:=by
-        simp at lastOracleVerifier
+        simp only [Fin.castSucc_mk, Fin.succ_mk] at lastOracleVerifier
         have h: ↑bIdx * ϑ + (ϑ - 1) + 1 = (↑bIdx + 1) * ϑ := by
           rw [Nat.add_assoc, Nat.sub_add_cancel (by exact NeZero.one_le)]
           rw [Nat.add_mul, Nat.one_mul]
         rw! (castMode:=.all) [h] at lastOracleVerifier
         convert lastOracleVerifier
-        all_goals try rfl
         case e'_13 hOStmt =>
           cases hOStmt
           apply eq_of_heq
@@ -337,7 +335,6 @@ def nonLastBlockOracleVerifier (bIdx : Fin (ℓ / ϑ - 1)) :=
           apply Fin.ext
           simpa only [Fin.val_succ] using h.symm
       )
-
   nonLastBlockOracleVerifier
 
 def lastBlockOracleVerifier :=
@@ -365,7 +362,8 @@ def lastBlockOracleVerifier :=
           (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
           ⟨bIdx * ϑ + i, lastBlockIdx_mul_ϑ_add_fin_lt_ℓ i⟩ nHCR
       )
-    simp [stmt, oStmt, Nat.zero_mod] at cur
+    simp only [Fin.coe_ofNat_eq_mod, Nat.zero_mod, add_zero, Nat.add_zero, Fin.val_last, stmt,
+      oStmt] at cur
     have h: (⟨bIdx * ϑ + ϑ, by apply lastBlockIdx_mul_ϑ_add_x_lt_ℓ_succ (hx:=by omega)⟩)
       = Fin.last ℓ := by
       apply Fin.eq_of_val_eq
@@ -405,10 +403,8 @@ def sumcheckFoldOracleVerifier :=
         pSpecFullNonLastBlock 𝔽q β bIdx (d := mp.degCombinator + 1))
       (V := fun bIdx => nonLastBlockOracleVerifier (L:=L) (mp := mp) 𝔽q β
         (ϑ:=ϑ) (bIdx:=bIdx))
-
   let lastOracleVerifier := lastBlockOracleVerifier (mp := mp) 𝔽q β
     (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
-
   let sumcheckFoldOV: OracleVerifier []ₒ
     (StmtIn := Statement (L := L) (ℓ := ℓ) Context 0)
     (OStmtIn := OracleStatement 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ 0)
@@ -424,17 +420,13 @@ def sumcheckFoldOracleVerifier :=
       (V₂:=by
         exact lastOracleVerifier
       )
-    simp [stmt, oStmt, Nat.zero_mod] at res
+    simp only [Fin.coe_ofNat_eq_mod, Nat.zero_mod, zero_mul, Fin.zero_eta, stmt, oStmt] at res
     unfold pSpecSumcheckFold pSpecNonLastBlocks
     convert res
-    all_goals simp
+    all_goals simp only [Fin.coe_ofNat_eq_mod, Nat.zero_mod, zero_mul, Message]
     all_goals first
       | exact HEq.rfl
-      | (have hi : (⟨0 * ϑ, by omega⟩ : Fin (ℓ + 1)) = 0 := Fin.ext (by simp)
-         rw! (castMode := .all) [hi]
-         rfl)
       | (apply OracleInterface.ext <;> rfl)
-
   sumcheckFoldOV
 
 end composedOracleVerifiers
@@ -467,7 +459,6 @@ def nonLastBlockOracleReduction (bIdx : Fin (ℓ / ϑ - 1)) :=
             (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
             (i := ⟨bIdx * ϑ + i, bIdx_mul_ϑ_add_i_fin_ℓ_pred_lt_ℓ bIdx i⟩) nHCR
         )
-
   let h1 : ↑bIdx * ϑ + (ϑ - 1) < ℓ := by
     let fv: Fin ϑ := ⟨ϑ - 1, by
       have h := NeZero.one_le (n:=ϑ)
@@ -481,7 +472,6 @@ def nonLastBlockOracleReduction (bIdx : Fin (ℓ / ϑ - 1)) :=
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
       (i := ⟨bIdx * ϑ + (ϑ - 1), h1⟩)
       (hCR := isCommitmentRoundOfNonLastBlock (𝓡:=𝓡) (r:=r) bIdx)
-
   let nonLastBlockOracleReduction :=
     OracleReduction.append (oSpec:=[]ₒ)
       (Stmt₁:=Statement (L := L) (ℓ := ℓ) Context ⟨bIdx * ϑ, by
@@ -518,17 +508,17 @@ def nonLastBlockOracleReduction (bIdx : Fin (ℓ / ϑ - 1)) :=
             apply bIdx_mul_ϑ_add_i_lt_ℓ_succ⟩
           (d := mp.degCombinator + 1))
       (R₁:=by
-        simp [stmt, oStmt, Nat.zero_mod] at firstFoldRelayRoundsOracleReduction
+        simp only [Fin.coe_ofNat_eq_mod, Nat.zero_mod, add_zero, Nat.add_zero, Fin.val_last,
+          stmt, oStmt] at firstFoldRelayRoundsOracleReduction
         exact firstFoldRelayRoundsOracleReduction
       )
       (R₂:=by
-        simp at lastOracleReduction
+        simp only [Fin.castSucc_mk, Fin.succ_mk] at lastOracleReduction
         have h: ↑bIdx * ϑ + (ϑ - 1) + 1 = (↑bIdx + 1) * ϑ := by
           rw [Nat.add_assoc, Nat.sub_add_cancel (by exact NeZero.one_le)]
           rw [Nat.add_mul, Nat.one_mul]
         rw! (castMode:=.all) [h] at lastOracleReduction
         convert lastOracleReduction
-        all_goals try rfl
         case e'_15 hOStmt =>
           cases hOStmt
           apply eq_of_heq
@@ -537,7 +527,6 @@ def nonLastBlockOracleReduction (bIdx : Fin (ℓ / ϑ - 1)) :=
           apply Fin.ext
           simpa only [Fin.val_succ] using h.symm
       )
-
   nonLastBlockOracleReduction
 
 def lastBlockOracleReduction :=
@@ -575,7 +564,8 @@ def lastBlockOracleReduction :=
               (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
               (i := ⟨bIdx * ϑ + i, lastBlockIdx_mul_ϑ_add_fin_lt_ℓ i⟩) nHCR
           )
-      simp [stmt, oStmt, wit, Nat.zero_mod] at cur
+      simp only [Fin.coe_ofNat_eq_mod, Nat.zero_mod, add_zero, Nat.add_zero, Fin.val_last, stmt,
+        oStmt, wit] at cur
       have h: (⟨bIdx * ϑ + ϑ, by apply lastBlockIdx_mul_ϑ_add_x_lt_ℓ_succ (hx:=by omega)⟩)
         = Fin.last ℓ := by
         apply Fin.eq_of_val_eq
@@ -624,9 +614,7 @@ def sumcheckFoldOracleReduction :=
           pSpecFullNonLastBlock 𝔽q β bIdx (d := mp.degCombinator + 1))
         (R := fun bIdx => nonLastBlockOracleReduction (L:=L) (mp := mp) 𝔽q β
           (ϑ:=ϑ) (bIdx:=bIdx))
-
   let lastOracleReduction := lastBlockOracleReduction (mp := mp) 𝔽q β (ϑ:=ϑ)
-
   let coreInteractionOracleReduction: OracleReduction []ₒ
     (StmtIn := Statement (L := L) (ℓ := ℓ) Context 0)
     (OStmtIn := OracleStatement 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ 0)
@@ -646,17 +634,13 @@ def sumcheckFoldOracleReduction :=
       (R₂:=by
         exact lastOracleReduction
       )
-    simp [stmt, oStmt, wit, Nat.zero_mod] at res
+    simp only [Fin.coe_ofNat_eq_mod, Nat.zero_mod, zero_mul, Fin.zero_eta, stmt, oStmt, wit] at res
     unfold pSpecSumcheckFold pSpecNonLastBlocks
     convert res
-    all_goals simp
+    all_goals simp only [Fin.coe_ofNat_eq_mod, Nat.zero_mod, zero_mul, Message]
     all_goals first
       | exact HEq.rfl
-      | (have hi : (⟨0 * ϑ, by omega⟩ : Fin (ℓ + 1)) = 0 := Fin.ext (by simp)
-         rw! (castMode := .all) [hi]
-         rfl)
       | (apply OracleInterface.ext <;> rfl)
-
   coreInteractionOracleReduction
 
 end composedOracleRedutions

--- a/ArkLib/ProofSystem/Binius/BinaryBasefold/Steps.lean
+++ b/ArkLib/ProofSystem/Binius/BinaryBasefold/Steps.lean
@@ -53,7 +53,6 @@ variable {Context : Type} {mp : SumcheckMultiplierParam L ℓ Context} -- Sumche
 section FoldStep
 /-- Most security properties happen at FoldStep, the CommitmentRound is
   just to place the conditional oracle message -/
-
 def foldPrvState (i : Fin ℓ) : Fin (2 + 1) → Type := fun
   -- Initial : current witness x t_eval_point x challenges
   | ⟨0, _⟩ => (Statement (L := L) Context i.castSucc ×
@@ -173,9 +172,8 @@ noncomputable def foldOracleVerifier (i : Fin ℓ) :
     -- Message 0 : Receive h_i(X) from prover
     let h_i ← query (spec := [(pSpecFold (L := L) (d := mp.degCombinator + 1)).Message]ₒ)
       ⟨⟨0, rfl⟩, ()⟩
-
-    -- Check sumcheck : s_i ?= h_i((0 : L)) + h_i((1 : L)), i.e. ∑_{y ∈ univ.map (boolEmbedding L)} h_i(y)
-    -- (matching how the prover sums the round poly over `univ.map (boolEmbedding L)`, not literal `0`/`1`).
+    -- Check sumcheck: `s_i = h_i(0) + h_i(1)`, matching the prover's sum over
+    -- `univ.map (boolEmbedding L)` rather than a literal pair of points.
     let sumcheck_check := h_i.val.eval ((0 : L)) + h_i.val.eval ((1 : L)) = stmtIn.sumcheck_target
     unless sumcheck_check do
       -- Return a dummy statement indicating failure
@@ -185,7 +183,6 @@ noncomputable def foldOracleVerifier (i : Fin ℓ) :
         challenges := Fin.snoc stmtIn.challenges 0
       }
       return dummyStmt
-
     -- Message 1 : Sample challenge r'_i and send to prover
     let r_i' : L := pSpecChallenges ⟨1, rfl⟩ -- This gets the challenge for message 1
 
@@ -195,7 +192,6 @@ noncomputable def foldOracleVerifier (i : Fin ℓ) :
       sumcheck_target := h_i.val.eval r_i',
       challenges := Fin.snoc stmtIn.challenges r_i'
     }
-
     pure stmtOut
   outputOracle := .inl {
     embed := ⟨fun j => by
@@ -323,7 +319,6 @@ def foldKStateProp {i : Fin ℓ} (m : Fin (2 + 1))
       ⟨⟨0, Nat.lt_of_succ_le hm⟩, by simp [pSpecFold]; rfl⟩
     let h_i : L⦃≤ mp.degCombinator + 1⦄[X] := msgsUpTo i_msg1
     h_i
-
   let get_rᵢ' := fun (m: Fin (2 + 1))
       (tr: Transcript m (pSpecFold (L := L) (d := mp.degCombinator + 1)))
       (hm: 2 ≤ m.val) =>
@@ -336,7 +331,6 @@ def foldKStateProp {i : Fin ℓ} (m : Fin (2 + 1))
       ⟨⟨1, Nat.lt_of_succ_le hm⟩, by simp only [Nat.reduceAdd]; rfl⟩
     let r_i' : L := chalsUpTo i_msg2
     r_i'
-
   match m with
   | ⟨0, _⟩ => -- equiv s relIn
     masterKStateProp (mp := mp) 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
@@ -390,18 +384,7 @@ def foldKnowledgeStateFunction (i : Fin ℓ) :
     fin_cases m
     · exact fun ⟨_, h⟩ => ⟨trivial, h⟩
     · simp at hDir
-  toFun_full := fun ⟨stmtLast, oStmtLast⟩ tr witOut h_relOut => by
-    simp at h_relOut
-    rcases h_relOut with ⟨stmtOut, ⟨oStmtOut, h_conj⟩⟩
-    have h_simulateQ := h_conj.1
-    have h_foldStepRelOut := h_conj.2
-    set witLast := (foldRbrExtractor (mp:=mp) 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) i).extractOut
-      ⟨stmtLast, oStmtLast⟩ tr witOut
-    simp only [Fin.reduceLast, Fin.isValue]
-    -- ⊢ foldKStateProp 𝔽q β 2 tr stmtLast witLast oStmtLast
-    -- TODO : prove this via the relations between stmtLast & stmtOut,
-      -- witLast & witOut, oStmtLast & oStmtOut
-    have h_oStmt : oStmtLast = oStmtOut := by sorry
+  toFun_full := fun _ _ _ _ => by
     sorry
 
 /-- RBR knowledge soundness for a single round oracle verifier -/
@@ -510,7 +493,8 @@ noncomputable def commitOracleVerifier (i : Fin ℓ) (hCR : isCommitmentRound �
       intro a b h_ab_eq
       simp only [MessageIdx, Fin.isValue] at h_ab_eq
       split_ifs at h_ab_eq with h_ab_eq_l h_ab_eq_r
-      · simp at h_ab_eq; apply Fin.eq_of_val_eq; exact h_ab_eq
+      · simp only [Sum.inl.injEq, Fin.mk.injEq] at h_ab_eq
+        exact Fin.eq_of_val_eq h_ab_eq
       · have ha_lt : a < toOutCodewordsCount ℓ ϑ i.succ := by omega
         have hb_lt : b < toOutCodewordsCount ℓ ϑ i.succ := by omega
         conv_rhs at ha_lt => rw [toOutCodewordsCount_succ_eq ℓ ϑ i]
@@ -642,7 +626,6 @@ def commitKStateProp (i : Fin ℓ) (m : Fin (1 + 1))
   (oStmtIn : (i_1 : Fin (toOutCodewordsCount ℓ ϑ i.castSucc)) →
     OracleStatement 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ i.castSucc i_1)
   : Prop :=
-
   match m with
   | ⟨0, _⟩ => -- same as relIn
     masterKStateProp (mp := mp) 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
@@ -679,6 +662,7 @@ def commitKState (i : Fin ℓ) (hCR : isCommitmentRound ℓ ϑ i) :
   toFun_full := fun (stmtIn, oStmtIn) tr witOut=> by
     sorry
 
+omit [CharP L 2] [SampleableType L] in
 /-- RBR knowledge soundness for a single round oracle verifier -/
 theorem commitOracleVerifier_rbrKnowledgeSoundness (i : Fin ℓ)
     (hCR : isCommitmentRound ℓ ϑ i) :
@@ -855,6 +839,7 @@ def relayKnowledgeStateFunction (i : Fin ℓ) (hNCR : ¬ isCommitmentRound ℓ �
   toFun_next := fun m hDir (stmtIn, oStmtIn) tr msg witMid => by exact fun a ↦ a
   toFun_full := fun (stmtIn, oStmtIn) tr witOut=> by sorry
 
+omit [SampleableType L] in
 /-- RBR knowledge soundness for a single round oracle verifier -/
 theorem relayOracleVerifier_rbrKnowledgeSoundness (i : Fin ℓ)
     (hNCR : ¬ isCommitmentRound ℓ ϑ i) :
@@ -941,7 +926,6 @@ noncomputable def finalSumcheckProver :
       challenges := stmtIn.challenges,
       final_constant := c
     }
-
     pure (⟨stmtOut, oStmtIn⟩, ())
 
 /-- The verifier for the final sumcheck step -/
@@ -955,8 +939,8 @@ noncomputable def finalSumcheckVerifier :
     (pSpec := pSpecFinalSumcheckStep (L := L)) where
   verify := fun stmtIn _ => do
     -- Get the final constant `c` from the prover's message
-    let c : L ← query (spec := [(pSpecFinalSumcheckStep (L := L)).Message]ₒ) ⟨⟨0, rfl⟩, ()⟩
-
+    let c : L ← query (spec := [(pSpecFinalSumcheckStep (L := L)).Message]ₒ)
+      ⟨⟨0, rfl⟩, ()⟩
     -- Check final sumcheck consistency
     let eq_tilde_eval : L := eqTilde (r := stmtIn.ctx.t_eval_point) (r' := stmtIn.challenges)
     unless stmtIn.sumcheck_target = eq_tilde_eval * c do
@@ -966,7 +950,6 @@ noncomputable def finalSumcheckVerifier :
         challenges := 0,
         final_constant := 0
       }
-
     -- Return the final sumcheck statement with the constant
     let stmtOut : FinalSumcheckStatementOut (L := L) (ℓ := ℓ) := {
       ctx := stmtIn.ctx,
@@ -1037,8 +1020,9 @@ def FinalSumcheckWit := fun (m : Fin (1 + 1)) =>
 /-- The round-by-round extractor for the final sumcheck step -/
 noncomputable def finalSumcheckRbrExtractor :
   Extractor.RoundByRound []ₒ
-    (StmtIn := (Statement (L := L) (SumcheckBaseContext L ℓ) (Fin.last ℓ)) × (∀ j, OracleStatement 𝔽q β
-      (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ) j))
+    (StmtIn := (Statement (L := L) (SumcheckBaseContext L ℓ) (Fin.last ℓ)) ×
+      (∀ j, OracleStatement 𝔽q β
+        (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ) j))
     (WitIn := Witness (L := L) 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (Fin.last ℓ))
     (WitOut := Unit)
     (pSpec := pSpecFinalSumcheckStep (L := L))
@@ -1081,21 +1065,18 @@ def finalSumcheckKStateProp {m : Fin (1 + 1)} (tr : Transcript m (pSpecFinalSumc
     let i_msg0 : tr_so_far.MessageIdx := ⟨⟨0, by omega⟩, rfl⟩
     let c : L := (ProtocolSpec.Transcript.equivMessagesChallenges (k := 1)
       (pSpec := pSpecFinalSumcheckStep (L := L)) tr).1 i_msg0
-
     let stmtOut : FinalSumcheckStatementOut (L := L) (ℓ := ℓ) := {
       ctx := stmt.ctx,
       sumcheck_target := stmt.sumcheck_target,
       challenges := stmt.challenges,
       final_constant := c
     }
-
     let sumcheckFinalCheck : Prop := stmt.sumcheck_target = eqTilde r stmt.challenges * c
     let finalFoldingProp := finalNonDoomedFoldingProp 𝔽q β (ϑ := ϑ)
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (h_le := by
         apply Nat.le_of_dvd;
         · exact Nat.pos_of_neZero ℓ
         · exact hdiv.out) (input := ⟨stmtOut, oStmt⟩)
-
     sumcheckFinalCheck ∧ finalFoldingProp -- local checks ∧ (oracleConsitency ∨ badEventExists)
 
 /-- The knowledge state function for the final sumcheck step -/
@@ -1118,8 +1099,9 @@ noncomputable def finalSumcheckKnowledgeStateFunction {σ : Type} (init : ProbCo
   toFun_full := fun stmt tr witOut h => by
     sorry
 
+omit [CharP L 2] in
 /-- Round-by-round knowledge soundness for the final sumcheck step -/
-theorem finalSumcheckOracleVerifier_rbrKnowledgeSoundness [Fintype L] {σ : Type}
+theorem finalSumcheckOracleVerifier_rbrKnowledgeSoundness {σ : Type}
     (init : ProbComp σ) (impl : QueryImpl []ₒ (StateT σ ProbComp)) :
     (finalSumcheckVerifier 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate)).rbrKnowledgeSoundness init impl
       (relIn := roundRelation 𝔽q β (ϑ := ϑ)

--- a/ArkLib/ProofSystem/Binius/FRIBinius/CoreInteractionPhase.lean
+++ b/ArkLib/ProofSystem/Binius/FRIBinius/CoreInteractionPhase.lean
@@ -144,12 +144,10 @@ def sumcheckFoldCtxLens : OracleContext.Lens
     toFunA := fun ⟨⟨outerStmtIn, outerOStmtIn⟩, outerWitIn⟩ => by
       let t : L⦃≤ 1⦄[X Fin ℓ'] := outerWitIn.t'
       let H : L⦃≤ 2⦄[X Fin (ℓ' - 0)] := outerWitIn.H
-
       let P₀ : L⦃< 2^ℓ'⦄[X] := polynomialFromNovelCoeffsF₂ K β ℓ' (by omega)
         (BinaryBasefold.witnessNovelCoeffs (L := L) t)
       let f₀ : (sDomain K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate))
         ⟨0, by omega⟩ → L := fun x => P₀.val.eval x.val
-
       exact { t := t, H := H, f := f₀ }
     toFunB := fun ⟨⟨outerStmtIn, outerOStmtIn⟩, outerWitIn⟩
       ⟨⟨innerStmtOut, innerOStmtOut⟩, innerWitOut⟩ => innerWitOut
@@ -210,13 +208,17 @@ def sumcheckFoldLiftContextOutput
 
 /-- Extractor lens for sumcheck fold lifting -/
 def sumcheckFoldExtractorLens : Extractor.Lens
-    (OuterStmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0 ×
+    (OuterStmtIn := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0 ×
       (∀ j, OracleStatement K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ 0 j))
-    (OuterStmtOut := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ')
-      ×(∀ j, OracleStatement K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ') j))
-    (InnerStmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0 ×
+    (OuterStmtOut := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ') ×
+      (∀ j, OracleStatement K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ') j))
+    (InnerStmtIn := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0 ×
       (∀ j, OracleStatement K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ 0 j))
-    (InnerStmtOut := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ')
+    (InnerStmtOut := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ')
       × (∀ j, OracleStatement K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ') j))
     (OuterWitIn := RingSwitching.SumcheckWitness L ℓ' 0)
     (OuterWitOut := BinaryBasefold.Witness K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
@@ -265,14 +267,18 @@ variable {σ : Type} {init : ProbComp σ} {impl : QueryImpl []ₒ (StateT σ Pro
 -- Completeness instance for the context lens
 instance sumcheckFoldCtxLens_complete :
   (sumcheckFoldCtxLens κ L K β ℓ ℓ' 𝓡 ϑ (h_ℓ_add_R_rate := h_ℓ_add_R_rate) h_l).toContext.IsComplete
-    (OuterStmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0 ×
+    (OuterStmtIn := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0 ×
       (∀ i, BinaryBasefold.OracleStatement K (⇑β) ϑ (h_ℓ_add_R_rate := h_ℓ_add_R_rate) 0 i))
-    (OuterStmtOut := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ') ×
+    (OuterStmtOut := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ') ×
       (∀ i, BinaryBasefold.OracleStatement K (⇑β) ϑ
         (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (Fin.last ℓ') i))
-    (InnerStmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0 ×
+    (InnerStmtIn := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0 ×
       (∀ i, BinaryBasefold.OracleStatement K (⇑β) ϑ (h_ℓ_add_R_rate := h_ℓ_add_R_rate) 0 i))
-    (InnerStmtOut := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ') ×
+    (InnerStmtOut := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ') ×
       (∀ i, BinaryBasefold.OracleStatement K (⇑β) ϑ
         (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (Fin.last ℓ') i))
     (OuterWitIn := RingSwitching.SumcheckWitness L ℓ' 0)
@@ -317,10 +323,12 @@ omit [NeZero ℓ] in
 theorem sumcheckFoldOracleReduction_perfectCompleteness :
   OracleReduction.perfectCompleteness
     (oSpec := []ₒ)
-    (StmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0)
+    (StmtIn := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0)
     (OStmtIn := BinaryBasefold.OracleStatement K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ 0)
     (WitIn := RingSwitching.SumcheckWitness L ℓ' 0)
-    (StmtOut := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
+    (StmtOut := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
     (OStmtOut := BinaryBasefold.OracleStatement K β
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ'))
     (WitOut := BinaryBasefold.Witness K β
@@ -340,16 +348,20 @@ theorem sumcheckFoldOracleReduction_perfectCompleteness :
     (impl := impl) :=
   OracleReduction.liftContext_perfectCompleteness
     (oSpec := []ₒ)
-    (OuterStmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0)
-    (OuterStmtOut := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
+    (OuterStmtIn := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0)
+    (OuterStmtOut := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
     (OuterWitIn := RingSwitching.SumcheckWitness L ℓ' 0)
     (OuterWitOut := BinaryBasefold.Witness K β
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (ℓ:=ℓ') (Fin.last ℓ'))
     (OuterOStmtIn := BinaryBasefold.OracleStatement K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ 0)
     (OuterOStmtOut := BinaryBasefold.OracleStatement K β
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ'))
-    (InnerStmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0)
-    (InnerStmtOut := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
+    (InnerStmtIn := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0)
+    (InnerStmtOut := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
     (InnerWitIn := BinaryBasefold.Witness K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (ℓ:=ℓ') 0)
     (InnerWitOut := BinaryBasefold.Witness K β
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (ℓ:=ℓ') (Fin.last ℓ'))
@@ -385,14 +397,18 @@ theorem sumcheckFoldOracleReduction_perfectCompleteness :
 -- Knowledge soundness instance for the extractor lens
 instance sumcheckFoldExtractorLens_rbr_knowledge_soundness :
     Extractor.Lens.IsKnowledgeSound
-      (OuterStmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0 ×
+      (OuterStmtIn := Statement (L := L) (ℓ := ℓ')
+        (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0 ×
         (∀ i, BinaryBasefold.OracleStatement K (⇑β) ϑ (h_ℓ_add_R_rate := h_ℓ_add_R_rate) 0 i))
-      (OuterStmtOut := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β))
+      (OuterStmtOut := Statement (L := L) (ℓ := ℓ')
+        (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β))
         (Fin.last ℓ') × (∀ i, BinaryBasefold.OracleStatement K (⇑β) ϑ
           (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (Fin.last ℓ') i))
-      (InnerStmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0 ×
+      (InnerStmtIn := Statement (L := L) (ℓ := ℓ')
+        (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0 ×
         (∀ i, BinaryBasefold.OracleStatement K (⇑β) ϑ (h_ℓ_add_R_rate := h_ℓ_add_R_rate) 0 i))
-      (InnerStmtOut := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β))
+      (InnerStmtOut := Statement (L := L) (ℓ := ℓ')
+        (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β))
         (Fin.last ℓ') × (∀ i, BinaryBasefold.OracleStatement K (⇑β) ϑ
           (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (Fin.last ℓ') i))
       (OuterWitIn := RingSwitching.SumcheckWitness L ℓ' 0)
@@ -428,13 +444,15 @@ instance sumcheckFoldExtractorLens_rbr_knowledge_soundness :
     sorry
 
 -- Round-by-round knowledge soundness for the lifted oracle verifier
-theorem sumcheckFoldOracleVerifier_rbrKnowledgeSoundness [Fintype L] :
+theorem sumcheckFoldOracleVerifier_rbrKnowledgeSoundness :
     OracleVerifier.rbrKnowledgeSoundness
       (oSpec := []ₒ)
-      (StmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0)
+      (StmtIn := Statement (L := L) (ℓ := ℓ')
+        (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0)
       (OStmtIn := BinaryBasefold.OracleStatement K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ 0)
       (WitIn := RingSwitching.SumcheckWitness L ℓ' 0)
-      (StmtOut := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
+      (StmtOut := Statement (L := L) (ℓ := ℓ')
+        (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
       (OStmtOut := BinaryBasefold.OracleStatement K β
         (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ'))
       (WitOut := BinaryBasefold.Witness K β
@@ -471,7 +489,8 @@ section FinalSumcheckStep
 noncomputable def finalSumcheckProver :
   OracleProver
     (oSpec := []ₒ)
-    (StmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
+    (StmtIn := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
     (OStmtIn := BinaryBasefold.OracleStatement K β
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ'))
     (WitIn := BinaryBasefold.Witness K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (ℓ:=ℓ') (Fin.last ℓ'))
@@ -481,11 +500,14 @@ noncomputable def finalSumcheckProver :
     (WitOut := Unit)
     (pSpec := BinaryBasefold.pSpecFinalSumcheckStep (L:=L)) where
   PrvState := fun
-    | 0 => Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ')
+    | 0 => Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ')
       × (∀ j, BinaryBasefold.OracleStatement K β
         (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ') j)
-      × BinaryBasefold.Witness K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (ℓ:=ℓ') (Fin.last ℓ')
-    | _ => Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ') ×
+      × BinaryBasefold.Witness K β
+        (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (ℓ:=ℓ') (Fin.last ℓ')
+    | _ => Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ') ×
       (∀ j, BinaryBasefold.OracleStatement K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ') j)
       × BinaryBasefold.Witness K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (ℓ:=ℓ') (Fin.last ℓ') × L
   input := fun ⟨⟨stmt, oStmt⟩, wit⟩ => (stmt, oStmt, wit)
@@ -515,7 +537,8 @@ noncomputable def finalSumcheckProver :
 noncomputable def finalSumcheckVerifier :
   OracleVerifier
     (oSpec := []ₒ)
-    (StmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
+    (StmtIn := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
     (OStmtIn := BinaryBasefold.OracleStatement K β
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ'))
     (StmtOut := BinaryBasefold.FinalSumcheckStatementOut (L:=L) (ℓ:=ℓ'))
@@ -526,16 +549,13 @@ noncomputable def finalSumcheckVerifier :
     -- Get the final constant `s'` from the prover's message
     let s' : L ← query (spec := [(BinaryBasefold.pSpecFinalSumcheckStep
       (L:=L)).Message]ₒ) ⟨⟨0, rfl⟩, ()⟩
-
     -- 8. `V` sets `e := eq̃(φ₀(r_κ), ..., φ₀(r_{ℓ-1}), φ₁(r'_0), ..., φ₁(r'_{ℓ'-1}))` and
     -- decomposes `e =: Σ_{u ∈ {0,1}^κ} β_u ⊗ e_u`.
     -- Then `V` computes the final eq value: `(Σ_{u ∈ {0,1}^κ} eq̃(u_0, ..., u_{κ-1},`
       -- `r''_0, ..., r''_{κ-1}) ⋅ e_u)`
-
     let eq_tilde_eval : L := RingSwitching.compute_final_eq_value κ L K
       (biniusProfile κ L K β) ℓ ℓ' h_l
       stmtIn.ctx.t_eval_point stmtIn.challenges stmtIn.ctx.r_batching
-
     -- 9. `V` requires `s_{ℓ'} ?= (Σ_{u ∈ {0,1}^κ} eq̃(u_0, ..., u_{κ-1},`
       -- `r''_0, ..., r''_{κ-1}) ⋅ e_u) ⋅ s'`.
     unless stmtIn.sumcheck_target = eq_tilde_eval * s' do
@@ -548,7 +568,6 @@ noncomputable def finalSumcheckVerifier :
         challenges := 0,
         final_constant := 0,
       }
-
     -- Return the final sumcheck statement with the constant
     let stmtOut : BinaryBasefold.FinalSumcheckStatementOut (L:=L) (ℓ:=ℓ') := {
       ctx := {
@@ -572,7 +591,8 @@ noncomputable def finalSumcheckVerifier :
 noncomputable def finalSumcheckOracleReduction :
   OracleReduction
     (oSpec := []ₒ)
-    (StmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
+    (StmtIn := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
     (OStmtIn := BinaryBasefold.OracleStatement K β
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ'))
     (WitIn := BinaryBasefold.Witness K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (ℓ:=ℓ') (Fin.last ℓ'))
@@ -616,8 +636,9 @@ def FinalSumcheckWit := fun (m : Fin (1 + 1)) =>
 /-- The round-by-round extractor for the final sumcheck step -/
 noncomputable def finalSumcheckRbrExtractor :
   Extractor.RoundByRound []ₒ
-    (StmtIn := (Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β))
-      (Fin.last ℓ')) × (∀ j, BinaryBasefold.OracleStatement K β
+    (StmtIn := Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ') ×
+      (∀ j, BinaryBasefold.OracleStatement K β
         (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ') j))
     (WitIn := BinaryBasefold.Witness K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (ℓ:=ℓ') (Fin.last ℓ'))
     (WitOut := Unit)
@@ -647,8 +668,10 @@ noncomputable def finalSumcheckRbrExtractor :
       }
   extractOut := fun ⟨stmtIn, oStmtIn⟩ tr witOut => ()
 
-def finalSumcheckKStateProp {m : Fin (1 + 1)} (tr : Transcript m (pSpecFinalSumcheckStep (L := L)))
-    (stmt : Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
+def finalSumcheckKStateProp {m : Fin (1 + 1)}
+    (tr : Transcript m (pSpecFinalSumcheckStep (L := L)))
+    (stmt : Statement (L := L) (ℓ := ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
     (witMid : FinalSumcheckWit κ (L := L) K β ℓ' 𝓡 (h_ℓ_add_R_rate := h_ℓ_add_R_rate) m)
     (oStmt : ∀ j, BinaryBasefold.OracleStatement K β
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ (Fin.last ℓ') j) : Prop :=
@@ -664,7 +687,6 @@ def finalSumcheckKStateProp {m : Fin (1 + 1)} (tr : Transcript m (pSpecFinalSumc
     let i_msg0 : tr_so_far.MessageIdx := ⟨⟨0, by omega⟩, rfl⟩
     let s' : L := (ProtocolSpec.Transcript.equivMessagesChallenges (k := 1)
       (pSpec := pSpecFinalSumcheckStep (L := L)) tr).1 i_msg0
-
     let stmtOut : BinaryBasefold.FinalSumcheckStatementOut (L:=L) (ℓ:=ℓ') := {
       -- Dummy unused values
       ctx := {
@@ -676,7 +698,6 @@ def finalSumcheckKStateProp {m : Fin (1 + 1)} (tr : Transcript m (pSpecFinalSumc
       challenges := stmt.challenges,
       final_constant := s'
     }
-
     let sumcheckFinalCheck : Prop := stmt.sumcheck_target = compute_final_eq_value κ L K
       (biniusProfile κ L K β) ℓ ℓ' h_l
       stmt.ctx.t_eval_point stmt.challenges stmt.ctx.r_batching * s'
@@ -685,7 +706,6 @@ def finalSumcheckKStateProp {m : Fin (1 + 1)} (tr : Transcript m (pSpecFinalSumc
         apply Nat.le_of_dvd;
         · exact Nat.pos_of_neZero ℓ'
         · exact hdiv.out) (input := ⟨stmtOut, oStmt⟩)
-
     sumcheckFinalCheck ∧ finalFoldingProp -- local checks ∧ (oracleConsitency ∨ badEventExists)
 
 /-- The knowledge state function for the final sumcheck step -/
@@ -711,7 +731,7 @@ noncomputable def finalSumcheckKnowledgeStateFunction {σ : Type} (init : ProbCo
     sorry
 
 /-- Round-by-round knowledge soundness for the final sumcheck step -/
-theorem finalSumcheckOracleVerifier_rbrKnowledgeSoundness [Fintype L] {σ : Type}
+theorem finalSumcheckOracleVerifier_rbrKnowledgeSoundness {σ : Type}
     (init : ProbComp σ) (impl : QueryImpl []ₒ (StateT σ ProbComp)) :
     (finalSumcheckVerifier κ L K β ℓ ℓ' 𝓡 ϑ
       h_ℓ_add_R_rate h_l).rbrKnowledgeSoundness init impl
@@ -734,8 +754,10 @@ section CoreInteractionPhaseReduction
 @[reducible]
 def coreInteractionOracleVerifier :=
   OracleVerifier.append (oSpec:=[]ₒ)
-    (Stmt₁ := Statement (L := L) (ℓ:=ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0)
-    (Stmt₂ := Statement (L := L) (ℓ:=ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
+    (Stmt₁ := Statement (L := L) (ℓ:=ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0)
+    (Stmt₂ := Statement (L := L) (ℓ:=ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
     (Stmt₃ := BinaryBasefold.FinalSumcheckStatementOut (L:=L) (ℓ:=ℓ'))
     (OStmt₁ := BinaryBasefold.OracleStatement K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ϑ 0)
     (OStmt₂ := BinaryBasefold.OracleStatement K β
@@ -752,8 +774,10 @@ def coreInteractionOracleVerifier :=
 @[reducible]
 def coreInteractionOracleReduction :=
   OracleReduction.append (oSpec:=[]ₒ)
-    (Stmt₁ := Statement (L := L) (ℓ:=ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0)
-    (Stmt₂ := Statement (L := L) (ℓ:=ℓ') (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
+    (Stmt₁ := Statement (L := L) (ℓ:=ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) 0)
+    (Stmt₂ := Statement (L := L) (ℓ:=ℓ')
+      (RingSwitchingBaseContext κ L K ℓ (biniusProfile κ L K β)) (Fin.last ℓ'))
     (Stmt₃ := BinaryBasefold.FinalSumcheckStatementOut (L:=L) (ℓ:=ℓ'))
     (Wit₁ := RingSwitching.SumcheckWitness L ℓ' 0)
     (Wit₂ := BinaryBasefold.Witness K β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (ℓ:=ℓ') (Fin.last ℓ'))

--- a/ArkLib/ProofSystem/RingSwitching/Packing/General.lean
+++ b/ArkLib/ProofSystem/RingSwitching/Packing/General.lean
@@ -64,11 +64,11 @@ def batchingCoreVerifier :=
 /-- The oracle verifier for the full DP24 ring-switching protocol -/
 @[reducible]
 def fullOracleVerifier :=
-  OracleVerifier.append (oSpec:=[]ₒ)
-    (V₁:=batchingCoreVerifier κ L K P ℓ ℓ' h_l mlIOPCS)
-    (pSpec₁:=pSpecLargeFieldReduction κ L K P ℓ')
-    (V₂:=mlIOPCS.oracleReduction.toOracleVerifier)
-    (pSpec₂:=mlIOPCS.pSpec)
+  OracleVerifier.append (oSpec := []ₒ)
+    (V₁ := batchingCoreVerifier κ L K P ℓ ℓ' h_l mlIOPCS)
+    (pSpec₁ := pSpecLargeFieldReduction κ L K P ℓ')
+    (V₂ := mlIOPCS.oracleReduction.toOracleVerifier)
+    (pSpec₂ := mlIOPCS.pSpec)
     (Oₛ₃ := fun i : Empty => nomatch i)
 
 def batchingCoreReduction :=
@@ -158,8 +158,6 @@ def fullRbrKnowledgeError (i : (fullPspec κ L K P ℓ' mlIOPCS).ChallengeIdx) :
   (g:=mlIOPCS.rbrKnowledgeError)
   (ChallengeIdx.sumEquiv.symm i)
 
-variable [SampleableType L]
-
 /-- Round-by-round knowledge soundness for the full ring-switching oracle verifier -/
 theorem fullOracleVerifier_rbrKnowledgeSoundness [IsDomain L] :
     OracleProof.rbrKnowledgeSoundness
@@ -198,7 +196,7 @@ theorem fullOracleVerifier_rbrKnowledgeSoundness [IsDomain L] :
       · sorry
     )
   convert res
-  · simp only [ChallengeIdx, Challenge, instSampleableTypeChallengeFullPspec]
+  · simp only [ChallengeIdx]
     sorry
 
 end SecurityProperties

--- a/ArkLib/ProofSystem/RingSwitching/Packing/General.lean
+++ b/ArkLib/ProofSystem/RingSwitching/Packing/General.lean
@@ -119,27 +119,35 @@ open Sumcheck.Structured
 section SecurityProperties
 variable {σ : Type} (init : ProbComp σ) {impl : QueryImpl []ₒ (StateT σ ProbComp)}
 
-omit [(i : mlIOPCS.pSpec.ChallengeIdx) → SampleableType (mlIOPCS.pSpec.Challenge i)] in
-lemma batchingCore_perfectCompleteness :
+omit [Fintype L] [Fintype K] [DecidableEq K]
+  [(i : mlIOPCS.pSpec.ChallengeIdx) → SampleableType (mlIOPCS.pSpec.Challenge i)] in
+lemma batchingCore_perfectCompleteness [Finite L] [Finite K] :
   (batchingCoreReduction κ L K P ℓ ℓ' h_l mlIOPCS).perfectCompleteness
   (pSpec := pSpecLargeFieldReduction κ L K P ℓ')
   (relIn := BatchingPhase.batchingInputRelation κ L K P ℓ ℓ' h_l mlIOPCS.toAbstractOStmtIn)
   (relOut := mlIOPCS.toRelInput)
   (init:=init) (impl:=impl) := by
+  let _ := Fintype.ofFinite L
+  let _ := Fintype.ofFinite K
+  classical
   apply OracleReduction.append_perfectCompleteness
   · exact BatchingPhase.batchingReduction_perfectCompleteness κ L K P ℓ ℓ' h_l
        mlIOPCS.toAbstractOStmtIn
   · exact SumcheckPhase.coreInteraction_perfectCompleteness
       κ L K P ℓ ℓ' h_l mlIOPCS.toAbstractOStmtIn (impl:=impl)
 
-omit [(i : mlIOPCS.pSpec.ChallengeIdx) → SampleableType (mlIOPCS.pSpec.Challenge i)] in
-theorem fullOracleReduction_perfectCompleteness :
+omit [Fintype L] [Fintype K] [DecidableEq K]
+  [(i : mlIOPCS.pSpec.ChallengeIdx) → SampleableType (mlIOPCS.pSpec.Challenge i)] in
+theorem fullOracleReduction_perfectCompleteness [Finite L] [Finite K] :
     OracleProof.perfectCompleteness
       (oracleProof := fullOracleReduction κ L K P ℓ ℓ' (h_l := h_l) mlIOPCS)
       (relation := BatchingPhase.batchingInputRelation κ L K P ℓ ℓ' h_l
         mlIOPCS.toAbstractOStmtIn)
       (init := init)
       (impl := impl) := by
+  let _ := Fintype.ofFinite L
+  let _ := Fintype.ofFinite K
+  classical
   exact OracleReduction.append_perfectCompleteness
     (R₁ := batchingCoreReduction κ L K P ℓ ℓ' h_l mlIOPCS)
     (R₂ := mlIOPCS.oracleReduction)
@@ -158,14 +166,17 @@ def fullRbrKnowledgeError (i : (fullPspec κ L K P ℓ' mlIOPCS).ChallengeIdx) :
   (g:=mlIOPCS.rbrKnowledgeError)
   (ChallengeIdx.sumEquiv.symm i)
 
+omit [Fintype K] [DecidableEq K] in
 /-- Round-by-round knowledge soundness for the full ring-switching oracle verifier -/
-theorem fullOracleVerifier_rbrKnowledgeSoundness [IsDomain L] :
+theorem fullOracleVerifier_rbrKnowledgeSoundness [Finite K] [IsDomain L] :
     OracleProof.rbrKnowledgeSoundness
       (verifier := fullOracleVerifier κ L K P ℓ ℓ' (h_l := h_l) mlIOPCS)
       (init := init)
       (impl := impl)
       (relIn := fullInputRelation κ L K P ℓ ℓ' h_l mlIOPCS)
       (rbrKnowledgeError := fun i => fullRbrKnowledgeError κ L K P ℓ' mlIOPCS i) := by
+  let _ := Fintype.ofFinite K
+  classical
   unfold fullOracleVerifier fullRbrKnowledgeError
   have batchInteractionRBRKS :=
     OracleVerifier.append_rbrKnowledgeSoundness (init:=init) (impl:=impl)

--- a/ArkLib/ProofSystem/RingSwitching/Packing/SumcheckPhase.lean
+++ b/ArkLib/ProofSystem/RingSwitching/Packing/SumcheckPhase.lean
@@ -210,7 +210,6 @@ def iteratedSumcheckKStateProp (i : Fin ℓ') (m : Fin (2 + 1))
       ⟨⟨0, Nat.lt_of_succ_le hm⟩, by simp [pSpecSumcheckRound]; rfl⟩
     let h_i : L⦃≤ 2⦄[X] := msgsUpTo i_msg1
     h_i
-
   let get_rᵢ' := fun (m: Fin (2 + 1)) (tr: Transcript m (pSpecSumcheckRound L)) (hm: 2 ≤ m.val) =>
     let ⟨msgsUpTo, chalsUpTo⟩ := Transcript.equivMessagesChallenges (k := m)
       (pSpec := pSpecSumcheckRound L) tr
@@ -221,7 +220,6 @@ def iteratedSumcheckKStateProp (i : Fin ℓ') (m : Fin (2 + 1))
       ⟨⟨1, Nat.lt_of_succ_le hm⟩, by simp only [Nat.reduceAdd]; rfl⟩
     let r_i' : L := chalsUpTo i_msg2
     r_i'
-
   match m with
   | ⟨0, _⟩ => -- equiv s relIn
     RingSwitching.masterKStateProp κ L K P ℓ ℓ' h_l
@@ -272,35 +270,31 @@ def iteratedSumcheckKnowledgeStateFunction (i : Fin ℓ') :
     · -- m = 0: succ = 1, castSucc = 0
       unfold iteratedSumcheckKStateProp
       simp only [masterKStateProp, iteratedSumcheckRbrExtractor, true_and]
-      simp only [Fin.succ_mk, Fin.castSucc_mk, Fin.castAdd_mk]
+      simp only [Fin.succ_mk, Fin.castSucc_mk]
       tauto
     · -- m = 1: dir 1 = V_to_P, contradicts hDir
-      simp [pSpecSumcheckRound] at hDir
-  toFun_full := fun ⟨stmtLast, oStmtLast⟩ tr witOut => by
-    intro h_relOut
-    simp at h_relOut
-    rcases h_relOut with ⟨stmtOut, ⟨oStmtOut, h_conj⟩⟩
-    have h_simulateQ := h_conj.1
-    have h_SumcheckStepRelOut := h_conj.2
-    set witLast := (iteratedSumcheckRbrExtractor κ L K P ℓ ℓ' h_l aOStmtIn i).extractOut
-      ⟨stmtLast, oStmtLast⟩ tr witOut
-    simp only [Fin.reduceLast, Fin.isValue]
-    -- ⊢ iteratedSumcheckKStateProp 𝔽q β 2 tr stmtLast witLast oStmtLast
-    -- TODO : prove this via the relations between stmtLast & stmtOut,
-      -- witLast & witOut, oStmtLast & oStmtOut
+      simp at hDir
+  toFun_full := fun _ _ _ _ => by
     sorry
 
+section
+local instance : DecidableEq K := Classical.decEq K
+
+omit [Fintype K] [DecidableEq K] in
 /-- RBR knowledge soundness for a single round oracle verifier -/
 theorem iteratedSumcheckOracleVerifier_rbrKnowledgeSoundness [IsDomain L] (i : Fin ℓ') :
     (iteratedSumcheckOracleVerifier κ L K P ℓ ℓ' aOStmtIn i).rbrKnowledgeSoundness init impl
       (relIn := sumcheckRoundRelation κ L K P ℓ ℓ' h_l aOStmtIn i.castSucc)
       (relOut := sumcheckRoundRelation κ L K P ℓ ℓ' h_l aOStmtIn i.succ)
       (fun j => roundKnowledgeError L ℓ' i) := by
+  classical
   use fun _ => SumcheckWitness L ℓ' i.castSucc
   use iteratedSumcheckRbrExtractor κ L K P ℓ ℓ' h_l aOStmtIn i
   use iteratedSumcheckKnowledgeStateFunction κ L K P ℓ ℓ' h_l aOStmtIn i
   intro stmtIn witIn prover j
   sorry
+
+end
 
 end IteratedSumcheckStep
 
@@ -386,6 +380,7 @@ noncomputable def finalSumcheckOracleReduction :
   prover := finalSumcheckProver κ L K P ℓ ℓ' aOStmtIn
   verifier := finalSumcheckVerifier κ L K P ℓ ℓ' h_l aOStmtIn
 
+omit [Fintype L] [Fintype K] [DecidableEq K] in
 /-- Perfect completeness for the final sumcheck step -/
 theorem finalSumcheckOracleReduction_perfectCompleteness {σ : Type}
   (init : ProbComp σ)
@@ -441,7 +436,6 @@ def finalSumcheckKStateProp {m : Fin (1 + 1)} (tr : Transcript m (pSpecFinalSumc
     let i_msg0 : tr_so_far.MessageIdx := ⟨⟨0, by omega⟩, rfl⟩
     let c : L := (ProtocolSpec.Transcript.equivMessagesChallenges (k := 1)
       (pSpec := pSpecFinalSumcheck L) tr).1 i_msg0
-
     let stmtOut : MLPEvalStatement L ℓ' := {
       t_eval_point := stmt.challenges,
       original_claim := c
@@ -450,7 +444,6 @@ def finalSumcheckKStateProp {m : Fin (1 + 1)} (tr : Transcript m (pSpecFinalSumc
       let eq_tilde_eval : L := compute_final_eq_value κ L K P ℓ ℓ' h_l
         stmt.ctx.t_eval_point stmt.challenges stmt.ctx.r_batching
       stmt.sumcheck_target = eq_tilde_eval * c
-
     let final_eval : Prop := witMid.t'.val.eval stmt.challenges = c
     sumcheckFinalLocalCheck ∧ final_eval
     ∧ aOStmtIn.initialCompatibility ⟨witMid.t', oStmt⟩
@@ -474,18 +467,25 @@ noncomputable def finalSumcheckKnowledgeStateFunction {σ : Type} (init : ProbCo
   toFun_full := fun stmt tr witOut h => by
     sorry
 
+section
+local instance : DecidableEq K := Classical.decEq K
+
+omit [Fintype K] [DecidableEq K] in
 /-- Round-by-round knowledge soundness for the final sumcheck step -/
-theorem finalSumcheckOracleVerifier_rbrKnowledgeSoundness [Fintype L] [IsDomain L] {σ : Type}
+theorem finalSumcheckOracleVerifier_rbrKnowledgeSoundness [IsDomain L] {σ : Type}
     (init : ProbComp σ) (impl : QueryImpl []ₒ (StateT σ ProbComp)) :
     (finalSumcheckVerifier κ L K P ℓ ℓ' h_l aOStmtIn).rbrKnowledgeSoundness init impl
       (relIn := sumcheckRoundRelation κ L K P ℓ ℓ' h_l aOStmtIn (Fin.last ℓ'))
       (relOut := aOStmtIn.toRelInput)
       (rbrKnowledgeError := fun _ => finalSumcheckRbrKnowledgeError (L := L)) := by
+  classical
   use (fun _ => SumcheckWitness L ℓ' (Fin.last ℓ'))
   use finalSumcheckRbrExtractor κ L K P ℓ ℓ' h_l aOStmtIn
   use finalSumcheckKnowledgeStateFunction κ L K P ℓ ℓ' h_l aOStmtIn init impl
   intro stmtIn witIn prover j
   sorry
+
+end
 
 end FinalSumcheckStep
 
@@ -541,6 +541,7 @@ def coreInteractionOracleReduction :=
 
 variable {σ : Type} {init : ProbComp σ} {impl : QueryImpl []ₒ (StateT σ ProbComp)}
 
+omit [Fintype L] [Fintype K] [DecidableEq K] in
 /-- Perfect completeness for large-field reduction (Sumcheck ++ FinalSum) -/
 theorem coreInteraction_perfectCompleteness :
   OracleReduction.perfectCompleteness
@@ -594,6 +595,10 @@ def coreInteractionRbrKnowledgeError (j : (pSpecCoreInteraction L ℓ').Challeng
 
 -- TODO: iteratedSumcheckLoop_rbrKnowledgeSoundness
 
+section
+local instance : DecidableEq K := Classical.decEq K
+
+omit [Fintype K] [DecidableEq K] in
 /-- RBR knowledge soundness for large-field reduction (Sumcheck ++ FinalSum) -/
 theorem coreInteraction_rbrKnowledgeSoundness [IsDomain L] :
   OracleVerifier.rbrKnowledgeSoundness
@@ -609,7 +614,11 @@ theorem coreInteraction_rbrKnowledgeSoundness [IsDomain L] :
     (relIn := sumcheckRoundRelation κ L K P ℓ ℓ' h_l aOStmtIn 0)
     (relOut := aOStmtIn.toRelInput)
     (rbrKnowledgeError := coreInteractionRbrKnowledgeError (L:=L) (ℓ':=ℓ')) := by
+  classical
   sorry
+
+
+end
 
 end LargeFieldReduction
 end


### PR DESCRIPTION
## Result

Removes real linter debt from six proof-system hotspots without suppressing diagnostics or weakening protocol/security statements:

- Batched FRI security
- FRIBinius core interaction
- Binary Basefold core interaction and steps
- Packing sumcheck and composed protocol security

The changes remove unused section/typeclass premises, replace proof-only `Fintype` assumptions with weaker `Finite` assumptions plus local instances, simplify dead proof branches, and make tactic dependencies explicit.

## Validation

- guarded exact builds pass for all six changed targets
- target non-sorry lint diagnostics: `0 / 0 / 0 / 0 / 3 / 1`
- the four residual diagnostics are the existing structurally captured `[Nontrivial L]` plus `[IsDomain L]` overlap; none are suppressed
- source admission-token count: `185 -> 184`, solely because two nested `sorry` tokens in one already-unfinished declaration become one; the kernel-tainted declaration set is unchanged at 43, so this is not a closed proof gap
- examples remain `125`; explicit axioms and native trust remain `0`
- independent `review-lean-formalization` hard gate: no correctness or trust blocker

Exact guarded timings on the reviewed head were 1.60s, 1.67s, 1.73s, 1.51s, 2.17s, and 4.05s for the six targets respectively.

## API note

Three packing security theorem types are logically generalized from proof-only `Fintype`/`DecidableEq` premises to `Finite`; ordinary callers are source-compatible because `Fintype` synthesizes `Finite`. Explicit `@` or named-instance callers may need adjustment. No in-tree caller breaks.
