### PR TITLE
lint: remove five non-Data warning hotspots

### DIFF
--- a/ArkLib/OracleReduction/Cast.lean
+++ b/ArkLib/OracleReduction/Cast.lean
@@ -57,8 +57,13 @@ protected def cast (P : Prover oSpec StmtIn WitIn StmtOut WitOut pSpec₁) :
 @[simp]
 theorem cast_id :
     Prover.cast rfl rfl = (id : Prover oSpec StmtIn WitIn StmtOut WitOut pSpec₁ → _) := by
-  funext; simp [Prover.cast]; ext <;> simp
-  · funext _ _; simp [MessageIdx.cast, bind_pure]
+  funext
+  unfold Prover.cast
+  simp only [ProtocolSpec.cast_id, id_eq]
+  ext <;> simp only [MessageIdx, Function.comp_apply, Fin.cast_eq_self, Message,
+    ChallengeIdx, Challenge, cast_eq, bind_pure_comp, heq_eq_eq]
+  · funext _ _
+    simp [MessageIdx.cast]
   · apply heq_of_eq
     funext _ _
     simp [ChallengeIdx.cast]
@@ -80,6 +85,7 @@ protected def cast (P : OracleProver oSpec StmtIn OStmtIn WitIn StmtOut OStmtOut
     OracleProver oSpec StmtIn OStmtIn WitIn StmtOut OStmtOut WitOut pSpec₂ :=
   Prover.cast hn hSpec P
 
+omit Oₛᵢ Oₛₒ in
 @[simp]
 theorem cast_id :
     OracleProver.cast rfl rfl =
@@ -259,8 +265,13 @@ theorem cast_processRound (j : Fin n₁)
       cast (by subst_vars; simp [Prover.cast]; rfl)
         ((P.cast hn hSpec).processRound (Fin.cast hn j)
           (cast (by subst_vars; simp [Prover.cast]; rfl) currentResult)) := by
-  subst hn; subst hSpec; congr 1; ext <;> simp [Prover.cast]
-  · funext _ _; simp [MessageIdx.cast, bind_pure]
+  subst hn; subst hSpec; congr 1
+  unfold Prover.cast
+  ext <;> simp only [MessageIdx, Function.comp_apply, Fin.cast_eq_self, Message,
+    ChallengeIdx, Challenge, cast_eq, bind_pure_comp, heq_eq_eq]
+  · apply heq_of_eq
+    funext _ _
+    simp [MessageIdx.cast]
   · apply heq_of_eq
     funext _ _
     simp [ChallengeIdx.cast]
@@ -271,8 +282,13 @@ theorem cast_runToRound (j : Fin (n₁ + 1)) (stmt : StmtIn) (wit : WitIn)
     P.runToRound j stmt wit =
       cast (by subst_vars; simp [Prover.cast]; rfl)
         ((P.cast hn hSpec).runToRound (Fin.cast (congrArg (· + 1) hn) j) stmt wit) := by
-  subst hn; subst hSpec; congr 1; ext <;> simp [Prover.cast]
-  · funext _ _; simp [MessageIdx.cast, bind_pure]
+  subst hn; subst hSpec; congr 1
+  unfold Prover.cast
+  ext <;> simp only [MessageIdx, Function.comp_apply, Fin.cast_eq_self, Message,
+    ChallengeIdx, Challenge, cast_eq, bind_pure_comp, heq_eq_eq]
+  · apply heq_of_eq
+    funext _ _
+    simp [MessageIdx.cast]
   · apply heq_of_eq
     funext _ _
     simp [ChallengeIdx.cast]
@@ -359,7 +375,8 @@ theorem cast_rbrKnowledgeSoundness (ε : pSpec₁.ChallengeIdx → ℝ≥0)
   subst hn
   simp only [ProtocolSpec.cast_id, id_eq] at hSpec
   subst hSpec
-  change @rbrKnowledgeSoundness ι oSpec StmtIn WitIn StmtOut WitOut n₁ pSpec₁ inst₂ σ init impl relIn relOut V ε
+  change @rbrKnowledgeSoundness ι oSpec StmtIn WitIn StmtOut WitOut n₁ pSpec₁ inst₂ σ
+    init impl relIn relOut V ε
   have hhandler : ∀ (t : (oSpec + [pSpec₁.Challenge]ₒ).Domain) (s : σ),
       𝒮[((impl.addLift (@challengeQueryImpl n₁ pSpec₁ inst₁) :
           QueryImpl (oSpec + [pSpec₁.Challenge]ₒ) (StateT σ ProbComp)) t).run s] =

--- a/ArkLib/OracleReduction/Composition/Sequential/General.lean
+++ b/ArkLib/OracleReduction/Composition/Sequential/General.lean
@@ -230,7 +230,10 @@ lemma seqCompose_toVerifier {m : ℕ}
     (seqCompose Stmt OStmt V).toVerifier =
       Verifier.seqCompose (fun i => Stmt i × (∀ j, OStmt i j)) (fun i => (V i).toVerifier) := by
   induction m with
-  | zero => simp; exact OracleVerifier.id_toVerifier
+  | zero =>
+    simp only [Fin.isValue, Fin.reduceLast, Fin.vsum_zero, seqCompose_zero, Nat.reduceAdd,
+      Verifier.seqCompose_zero]
+    exact OracleVerifier.id_toVerifier
   | succ m ih =>
     simp only [seqCompose_succ, Verifier.seqCompose_succ]
     have h1 := OracleVerifier.append_toVerifier (V 0) (seqCompose (Stmt ∘ Fin.succ)
@@ -304,7 +307,10 @@ lemma seqCompose_toReduction {m : ℕ}
       Reduction.seqCompose (fun i => Stmt i × (∀ j, OStmt i j)) Wit
         (fun i => (R i).toReduction) := by
   induction m with
-  | zero => simp; exact OracleReduction.id_toReduction
+  | zero =>
+    simp only [Fin.isValue, Fin.reduceLast, Fin.vsum_zero, seqCompose_zero, Nat.reduceAdd,
+      Reduction.seqCompose_zero]
+    exact OracleReduction.id_toReduction
   | succ m ih =>
     simp only [seqCompose_succ, Reduction.seqCompose_succ]
     have h1 := OracleReduction.append_toReduction (R 0) (seqCompose (Stmt ∘ Fin.succ)
@@ -357,10 +363,11 @@ theorem seqCompose_completeness
   induction m with
   | zero => simp only [seqCompose_zero]; exact id_perfectCompleteness init impl
   | succ m ih =>
-    simp
+    simp only [Fin.vsum_succ, seqCompose_succ, Fin.castSucc_zero, Fin.succ_zero_eq_one,
+      Function.comp_apply, Fin.succ_last, Nat.succ_eq_add_one]
     have := ih (fun i => rel i.succ) (fun i => R i.succ)
       (fun i => completenessError i.succ) (fun i => h i.succ)
-    simp at this
+    simp only [Fin.succ_zero_eq_one, Fin.succ_last, Nat.succ_eq_add_one] at this
     rw [Fin.sum_univ_succ]
     exact append_completeness
       (R 0)
@@ -394,12 +401,16 @@ theorem seqCompose_soundness
       (Verifier.seqCompose Stmt V).soundness init impl (lang 0) (lang (Fin.last m))
         (∑ i, soundnessError i) := by
   induction m with
-  | zero => simp; exact Verifier.id_soundness init impl
+  | zero =>
+    simp only [Fin.isValue, Fin.reduceLast, Fin.vsum_zero, seqCompose_zero,
+      Finset.univ_eq_empty, Finset.sum_empty]
+    exact Verifier.id_soundness init impl
   | succ m ih =>
-    simp
+    simp only [Fin.vsum_succ, seqCompose_succ, Fin.castSucc_zero, Fin.succ_zero_eq_one,
+      Function.comp_apply, Fin.succ_last, Nat.succ_eq_add_one]
     have := ih (fun i => lang i.succ) (fun i => V i.succ)
       (fun i => soundnessError i.succ) (fun i => h i.succ)
-    simp at this
+    simp only [Fin.succ_zero_eq_one, Fin.succ_last, Nat.succ_eq_add_one] at this
     rw [Fin.sum_univ_succ]
     exact append_soundness (V 0) (seqCompose (Stmt ∘ Fin.succ) (fun i => V i.succ))
       (h 0) this
@@ -415,12 +426,16 @@ theorem seqCompose_knowledgeSoundness
       (Verifier.seqCompose Stmt V).knowledgeSoundness init impl (rel 0) (rel (Fin.last m))
         (∑ i, knowledgeError i) := by
   induction m with
-  | zero => simp; exact Verifier.id_knowledgeSoundness init impl
+  | zero =>
+    simp only [Fin.isValue, Fin.reduceLast, Fin.vsum_zero, seqCompose_zero,
+      Finset.univ_eq_empty, Finset.sum_empty]
+    exact Verifier.id_knowledgeSoundness init impl
   | succ m ih =>
-    simp
+    simp only [Fin.vsum_succ, seqCompose_succ, Fin.castSucc_zero, Fin.succ_zero_eq_one,
+      Function.comp_apply, Fin.succ_last, Nat.succ_eq_add_one]
     have := ih (fun i => rel i.succ) (fun i => V i.succ)
       (fun i => knowledgeError i.succ) (fun i => h i.succ)
-    simp at this
+    simp only [Fin.succ_zero_eq_one, Fin.succ_last, Nat.succ_eq_add_one] at this
     rw [Fin.sum_univ_succ]
     exact append_knowledgeSoundness (V 0) (seqCompose (Stmt ∘ Fin.succ) (fun i => V i.succ))
       (h 0) this
@@ -447,12 +462,13 @@ theorem seqCompose_rbrSoundness
     rw [Verifier.seqCompose_zero]
     exact Verifier.id_rbrSoundness init impl
   | succ m ih =>
-    simp
+    simp only [Fin.vsum_succ, seqCompose_succ, Fin.castSucc_zero, Fin.succ_zero_eq_one,
+      Function.comp_apply, Fin.succ_last, Nat.succ_eq_add_one, ChallengeIdx]
     have := ih (fun i => lang i.succ) (fun i => V i.succ)
       (fun i => rbrSoundnessError i.succ) (fun i => h i.succ)
-    simp at this
+    simp only [Fin.succ_zero_eq_one, Fin.succ_last, Nat.succ_eq_add_one, ChallengeIdx] at this
     convert append_rbrSoundness (V 0) (seqCompose (Stmt ∘ Fin.succ) (fun i => V i.succ))
-      (h 0) this <;>
+      (h 0) this;
     sorry
 
 /-- If all verifiers in a sequence satisfy round-by-round knowledge soundness with respective RBR
@@ -479,12 +495,13 @@ theorem seqCompose_rbrKnowledgeSoundness
     rw [Verifier.seqCompose_zero]
     exact Verifier.id_rbrKnowledgeSoundness init impl
   | succ m ih =>
-    simp
+    simp only [Fin.vsum_succ, seqCompose_succ, Fin.castSucc_zero, Fin.succ_zero_eq_one,
+      Function.comp_apply, Fin.succ_last, Nat.succ_eq_add_one, ChallengeIdx]
     have := ih (fun i => rel i.succ) (fun i => V i.succ)
       (fun i => rbrKnowledgeError i.succ) (fun i => h i.succ)
-    simp at this
+    simp only [Fin.succ_zero_eq_one, Fin.succ_last, Nat.succ_eq_add_one, ChallengeIdx] at this
     convert append_rbrKnowledgeSoundness (V 0) (seqCompose (Stmt ∘ Fin.succ) (fun i => V i.succ))
-      (h 0) this <;>
+      (h 0) this;
     sorry
 
 end Verifier

--- a/ArkLib/OracleReduction/Composition/Sequential/IsPure.lean
+++ b/ArkLib/OracleReduction/Composition/Sequential/IsPure.lean
@@ -44,7 +44,7 @@ theorem IsPure.append (V₁ : Verifier oSpec Stmt₁ Stmt₂ pSpec₁)
   obtain ⟨f₁, hf₁⟩ := h₁.is_pure
   obtain ⟨f₂, hf₂⟩ := h₂.is_pure
   refine ⟨fun stmt tr => f₂ (f₁ stmt tr.fst) tr.snd, fun stmt tr => ?_⟩
-  simp only [Verifier.append, hf₁, hf₂, pure_bind, bind_pure]
+  simp only [Verifier.append, hf₁, hf₂, pure_bind]
 
 /-- **Purity data composes computably**: the composed verdict runs the left verdict on the
   transcript prefix and the right verdict on the suffix, from the statement the left verifier
@@ -61,7 +61,7 @@ def PureForm.append {V₁ : Verifier oSpec Stmt₁ Stmt₂ pSpec₁}
   verify_eq := fun stmt tr => by
     have h₁ := P₁.verify_eq
     have h₂ := P₂.verify_eq
-    simp only [Verifier.append, h₁, h₂, pure_bind, bind_pure]
+    simp only [Verifier.append, h₁, h₂, pure_bind]
 
 /-- Purity is preserved by `n`-ary sequential composition of verifiers. The base case is the
   identity verifier (`Verifier.seqCompose` reduces to `Verifier.id` at `m = 0`); the step case is

--- a/ArkLib/OracleReduction/Equiv.lean
+++ b/ArkLib/OracleReduction/Equiv.lean
@@ -97,7 +97,8 @@ def symm (eqv : Equiv pSpec pSpec') : Equiv pSpec' pSpec where
   dir_eq := fun i => by simp [eqv.dir_eq]
   typeEquiv := fun i => (eqv.typeEquiv (Fin.cast (eqv.round_eq.symm) i)).symm
 
-/-- Compose protocol specification equivalences (spelled `equivTrans` because `trans` is reserved). -/
+/-- Compose protocol specification equivalences (spelled `equivTrans` because `trans` is
+reserved). -/
 def equivTrans (eqv : Equiv pSpec pSpec') (eqv' : Equiv pSpec' pSpec'') : Equiv pSpec pSpec'' where
   round_eq := eqv.round_eq.trans eqv'.round_eq
   dir_eq := fun i => by simp [eqv.dir_eq, eqv'.dir_eq]

--- a/ArkLib/OracleReduction/ProtocolSpec/Cast.lean
+++ b/ArkLib/OracleReduction/ProtocolSpec/Cast.lean
@@ -81,15 +81,14 @@ theorem cast_id : MessageIdx.cast (Eq.refl n₁) rfl = (id : pSpec₁.MessageIdx
 
 theorem cast_injective : Function.Injective (MessageIdx.cast hn hSpec) := by
   intro i j h'
-  simp [MessageIdx.cast] at h'
   ext : 1
-  exact h'
+  exact Fin.cast_injective hn (congrArg Subtype.val h')
 
 instance instDCast₂ : DCast₂ Nat ProtocolSpec (fun _ pSpec => MessageIdx pSpec) where
   dcast₂ h := MessageIdx.cast h
   dcast₂_id := cast_id
 
-theorem cast_eq_dcast₂ {hn} {hSpec : pSpec₁.cast hn = pSpec₂} {i : MessageIdx pSpec₁}:
+theorem cast_eq_dcast₂ {hn} {hSpec : pSpec₁.cast hn = pSpec₂} {i : MessageIdx pSpec₁} :
     i.cast hn hSpec = dcast₂ hn hSpec i := rfl
 
 end MessageIdx
@@ -125,15 +124,14 @@ theorem cast_id : ChallengeIdx.cast (Eq.refl n₁) rfl = (id : pSpec₁.Challeng
 
 theorem cast_injective : Function.Injective (ChallengeIdx.cast hn hSpec) := by
   intro i j h'
-  simp [ChallengeIdx.cast] at h'
   ext : 1
-  exact h'
+  exact Fin.cast_injective hn (congrArg Subtype.val h')
 
 instance instDCast₂ : DCast₂ Nat ProtocolSpec (fun _ pSpec => ChallengeIdx pSpec) where
   dcast₂ h := ChallengeIdx.cast h
   dcast₂_id := cast_id
 
-theorem cast_eq_dcast₂ {hn} {hSpec : pSpec₁.cast hn = pSpec₂} {i : ChallengeIdx pSpec₁}:
+theorem cast_eq_dcast₂ {hn} {hSpec : pSpec₁.cast hn = pSpec₂} {i : ChallengeIdx pSpec₁} :
     i.cast hn hSpec = dcast₂ hn hSpec i := rfl
 
 end ChallengeIdx
@@ -173,7 +171,7 @@ instance instDCast₃ : DCast₃ Nat (fun n => Fin (n + 1)) (fun n _ => Protocol
     (fun _ k pSpec => pSpec.Transcript k) where
   dcast₃ h h' h'' T := Transcript.cast h
     (by simp only [dcast] at h'; rw [← h']; subst h; rfl)
-    (by simp [ProtocolSpec.cast_eq_dcast, dcast_eq_root_cast]; exact h'')
+    (by simp only [ProtocolSpec.cast_eq_dcast, dcast_eq_root_cast]; exact h'')
     T
   dcast₃_id := cast_id
 

--- a/ArkLib/OracleReduction/ProtocolSpec/SeqCompose.lean
+++ b/ArkLib/OracleReduction/ProtocolSpec/SeqCompose.lean
@@ -56,7 +56,7 @@ theorem append_left_injective {pSpec : ProtocolSpec n} :
     Function.Injective (@ProtocolSpec.append m n · pSpec) := by
   simp only [append, Fin.vappend_eq_append]
   intro x y h
-  simp at h
+  simp only [mk.injEq] at h
   obtain ⟨hDir, hType⟩ := h
   ext i
   · simp [Fin.append_left_injective pSpec.dir hDir]
@@ -67,7 +67,7 @@ theorem append_right_injective {pSpec : ProtocolSpec m} :
   unfold ProtocolSpec.append
   simp only [Fin.vappend_eq_append]
   intro x y h
-  simp at h
+  simp only [mk.injEq] at h
   obtain ⟨hDir, hType⟩ := h
   ext i
   · simp [Fin.append_right_injective pSpec.dir hDir]
@@ -183,8 +183,8 @@ theorem take_append_left (T : FullTranscript pSpec₁) (T' : FullTranscript pSpe
     (T ++ₜ T').take m (Nat.le_add_right m n) =
       T.cast rfl (by simp [ProtocolSpec.append]) := by
   ext i
-  simp [take, append, ProtocolSpec.append, Fin.castLE,
-    FullTranscript.cast, Transcript.cast]
+  simp only [take, append, ProtocolSpec.append, Fin.castLE, FullTranscript.cast,
+    Transcript.cast, Fin.take_apply]
   have : ⟨i.val, by omega⟩ = Fin.castAdd n i := by ext; simp
   rw! (castMode := .all) [this, Fin.happend_left]
   rfl
@@ -194,7 +194,8 @@ theorem rtake_append_right (T : FullTranscript pSpec₁) (T' : FullTranscript pS
     (T ++ₜ T').rtake n (Nat.le_add_left n m) =
       T'.cast rfl (by simp [ProtocolSpec.append]) := by
   ext i
-  simp [rtake, Fin.rtake, append, Fin.cast, FullTranscript.cast, Transcript.cast]
+  simp only [rtake, Fin.rtake, append, Fin.cast, Fin.val_natAdd, FullTranscript.cast,
+    Transcript.cast, Fin.val_last, Fin.cast_eq_self, take_Type]
   have : ⟨m + n - n + i.val, by omega⟩ = Fin.natAdd m i := by ext; simp
   rw! (castMode := .all) [this, Fin.happend_right]
   apply eq_of_heq
@@ -238,10 +239,12 @@ def MessageIdx.sumEquiv :
   toFun := Sum.elim (MessageIdx.inl) (MessageIdx.inr)
   invFun := fun ⟨i, h⟩ => by
     by_cases hi : i < m
-    · simp [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi] at h
-      exact Sum.inl ⟨⟨i, hi⟩, h⟩
-    · simp [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi] at h
-      exact Sum.inr ⟨⟨i - m, by omega⟩, h⟩
+    · exact Sum.inl ⟨⟨i, hi⟩, by
+        convert h using 1; simp [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi];
+          congr⟩
+    · exact Sum.inr ⟨⟨i - m, by omega⟩, by
+        convert h using 1; simp [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi];
+          congr⟩
   left_inv := fun i => by
     rcases i with ⟨⟨i, isLt⟩, h⟩ | ⟨⟨i, isLt⟩, h⟩ <;>
     simp [MessageIdx.inl, MessageIdx.inr, isLt]
@@ -286,10 +289,12 @@ def ChallengeIdx.sumEquiv :
   toFun := Sum.elim (ChallengeIdx.inl) (ChallengeIdx.inr)
   invFun := fun ⟨i, h⟩ => by
     by_cases hi : i < m
-    · simp [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi] at h
-      exact Sum.inl ⟨⟨i, hi⟩, h⟩
-    · simp [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi] at h
-      exact Sum.inr ⟨⟨i - m, by omega⟩, h⟩
+    · exact Sum.inl ⟨⟨i, hi⟩, by
+        convert h using 1; simp [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi];
+          congr⟩
+    · exact Sum.inr ⟨⟨i - m, by omega⟩, by
+        convert h using 1; simp [Fin.vappend_eq_append, Fin.append, Fin.addCases, hi];
+          congr⟩
   left_inv := fun i => by
     rcases i with ⟨⟨i, isLt⟩, h⟩ | ⟨⟨i, isLt⟩, h⟩ <;>
     simp [ChallengeIdx.inl, ChallengeIdx.inr, isLt]
@@ -572,9 +577,11 @@ def seqComposeChallengeIdxToSigma {m : ℕ} {n : Fin m → ℕ} {pSpec : ∀ i, 
     (k : (seqCompose pSpec).ChallengeIdx) : (i : Fin m) × (pSpec i).ChallengeIdx :=
   let ij := Fin.splitSum k.1
   ⟨ij.1, ⟨ij.2, by
-    simp [ij]; have := k.property; simp at this
+    simp only [ij]
+    have := k.property
+    simp only [seqCompose_dir] at this
     have hk : k.1 = Fin.embedSum ij.1 ij.2 := by simp [ij]
-    simp [hk] at this
+    simp only [hk, Fin.vflatten_embedSum] at this
     exact this⟩⟩
 
 /-- The challenge type of a sequential composition at a combined challenge index equals the
@@ -612,9 +619,11 @@ def seqComposeMessageIdxToSigma {m : ℕ} {n : Fin m → ℕ} {pSpec : ∀ i, Pr
     (k : (seqCompose pSpec).MessageIdx) : (i : Fin m) × (pSpec i).MessageIdx :=
   let ij := Fin.splitSum k.1
   ⟨ij.1, ⟨ij.2, by
-    simp [ij]; have := k.property; simp at this
+    simp only [ij]
+    have := k.property
+    simp only [seqCompose_dir] at this
     have hk : k.1 = Fin.embedSum ij.1 ij.2 := by simp [ij]
-    simp [hk] at this
+    simp only [hk, Fin.vflatten_embedSum] at this
     exact this⟩⟩
 
 /-- The equivalence between the message indices of the individual protocols and the message

--- a/ArkLib/ProofSystem/Binius/BinaryBasefold/Basic.lean
+++ b/ArkLib/ProofSystem/Binius/BinaryBasefold/Basic.lean
@@ -252,7 +252,7 @@ lemma toOutCodewordsCount_succ_eq (i : Fin ℓ) :
     simp only [left_eq_ite_iff, Nat.add_eq_left, one_ne_zero, imp_false, Decidable.not_not]
     exact hv
   · rw [isCommitmentRound]
-    simp [ne_eq, hv, ↓reduceIte]
+    simp only [ne_eq, hv, ↓reduceIte]
     unfold toOutCodewordsCount
     have h_i_lt_ℓ: i.castSucc.val < ℓ := by
       change i.val < ℓ
@@ -543,7 +543,6 @@ noncomputable def extractMLP (i : Fin ℓ) (f : (sDomain 𝔽q β h_ℓ_add_R_ra
     }
   -- Run Berlekamp-Welch decoder to get P(X) in monomial basis
   let berlekamp_welch_result: Option L[X] := BerlekampWelch.decoder e k ωs f_vals
-
   match berlekamp_welch_result with
   | none => exact none -- Decoder failed
   | some P =>
@@ -587,7 +586,6 @@ noncomputable def extractMLP (i : Fin ℓ) (f : (sDomain 𝔽q β h_ℓ_add_R_ra
           have : ℓ < r := by omega
           exact Nat.le_of_lt this
         some (AdditiveNTT.monomialToNovelCoeffs 𝔽q β (ℓ - i.val) (by omega) monomial_coeffs)
-
       match novel_coeffs with
       | none => exact none
       | some t_coeffs =>
@@ -598,7 +596,6 @@ noncomputable def extractMLP (i : Fin ℓ) (f : (sDomain 𝔽q β h_ℓ_add_R_ra
           let w_index : Fin (2^(ℓ - i.val)) := Nat.binaryFinMapToNat
             (n:=ℓ - i.val) (m:=w) (h_binary:=by intro j; simp only [Nat.cast_id]; omega)
           t_coeffs w_index
-
         let t_multilinear_mv := MvPolynomial.MLE hypercube_evals
         exact some ⟨t_multilinear_mv, MLE_mem_restrictDegree hypercube_evals⟩
 
@@ -1020,24 +1017,20 @@ def finalNonDoomedFoldingProp {h_le : ϑ ≤ ℓ}
     exact isCompliant (i := ⟨k, by rw [h_k]; exact rounds_sub_steps_lt⟩) (steps := ϑ)
       (h_i_add_steps := by simp only; exact Nat.le_of_eq h_k_add_ϑ) (f_i := f_k)
       (f_i_plus_steps := by simp only [h_k_add_ϑ]; exact f_ℓ) (challenges := challenges)
-
   -- If oracleFoldingConsistency is true, then we can extract the original
     -- well-formed poly `t` and derive witnesses that satisfy the relations at any state
   let oracleFoldingConsistency: Prop :=
     (oracleFoldingConsistencyProp 𝔽q β (i := Fin.last ℓ)
       (challenges := stmt.challenges) (oStmt := oStmt))
     ∧ finalOracleFoldingConsistency
-
   let finalFoldingBadEvent : Prop :=
     Binius.BinaryBasefold.foldingBadEvent (i := ⟨k, by rw [h_k]; exact rounds_sub_steps_lt⟩)
       (steps := ϑ) (h_i_add_steps := by simp only; exact Nat.le_of_eq h_k_add_ϑ) (f_i := f_k)
       (challenges := challenges)
-
   -- All bad folding events are fully formed across the sum-check rounds,
     -- no new bad event at the final sumcheck step
   let foldingBadEventExists : Prop := badEventExistsProp 𝔽q β (stmtIdx := Fin.last ℓ)
     (oStmt := oStmt) (challenges := stmt.challenges)
-
   oracleFoldingConsistency ∨ foldingBadEventExists
 
 /-- Input relation for round i: R_i must hold at the beginning of round i -/

--- a/ArkLib/ProofSystem/Binius/BinaryBasefold/QueryPhase.lean
+++ b/ArkLib/ProofSystem/Binius/BinaryBasefold/QueryPhase.lean
@@ -91,12 +91,10 @@ def proximityChecksSpec (γ_challenges :
       -- Create the suffix `(v_{i+ϑ}, ..., v_{ℓ+R-1})` as an element of `S^(i+ϑ)`
       let next_suffix_of_v := extractNextSuffixFromChallenge 𝔽q β (ϑ:=ϑ)
         (h_ℓ_add_R_rate := h_ℓ_add_R_rate) v i h_i_add_ϑ_le_ℓ
-
       let next_suffix_of_v_fin : Fin (2 ^ (ℓ + 𝓡 - (i + ϑ))) :=
         by simpa [Fin.val_mk] using
           sDomainToFin 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate) ⟨i + ϑ, by omega⟩ (by
               apply Nat.lt_add_of_pos_right_of_le; simp only; omega) next_suffix_of_v
-
       -- Create the fiber evaluation mapping by querying oracle f^(i) at all fiber points
       let f_i_on_fiber : Fin (2^ϑ) → L := fun u =>
         let x: Fin (2 ^ (ℓ + 𝓡 - i)) := by
@@ -110,14 +108,11 @@ def proximityChecksSpec (γ_challenges :
         let x_point := finToSDomain 𝔽q β h_ℓ_add_R_rate ⟨i, by omega⟩ (by
             apply Nat.lt_add_of_pos_right_of_le; simp only; omega) x
         oStmt k_th_oracleIdx x_point
-
       -- Compute the next value using localized fold matrix form
       let cur_challenge_batch : Fin ϑ → L := fun j => fold_challenges ⟨i + j.val, by omega⟩
-
       let c_next := localized_fold_matrix_form 𝔽q β (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
         (i:=⟨i, by omega⟩) (steps:=ϑ) (h_i_add_steps:=by simp only; omega)
         (r_challenges:=cur_challenge_batch) (y:=next_suffix_of_v) (fiber_eval_mapping:=f_i_on_fiber)
-
       -- NOTE: at i, we do the consistency check FOR THE NEXT LEVEL (`i + ϑ`):
       -- `c_next ?= f^(i + ϑ)(v_{i + ϑ}, ..., v_{ℓ+R-1})`, the final check is also covered
       let consistency_check : Prop :=
@@ -151,7 +146,8 @@ def queryCodeword (j : Fin (toOutCodewordsCount ℓ ϑ (Fin.last ℓ)))
       OracleComp.lift <| by
         exact OracleSpec.query
             (show
-                [OracleStatement 𝔽q β (ϑ:=ϑ) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (Fin.last ℓ)]ₒ.Domain from
+                [OracleStatement 𝔽q β (ϑ:=ϑ) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
+                  (Fin.last ℓ)]ₒ.Domain from
               ⟨⟨j, by omega⟩, point⟩)
 
 section FinalQueryRoundIOR
@@ -202,7 +198,8 @@ noncomputable def queryOracleVerifier :
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (Fin.last ℓ))
     (pSpec := pSpecQuery 𝔽q β γ_repetitions (h_ℓ_add_R_rate := h_ℓ_add_R_rate))
     (fun (stmt: FinalSumcheckStatementOut (L:=L) (ℓ:=ℓ))
-    (challenges: (pSpecQuery 𝔽q β γ_repetitions (h_ℓ_add_R_rate := h_ℓ_add_R_rate)).Challenges) => do
+    (challenges:
+      (pSpecQuery 𝔽q β γ_repetitions (h_ℓ_add_R_rate := h_ℓ_add_R_rate)).Challenges) => do
     -- Get all γ challenges from the second message (final sumcheck already checked earlier).
     let c := stmt.final_constant
     let fold_challenges : Fin γ_repetitions → sDomain 𝔽q β h_ℓ_add_R_rate 0 :=
@@ -367,7 +364,8 @@ else
     let r := stmt.ctx.t_eval_point
     let s := stmt.ctx.original_claim
     let challenges : Fin ℓ → L := stmt.challenges
-    let tr_so_far := (pSpecQuery 𝔽q β γ_repetitions (h_ℓ_add_R_rate := h_ℓ_add_R_rate)).take m m.is_le
+    let tr_so_far :=
+      (pSpecQuery 𝔽q β γ_repetitions (h_ℓ_add_R_rate := h_ℓ_add_R_rate)).take m m.is_le
     let chalIdx : tr_so_far.ChallengeIdx := ⟨⟨0,
       Nat.lt_of_succ_le (by omega)⟩, by simp only [Nat.reduceAdd]; rfl⟩
     let γ_challenges : Fin γ_repetitions → sDomain 𝔽q
@@ -400,7 +398,7 @@ noncomputable def queryKnowledgeStateFunction {σ : Type} (init : ProbComp σ)
     sorry
 
 /-- Round-by-round knowledge soundness for the oracle verifier (query phase) -/
-theorem queryOracleVerifier_rbrKnowledgeSoundness [Fintype L] {σ : Type} (init : ProbComp σ)
+theorem queryOracleVerifier_rbrKnowledgeSoundness {σ : Type} (init : ProbComp σ)
     (impl : QueryImpl []ₒ (StateT σ ProbComp)) :
     OracleProof.rbrKnowledgeSoundness init impl
     (relIn := finalSumcheckRelOut 𝔽q β (ϑ:=ϑ) (h_ℓ_add_R_rate := h_ℓ_add_R_rate))

--- a/ArkLib/ProofSystem/Binius/BinaryBasefold/Spec.lean
+++ b/ArkLib/ProofSystem/Binius/BinaryBasefold/Spec.lean
@@ -176,7 +176,6 @@ lemma isCommitmentRoundOfNonLastBlock (bIdx : Fin (ℓ / ϑ - 1)) :
     rw [Nat.add_assoc, Nat.sub_add_cancel (by exact NeZero.one_le)];
     conv_lhs => enter [2]; rw [←Nat.one_mul (n:=ϑ)]
     rw [←Nat.add_mul];
-
   have hdivLe: ϑ ∣ ↑bIdx * ϑ + (ϑ - 1) + 1 := by
     rw [h_eq]
     exact Nat.dvd_mul_left ϑ (↑bIdx + 1)
@@ -409,6 +408,7 @@ instance {d : ℕ} : ∀ i, SampleableType ((pSpecCoreInteraction 𝔽q β (ϑ:=
   instSampleableTypeChallengeAppend
 
 /-- SampleableType instance for sDomain, constructed via its equivalence with a Fin type. -/
+@[instance_reducible]
 def instSDomain {i : Fin r} (h_i : i < ℓ + 𝓡) :
     SampleableType (sDomain 𝔽q β h_ℓ_add_R_rate i) :=
   let T := sDomain 𝔽q β h_ℓ_add_R_rate i

--- a/ArkLib/ProofSystem/Component/CheckClaim.lean
+++ b/ArkLib/ProofSystem/Component/CheckClaim.lean
@@ -82,9 +82,10 @@ variable {σ : Type} {init : ProbComp σ} {impl : QueryImpl oSpec (StateT σ Pro
 /-- The `CheckClaim` reduction satisfies perfect completeness with respect to the predicate as the
   input relation, and the output relation being always true. -/
 @[simp]
-theorem reduction_completeness [Nonempty σ] [DecidableEq Statement] :
+theorem reduction_completeness [Nonempty σ] :
     (reduction oSpec Statement pred).perfectCompleteness init impl
     (relIn Statement pred) (relOut Statement) := by
+  classical
   simp only [Reduction.perfectCompleteness, Reduction.completeness, ENNReal.coe_zero, tsub_zero]
   intro stmt () valid
   simp only [relIn, Set.mem_ofPred_eq] at valid
@@ -126,8 +127,9 @@ theorem reduction_completeness [Nonempty σ] [DecidableEq Statement] :
       (Prod.fst <$> (pure (some ((default, stmt, ()), stmt)) :
         StateT σ ProbComp _).run s) at hx
     rw [StateT.run_pure] at hx
-    simp [map_pure, support_pure] at hx
-    cases hx
+    have hx' : some x = some ((default, stmt, ()), stmt) := by
+      simpa [map_pure, support_pure] using hx
+    cases hx'
     simp [relOut]
 
 /-- The knowledge state function for the `CheckClaim` reduction, mirroring the trivial-verifier
@@ -247,7 +249,8 @@ theorem oracleVerifier_toVerifier_run {stmt : Statement} {oStmt : ∀ i, OStatem
   simp only [Verifier.run, OracleVerifier.toVerifier]
   rw [oracleVerifier_materializeOutput]
   simp only [oracleVerifier]
-  simp [OptionT.run_pure, simulateQ_pure]
+  simp only [MessageIdx, Message, OptionT.run_pure, simulateQ_pure, map_pure,
+    Option.map_some]
   apply OptionT.ext
   rfl
 
@@ -319,8 +322,9 @@ theorem oracleReduction_completeness
       (Prod.fst <$> (pure (some ((default, ((stmt, oStmt), ())), (stmt, oStmt))) :
         StateT σ ProbComp _).run s) at hx
     rw [StateT.run_pure] at hx
-    simp [map_pure, support_pure] at hx
-    cases hx
+    have hx' : some x = some ((default, ((stmt, oStmt), ())), (stmt, oStmt)) := by
+      simpa [map_pure, support_pure] using hx
+    cases hx'
     exact ⟨⟨hIn, hP stmt oStmt hIn⟩, rfl⟩
 
 /-- **Coordinate-wise special soundness of `CheckClaim`, named form.** The verifier is a pure

--- a/ArkLib/ProofSystem/Component/DoNothing.lean
+++ b/ArkLib/ProofSystem/Component/DoNothing.lean
@@ -95,7 +95,7 @@ theorem oracleReduction_perfectCompleteness :
 
 /-- The `DoNothing` oracle verifier is perfectly round-by-round knowledge sound. -/
 @[simp]
-theorem oracleVerifier_rbrKnowledgeSoundness [DecidablePred (· ∈ rel)] :
+theorem oracleVerifier_rbrKnowledgeSoundness :
     (oracleVerifier oSpec Statement OStatement).rbrKnowledgeSoundness init impl rel rel 0 :=
   OracleVerifier.id_rbrKnowledgeSoundness init impl
 

--- a/ArkLib/ProofSystem/Component/NoInteraction.lean
+++ b/ArkLib/ProofSystem/Component/NoInteraction.lean
@@ -66,14 +66,19 @@ def reduction : Reduction oSpec StmtIn WitIn StmtOut WitOut !p[] where
 variable {σ : Type} {init : ProbComp σ} {impl : QueryImpl oSpec (StateT σ ProbComp)}
   {relIn : Set (StmtIn × WitIn)} {relOut : Set (StmtOut × WitOut)}
 
-theorem reduction_completeness {ε : ℝ≥0} [DecidablePred (· ∈ relOut)]
-    [DecidableEq StmtOut]
+theorem reduction_completeness {ε : ℝ≥0}
     (hRel : ∀ stmtIn witIn, (stmtIn, witIn) ∈ relIn →
-      Pr[fun ⟨stmtOut, witOut⟩ => (stmtOut, witOut) ∈ relOut | do
+      Pr[ fun ⟨stmtOut, witOut⟩ => (stmtOut, witOut) ∈ relOut | do
         (simulateQ impl <| combineMap mapStmt mapWit ⟨stmtIn, witIn⟩).run' (← init)] ≥ 1 - ε) :
     Reduction.completeness init impl relIn relOut (reduction mapStmt mapWit) ε := by
-  simp [Reduction.completeness, Reduction.run, Verifier.run, prover, Prover.run,
-    - tsub_le_iff_right]
+  classical
+  simp only [Reduction.completeness, ChallengeIdx, Challenge, QueryImpl.addLift_def,
+    PFunctor.Handler.liftTarget_self, Reduction.run, Prover.run, Fin.reduceLast, prover,
+    Nat.reduceAdd, Fin.isValue, MessageIdx, Message, Prover.runToRound_zero_of_prover_first,
+    id_eq, liftM_bind, bind_pure_comp, liftM_map, map_bind, Functor.map_map, pure_bind,
+    monadLift_liftM_OptionT, Verifier.run, OptionT.run_monadLift, monadLift_self,
+    bind_map_left, Option.getM_some, map_pure, bind_assoc, OptionT.run_bind,
+    OptionT.run_map, StateT.run'_eq, OptionT.mk_bind, ge_iff_le]
   intro stmtIn witIn hStmtIn
   refine ge_trans ?_ (hRel stmtIn witIn hStmtIn)
   sorry

--- a/ArkLib/ProofSystem/Component/RandomQuery.lean
+++ b/ArkLib/ProofSystem/Component/RandomQuery.lean
@@ -99,6 +99,7 @@ def oracleVerifier : OracleVerifier oSpec
       change HEq O O
       rfl }
 
+omit inst in
 @[simp]
 theorem oracleVerifier_materializeOutput (challenges : (pSpec OStatement).Challenges)
     (oStmt : ∀ i, OStmtIn OStatement i) (messages : (pSpec OStatement).Messages) :
@@ -127,7 +128,6 @@ instance : VerifierOnly (pSpec OStatement) where
 
 variable {σ : Type} {init : ProbComp σ} {impl : QueryImpl oSpec (StateT σ ProbComp)}
 
-set_option linter.unusedSimpArgs false in
 /-- The `RandomQuery` oracle reduction is perfectly complete. -/
 @[simp]
 theorem oracleReduction_completeness :
@@ -142,28 +142,17 @@ theorem oracleReduction_completeness :
     OracleVerifier.toVerifier, Verifier.run]
   simp_rw [show (pure : _ → OptionT (OracleComp _) _) = fun x => (pure (some x) :
     OracleComp _ _) from rfl]
-  simp only [← OracleComp.liftComp_eq_liftM, OracleComp.liftComp_pure,
-    pure_bind, bind_assoc]
+  simp only [OracleComp.liftComp_pure, ← OracleComp.liftComp_eq_liftM, pure_bind]
   erw [simulateQ_bind]
   erw [simulateQ_bind]
-  simp only [QueryImpl.addLift_def, simulateQ_pure,
-    QueryImpl.simulateQ_add_liftComp_right, QueryImpl.simulateQ_add_liftComp_left,
-    simulateQ_query,
-    ← OracleComp.liftComp_eq_liftM, OracleComp.liftComp_pure,
-    pure_bind, bind_assoc, map_pure, monadLift_pure, monadLift_bind]
+  simp only [QueryImpl.addLift_def, monadLift_bind, monadLift_pure, simulateQ_pure,
+    bind_assoc, pure_bind]
   erw [simulateQ_bind]
-  simp only [QueryImpl.addLift_def, simulateQ_pure,
-    QueryImpl.simulateQ_add_liftComp_right, QueryImpl.simulateQ_add_liftComp_left,
-    simulateQ_query,
-    ← OracleComp.liftComp_eq_liftM, OracleComp.liftComp_pure,
-    pure_bind, bind_assoc, map_pure, monadLift_pure, monadLift_bind,
-    OptionT.run_mk, OptionT.run_pure, OptionT.run_bind, OptionT.run,
-    Option.getM, Option.bind_some, Option.elimM,
-    FullTranscript.challenges, FullTranscript.messages, ChallengeIdx, Challenge,
-    hEq]
+  simp only [Challenge, ChallengeIdx, simulateQ_pure, OptionT.run,
+    FullTranscript.challenges, map_pure, Option.getM, bind_assoc, pure_bind]
   erw [simulateQ_query]
   simp only [StmtOut, OStmtOut, WitOut, Fin.isValue, Fin.vcons_of_one, ChallengeIdx,
-    Challenge, ofPFunctor_toPFunctor, QueryImpl.liftTarget_self, MessageIdx, OStmtIn,
+    Challenge, ofPFunctor_toPFunctor, QueryImpl.liftTarget_self, MessageIdx,
     Message, bind_map_left, StateT.run'_eq, StateT.run_bind, map_bind, OptionT.mk_bind,
     Set.mem_ofPred_eq, probEvent_eq_one_iff, probFailure_bind_eq_zero_iff,
     OptionT.probFailure_liftM, probFailure_eq_zero, OptionT.support_liftM,
@@ -172,32 +161,25 @@ theorem oracleReduction_completeness :
     exists_eq_right, exists_prop, forall_exists_index, and_imp, Prod.mk.injEq]
   constructor <;> intro <;> intro <;> intro <;> intro
   all_goals try erw [simulateQ_bind]
-  all_goals simp only [MonadLift.monadLift, liftM, monadLift, MonadLiftT.monadLift]
-  all_goals simp only [OracleComp.liftComp_pure, QueryImpl.simulateQ_add_liftComp_left,
-    simulateQ_pure, simulateQ_id', pure_bind, bind_assoc, map_pure, monadLift_pure,
-    OptionT.run_mk, OptionT.run_pure, OptionT.run_bind, OptionT.run,
-    StateT.run'_eq, probFailure_eq_zero, hEq,
-    support_pure, Set.mem_singleton_iff, Prod.eq_iff_fst_eq_snd_eq]
+  all_goals simp only [monadLift, MonadLift.monadLift, liftM]
+  all_goals simp only [OptionT.run]
   all_goals try erw [simulateQ_pure]
-  all_goals try simp_all only [simulateQ_pure, pure_bind, map_pure,
-    OptionT.run_mk, OptionT.run_pure, OptionT.run_bind, OptionT.run,
-    StateT.run'_eq, StateT.run_pure, probFailure_eq_zero,
-    support_pure, support_map, Set.mem_singleton_iff, Set.mem_image,
-    OptionT.probFailure_eq, probOutput_pure, hEq]
+  all_goals try simp_all only [pure_bind, OptionT.probFailure_eq, OptionT.run,
+    probFailure_eq_zero]
   · rw [show OptionT.mk = id from rfl]
     simp only [ChallengeIdx, Fin.vcons_of_one, Challenge, Fin.isValue, input_query,
-      cont_query, input_apply, id_eq, zero_add, probOutput_eq_zero_iff, support_map,
+      cont_query, id_eq, zero_add, probOutput_eq_zero_iff, support_map,
       Set.mem_image, Prod.exists, exists_and_right, exists_eq_right, not_exists]
     intro
     erw [simulateQ_pure]
-    simp [support_pure, pure_bind]
+    simp only [Fin.isValue, StmtIn, StateT.run_pure, support_pure,
+      Set.mem_singleton_iff, Prod.mk.injEq, reduceCtorEq, false_and,
+      not_false_eq_true, implies_true]
   · intro a b x hx x_1 hx1 x_2 x_3
     erw [simulateQ_bind]
-    simp only [liftComp_eq_liftM, pure_bind, simulateQ_pure, OptionT.lift,
-      OptionT.run_mk, map_pure]
+    simp only [OptionT.lift]
     erw [simulateQ_pure]
-    simp only [pure_bind, simulateQ_pure, support_pure, StateT.run, StateT.run',
-      Set.mem_singleton_iff, Prod.mk.injEq]
+    simp only [StateT.run, pure_bind]
     rintro ⟨⟨rfl, rfl⟩, rfl⟩
     refine ⟨?_, rfl, ?_⟩ <;> congr 1
 
@@ -234,7 +216,8 @@ def stateFunction [Inhabited OStatement] : (oracleVerifier oSpec OStatement).Sta
     -- absorbs the outer `pure (stmtOut, ...)`.
     erw [simulateQ_pure] at hx
     -- Now hx : some x ∈ support ((pure (some (tr.challenges ⟨0,_⟩, fun i => oStmt i))).run' s)
-    -- `pure` in `StateT σ ProbComp` unfolds via `StateT.run_pure`, then `map_pure` + `support_pure`.
+    -- `pure` in `StateT σ ProbComp` unfolds via `StateT.run_pure`, then `map_pure` and
+    -- `support_pure`.
     simp only [StateT.run'_eq, StateT.run_pure, map_pure, support_pure,
       Set.mem_singleton_iff, Option.map_some, Option.some.injEq] at hx
     subst x
@@ -310,13 +293,14 @@ theorem oracleVerifier_rbrKnowledgeSoundness [Nonempty (Query OStatement)]
   refine ⟨fun _ => Unit, rbrExtractor oSpec OStatement,
     knowledgeStateFunction oSpec OStatement, ?_⟩
   rintro ⟨stmt, oracles⟩ i transcript
-  have hi : i = ⟨0, by simp [pSpec]⟩ := by aesop
+  have hi : i = ⟨0, by simp⟩ := by aesop
   subst i
   have htr : transcript = fun j => Fin.elim0 j := by
     funext j
     exact Fin.elim0 j
   rw [htr]
-  simp [knowledgeStateFunction, rbrExtractor, pSpec]
+  dsimp [knowledgeStateFunction, rbrExtractor, pSpec]
+  simp only [exists_const]
   rcases Classical.em (oracles 0 = oracles 1) with hOracles | hOracles
   · simp [hOracles]
   · simp only [hOracles, not_false_eq_true, true_and]
@@ -346,9 +330,12 @@ theorem oracleVerifier_rbrKnowledgeSoundness [Nonempty (Query OStatement)]
       ext q
       simp
     rw [hfilter]
+    have hdenom : (Fintype.card (Query OStatement) : ℝ≥0) ≠ 0 := by
+      exact_mod_cast Fintype.card_ne_zero
+    rw [ENNReal.coe_div hdenom]
     apply ENNReal.div_le_div_right
-    have hcard := hDist (oracles 0) (oracles 1) hOracles
-    exact Nat.cast_le.mpr hcard
+    · have hcard := hDist (oracles 0) (oracles 1) hOracles
+      exact Nat.cast_le.mpr hcard
 
 end RandomQuery
 
@@ -358,9 +345,9 @@ end RandomQuery
 --   Random query where we throw away the second oracle, and replace with the response:
 --   - The input relation is `{ ⟨⟨_, 𝒪⟩, _⟩ | 𝒪 0 = 𝒪 1 }`.
 --   - The output relation is `{ ⟨⟨q, r⟩, 𝒪⟩, _⟩ | oracle (𝒪 0) q = r }`.
---   - The (oracle) verifier sends a single random query `q` to the prover, queries the oracle `𝒪 1` at
---     `q` to get response `r`, returns `(q, r)` as the output statement, and drop `𝒪 1` from the
---     output oracle statement.
+--   - The (oracle) verifier sends a single random query `q` to the prover, queries the oracle
+--     `𝒪 1` at `q` to get response `r`, returns `(q, r)` as the output statement, and drops
+--     `𝒪 1` from the output oracle statement.
 
 --   This is just the concatenation of `RandomQuery` and `ReduceClaim`.
 -- -/
@@ -379,8 +366,8 @@ end RandomQuery
 --   oracles 0 = oracles 1
 
 -- /--
--- The final relation states that the first oracle `oStmt ()` agrees with the response `r` at the query
--- `q`.
+-- The final relation states that the first oracle `oStmt ()` agrees with the response `r` at the
+-- query `q`.
 -- -/
 -- @[reducible, simp]
 -- def relOut : (StmtOut OStatement × ∀ i, OStmtOut OStatement i) → WitOut → Prop :=

--- a/ArkLib/ProofSystem/Component/ReduceClaim.lean
+++ b/ArkLib/ProofSystem/Component/ReduceClaim.lean
@@ -362,8 +362,11 @@ theorem oracleReduction_completeness --(h : init.neverFails)
         (mapStmt stmtIn, mapOStmt embedIdx hEq oStmtIn))) :
           StateT σ ProbComp _).run s) at hx
     rw [StateT.run_pure] at hx
-    simp [map_pure, support_pure] at hx
-    cases hx
+    have hx' : some x = some ((default,
+        ((mapStmt stmtIn, mapOStmt embedIdx hEq oStmtIn), mapWit stmtIn witIn)),
+        (mapStmt stmtIn, mapOStmt embedIdx hEq oStmtIn)) := by
+      simpa [map_pure, support_pure] using hx
+    cases hx'
     exact ⟨hRel stmtIn oStmtIn witIn hIn, rfl⟩
   -- -- TODO: clean up this proof
   -- simp only [OracleReduction.perfectCompleteness, oracleReduction, OracleReduction.toReduction,

--- a/ArkLib/ProofSystem/Component/SendWitness.lean
+++ b/ArkLib/ProofSystem/Component/SendWitness.lean
@@ -139,8 +139,10 @@ theorem reduction_completeness :
           (default : (pSpec Witness).Transcript 0), (stmtIn, witIn), ()),
         (stmtIn, witIn))) : StateT _ ProbComp _).run s) at hx
     rw [StateT.run_pure] at hx
-    simp [map_pure, support_pure] at hx
-    cases hx
+    have hx' : some x = some ((ProtocolSpec.Transcript.concat (m := 0) witIn
+        (default : (pSpec Witness).Transcript 0), (stmtIn, witIn), ()), (stmtIn, witIn)) := by
+      exact Set.mem_singleton_iff.mp hx
+    cases hx'
     exact ⟨hIn, rfl⟩
 
 /-- **Coordinate-wise special soundness of `SendWitness`, named form.** The verifier has no
@@ -178,9 +180,11 @@ end Reduction
   verifier and reduction below are left commented out). Finishing it *as sketched* is blocked by the
   current `OracleVerifier` interface: the prover sends the whole family as a **single** product
   message `∀ i, Witness i` (`oraclePSpec` has one round), yet the intended output oracle statements
-  `OStatement ⊕ᵥ Witness` and the commented `embed` (via `FinEnum.equiv`) expect **per-index**
+  `OStatement ⊕ᵥ Witness` and the commented `embed` (via `FinEnum.equiv`) expect
+  **per-index**
   oracles. Under `embed`/`hEq` an output oracle can only *select* an existing source oracle, not
-  decompose a product; this is exactly the `simulateOutputQuery` refactor noted in `OracleReduction/Basic`.
+  decompose a product; this is exactly the `simulateOutputQuery` refactor noted in
+  `OracleReduction/Basic`.
   Two coherent designs resolve it — (a) keep the single product message and output it as one product
   oracle (which is `SendSingleWitness` at `Witness := ∀ i, Witness i`), or (b) rewrite `oraclePSpec`
   as a `FinEnum.card ιw`-round protocol so each witness is its own message (per-index oracles then

--- a/ArkLib/ProofSystem/RingSwitching/Packing/BatchingPhase.lean
+++ b/ArkLib/ProofSystem/RingSwitching/Packing/BatchingPhase.lean
@@ -273,7 +273,6 @@ def batchingKStateProp {m : Fin (2 + 1)}
     let i_msg2 : ((pSpecBatching (κ:=κ) (L:=L) (K:=K) (P:=P)).take 2 (by omega)).ChallengeIdx :=
       ⟨⟨1, Nat.lt_of_succ_le (by omega)⟩, by simp [pSpecBatching]; rfl⟩
     let batching_challenges: Fin κ → L := chalsUpTo i_msg2
-
     let ctx : RingSwitchingBaseContext κ L K ℓ P := {
       t_eval_point := stmt.t_eval_point,
       original_claim := stmt.original_claim,
@@ -311,7 +310,7 @@ noncomputable def batchingKnowledgeStateFunction :
     | ⟨0, _⟩ => by -- from accumulative KState
       intro hSuccTrue
       simp only [batchingKStateProp, Fin.zero_eta, Fin.isValue, Fin.succ_zero_eq_one,
-        Equiv.toFun_as_coe, Transcript.equivMessagesChallenges_apply, Fin.castSucc_zero,
+        Transcript.equivMessagesChallenges_apply, Fin.castSucc_zero,
         batchingRbrExtractor, Fin.mk_one, Fin.succ_one_eq_two,
         batchingInputRelationProp] at ⊢ hSuccTrue
       rw [hSuccTrue.1]
@@ -324,6 +323,7 @@ noncomputable def batchingKnowledgeStateFunction :
 
 /-! ## Security Properties -/
 
+omit [Fintype L] [Fintype K] [DecidableEq K] in
 /-- Perfect completeness for the batching phase oracle reduction. -/
 theorem batchingReduction_perfectCompleteness :
   OracleReduction.perfectCompleteness
@@ -331,19 +331,23 @@ theorem batchingReduction_perfectCompleteness :
     (relIn := batchingInputRelation κ L K P ℓ ℓ' h_l aOStmtIn)
     (relOut := sumcheckRoundRelation κ L K P ℓ ℓ' h_l aOStmtIn 0)
     (init := init) (impl := impl) := by
+  classical
   -- The honest prover's computations are deterministic. If the input relation holds,
   -- the prover correctly computes ŝ, h, and s₀, so the output relation will also hold.
   unfold OracleReduction.perfectCompleteness
   sorry
 
+omit [Fintype K] [DecidableEq K] in
 /-- RBR knowledge soundness for the batching phase oracle verifier. -/
-theorem batchingOracleVerifier_rbrKnowledgeSoundness [IsDomain L] :
+theorem batchingOracleVerifier_rbrKnowledgeSoundness [NoZeroDivisors L] :
   OracleVerifier.rbrKnowledgeSoundness
     (verifier := oracleVerifier κ L K P ℓ ℓ' h_l (aOStmtIn:=aOStmtIn))
     (init := init) (impl := impl)
     (relIn := batchingInputRelation κ L K P ℓ ℓ' h_l aOStmtIn)
     (relOut := sumcheckRoundRelation κ L K P ℓ ℓ' h_l aOStmtIn 0)
     (rbrKnowledgeError := batchingRBRKnowledgeError (κ:=κ) (L:=L) (K:=K) (P:=P)) := by
+  let _ : IsDomain L := NoZeroDivisors.to_isDomain L
+  classical
   -- Proof follows by constructing the extractor and knowledge state function.
   use batchingWitMid L K ℓ ℓ'
   use batchingRbrExtractor κ L K P ℓ ℓ' h_l (aOStmtIn:=aOStmtIn)

--- a/ArkLib/ProofSystem/RingSwitching/Packing/General.lean
+++ b/ArkLib/ProofSystem/RingSwitching/Packing/General.lean
@@ -168,13 +168,14 @@ def fullRbrKnowledgeError (i : (fullPspec κ L K P ℓ' mlIOPCS).ChallengeIdx) :
 
 omit [Fintype K] [DecidableEq K] in
 /-- Round-by-round knowledge soundness for the full ring-switching oracle verifier -/
-theorem fullOracleVerifier_rbrKnowledgeSoundness [Finite K] [IsDomain L] :
+theorem fullOracleVerifier_rbrKnowledgeSoundness [Finite K] [NoZeroDivisors L] :
     OracleProof.rbrKnowledgeSoundness
       (verifier := fullOracleVerifier κ L K P ℓ ℓ' (h_l := h_l) mlIOPCS)
       (init := init)
       (impl := impl)
       (relIn := fullInputRelation κ L K P ℓ ℓ' h_l mlIOPCS)
       (rbrKnowledgeError := fun i => fullRbrKnowledgeError κ L K P ℓ' mlIOPCS i) := by
+  let _ : IsDomain L := NoZeroDivisors.to_isDomain L
   let _ := Fintype.ofFinite K
   classical
   unfold fullOracleVerifier fullRbrKnowledgeError

--- a/ArkLib/ProofSystem/RingSwitching/Packing/Prelude.lean
+++ b/ArkLib/ProofSystem/RingSwitching/Packing/Prelude.lean
@@ -143,10 +143,8 @@ def packMLE (β : Basis (Fin κ → Fin 2) K L) (t : MultilinearPoly K ℓ) :
           w ⟨i.val - κ, by omega⟩
       -- Evaluate the small-field polynomial `t` at this point.
       MvPolynomial.eval (fun i => ↑(concatenated_point i)) t.val
-
     -- b. Use `equivFun.symm` = ∑ v, (coeffs_for_w v) • (β v).
     β.equivFun.symm coeffs_for_w
-
   -- 2. The packed polynomial `t'` is the multilinear extension of this function.
   ⟨MvPolynomial.MLE packing_func, MLE_mem_restrictDegree packing_func⟩
 
@@ -166,17 +164,14 @@ def unpackMLE (β : Basis (Fin κ → Fin 2) K L) (t' : MultilinearPoly L ℓ') 
     -- a. Deconstruct the evaluation point `p` into `v` (first κ bits) and `w` (last ℓ' bits).
     let v (i : Fin κ) : Fin 2 := p ⟨i.val, by omega⟩
     let w (i : Fin ℓ') : Fin 2 := p ⟨i.val + κ, by { rw [h_l]; omega }⟩
-
     -- b. Evaluate the large-field polynomial `t'` at the point `w`.
     let t'_eval_at_w : L := MvPolynomial.eval (fun i => ↑(w i)) t'.val
-
     -- c. Get the K-coefficients of this L-element with respect to the basis `β`.
     -- `β.repr/β.equivFun` maps an element of L to its coordinate function `(Fin κ → Fin 2) → K`.
     let coeffs : (Fin κ → Fin 2) → K := β.repr t'_eval_at_w
     -- d. The desired evaluation t(p) = t(v,w)
       -- is the coefficient corresponding to the basis vector `β_v`.
     coeffs v
-
   -- 2. The unpacked polynomial `t` is the multilinear extension of this evaluation function.
   ⟨MvPolynomial.MLE unpacked_evals, MLE_mem_restrictDegree unpacked_evals⟩
 
@@ -487,7 +482,7 @@ existing `rfl`/instance-driven Binius proofs (and the byte-identical `#print axi
     refine Finset.sum_congr rfl fun u _ => ?_
     unfold decompose_tensor_algebra_rows
     rw [Basis.baseChange_apply, smul_tmul']
-    show _ = (φ₀ L K) _ * (φ₁ L K) _
+    change _ = (φ₀ L K) _ * (φ₁ L K) _
     unfold φ₀ φ₁
     simp [Algebra.TensorProduct.tmul_mul_tmul]
   decomposeColumns_spec := fun z => by
@@ -497,7 +492,7 @@ existing `rfl`/instance-driven Binius proofs (and the byte-identical `#print axi
     refine Finset.sum_congr rfl fun v _ => ?_
     unfold decompose_tensor_algebra_columns
     rw [Basis.baseChangeRight_apply, Algebra.smul_def]
-    show algebraMap L (L ⊗[K] L) _ * _ = (φ₁ L K) _ * (φ₀ L K) _
+    change algebraMap L (L ⊗[K] L) _ * _ = (φ₁ L K) _ * (φ₀ L K) _
     rw [show (algebraMap L (L ⊗[K] L)) =
       (Algebra.TensorProduct.includeRight).toRingHom.comp (algebraMap L L) by rfl]
     unfold φ₀ φ₁

--- a/ArkLib/ProofSystem/RingSwitching/Packing/SumcheckPhase.lean
+++ b/ArkLib/ProofSystem/RingSwitching/Packing/SumcheckPhase.lean
@@ -282,11 +282,12 @@ local instance : DecidableEq K := Classical.decEq K
 
 omit [Fintype K] [DecidableEq K] in
 /-- RBR knowledge soundness for a single round oracle verifier -/
-theorem iteratedSumcheckOracleVerifier_rbrKnowledgeSoundness [IsDomain L] (i : Fin ℓ') :
+theorem iteratedSumcheckOracleVerifier_rbrKnowledgeSoundness [NoZeroDivisors L] (i : Fin ℓ') :
     (iteratedSumcheckOracleVerifier κ L K P ℓ ℓ' aOStmtIn i).rbrKnowledgeSoundness init impl
       (relIn := sumcheckRoundRelation κ L K P ℓ ℓ' h_l aOStmtIn i.castSucc)
       (relOut := sumcheckRoundRelation κ L K P ℓ ℓ' h_l aOStmtIn i.succ)
       (fun j => roundKnowledgeError L ℓ' i) := by
+  let _ : IsDomain L := NoZeroDivisors.to_isDomain L
   classical
   use fun _ => SumcheckWitness L ℓ' i.castSucc
   use iteratedSumcheckRbrExtractor κ L K P ℓ ℓ' h_l aOStmtIn i
@@ -472,12 +473,13 @@ local instance : DecidableEq K := Classical.decEq K
 
 omit [Fintype K] [DecidableEq K] in
 /-- Round-by-round knowledge soundness for the final sumcheck step -/
-theorem finalSumcheckOracleVerifier_rbrKnowledgeSoundness [IsDomain L] {σ : Type}
+theorem finalSumcheckOracleVerifier_rbrKnowledgeSoundness [NoZeroDivisors L] {σ : Type}
     (init : ProbComp σ) (impl : QueryImpl []ₒ (StateT σ ProbComp)) :
     (finalSumcheckVerifier κ L K P ℓ ℓ' h_l aOStmtIn).rbrKnowledgeSoundness init impl
       (relIn := sumcheckRoundRelation κ L K P ℓ ℓ' h_l aOStmtIn (Fin.last ℓ'))
       (relOut := aOStmtIn.toRelInput)
       (rbrKnowledgeError := fun _ => finalSumcheckRbrKnowledgeError (L := L)) := by
+  let _ : IsDomain L := NoZeroDivisors.to_isDomain L
   classical
   use (fun _ => SumcheckWitness L ℓ' (Fin.last ℓ'))
   use finalSumcheckRbrExtractor κ L K P ℓ ℓ' h_l aOStmtIn
@@ -600,7 +602,7 @@ local instance : DecidableEq K := Classical.decEq K
 
 omit [Fintype K] [DecidableEq K] in
 /-- RBR knowledge soundness for large-field reduction (Sumcheck ++ FinalSum) -/
-theorem coreInteraction_rbrKnowledgeSoundness [IsDomain L] :
+theorem coreInteraction_rbrKnowledgeSoundness [NoZeroDivisors L] :
   OracleVerifier.rbrKnowledgeSoundness
     (verifier := coreInteractionOracleVerifier κ L K P ℓ ℓ' h_l aOStmtIn)
     (StmtIn := Statement (L := L) (ℓ := ℓ') (RingSwitchingBaseContext κ L K ℓ P) 0)
@@ -614,6 +616,7 @@ theorem coreInteraction_rbrKnowledgeSoundness [IsDomain L] :
     (relIn := sumcheckRoundRelation κ L K P ℓ ℓ' h_l aOStmtIn 0)
     (relOut := aOStmtIn.toRelInput)
     (rbrKnowledgeError := coreInteractionRbrKnowledgeError (L:=L) (ℓ':=ℓ')) := by
+  let _ : IsDomain L := NoZeroDivisors.to_isDomain L
   classical
   sorry
 


### PR DESCRIPTION
## Summary

Removes the next five coherent non-Data linter hotspots without suppressing diagnostics:

- sequential composition: replace flexible simplification with stable exact rewrite sets
- cast/equivalence infrastructure: prove cast injectivity directly and remove irrelevant section capture
- BinaryBasefold: clean structural/style warnings and remove a duplicate `Fintype L` theorem parameter
- reusable proof-system components: replace mutation-prone simplification with explicit equalities, remove redundant decidability assumptions, and delete the `RandomQuery` `unusedSimpArgs` suppression
- ring-switching Packing: remove style and unused-argument warnings, weaken unnecessary finiteness/decidability capture, and state soundness against `NoZeroDivisors` while deriving `IsDomain` internally

## Result

The selected modules go from 124 actionable linter warnings to 0:

| Batch | Before | After |
| --- | ---: | ---: |
| Sequential composition | 21 | 0 |
| Cast/equivalence | 37 | 0 |
| BinaryBasefold | 21 | 0 |
| Components | 27 | 0 |
| Packing | 18 | 0 |
| **Total** | **124** | **0** |

Existing `sorry` warnings remain visible and unchanged. No linter directive is added; touched files contain no `set_option linter.*` directive.

## Trust and API review

- source trust inventory: admissions 184 -> 184; examples 135 -> 135; explicit axioms 0 -> 0; native trust 0 -> 0
- axiom sweep: no new axiom/sorry taint
- theorem statements are unchanged except for removing redundant inferred assumptions or replacing the redundant `IsDomain L` + outer `Nontrivial L` pair with outer `Nontrivial L` + `NoZeroDivisors L` (equivalent for the commutative-ring setting)
- no security or trust gate is weakened

## Validation

- `lake build ArkLib`
- `./scripts/validate.sh`
- `./scripts/validate.sh --axioms`
- `./scripts/check-imports.sh`
- `python3 scripts/source-trust-audit.py --base-ref origin/main`
- focused rebuild of all 19 touched modules, with no target warnings other than pre-existing `sorry` declarations
