### PR TITLE
perf: reduce proof-checking hotspots

### DIFF
--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
@@ -500,7 +500,7 @@ noncomputable def constraintMap (k n m : ℕ) (ωs : Fin n ↪ F) (f : Fin n →
   map_add' c d := by simp +zetaDelta at *; rfl
   map_smul' a c := by unfold evalConstraint coeffsToPoly; aesop
 
-/-- There exists a non-zero polynomial satisfying the conditions. -/
+/-- A dimension surplus gives a nonzero coefficient vector in the constraint map's kernel. -/
 private lemma exists_nonzero_solution_of_numVars_gt (k n m : ℕ) (ωs : Fin n ↪ F)
     (f : Fin n → F) (D : ℕ) (hD : numVars k D > numConstraints n m) :
     ∃ c : (weightBoundIndices k D) → F, c ≠ 0 ∧ constraintMap k n m ωs f D c = 0 := by

--- a/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
+++ b/ArkLib/Data/CodingTheory/GuruswamiSudan/Basic.lean
@@ -501,44 +501,36 @@ noncomputable def constraintMap (k n m : ℕ) (ωs : Fin n ↪ F) (f : Fin n →
   map_smul' a c := by unfold evalConstraint coeffsToPoly; aesop
 
 /-- There exists a non-zero polynomial satisfying the conditions. -/
+private lemma exists_nonzero_solution_of_numVars_gt (k n m : ℕ) (ωs : Fin n ↪ F)
+    (f : Fin n → F) (D : ℕ) (hD : numVars k D > numConstraints n m) :
+    ∃ c : (weightBoundIndices k D) → F, c ≠ 0 ∧ constraintMap k n m ωs f D c = 0 := by
+  have h_kernel_nontrivial : Module.finrank F ((weightBoundIndices k D) → F) >
+      Module.finrank F ((Fin n → constraintIndices m → F)) := by
+    convert hD using 1
+    · simp [numVars]
+    · simp [numConstraints]
+      norm_num [Module.finrank]
+  have h_inj : ¬ Function.Injective (constraintMap k n m ωs f D) := by
+    intro h_inj
+    exact h_kernel_nontrivial.not_ge
+      (LinearMap.finrank_range_of_inj h_inj ▸ Submodule.finrank_le _)
+  contrapose! h_inj
+  exact LinearMap.ker_eq_bot.mp (eq_bot_iff.mpr fun x hx ↦
+    by_contra fun hx' ↦ h_inj x hx' <| by simpa using hx)
+
+/-- There exists a non-zero polynomial satisfying the conditions. -/
 lemma exists_nonzero_solution (k n m : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F) :
     ∃ c : (weightBoundIndices k (proximity_gap_degree_bound k n m)) → F,
-    c ≠ 0 ∧ constraintMap k n m ωs f (proximity_gap_degree_bound k n m) c = 0 := by
-      have h_kernel_nontrivial : Module.finrank F ((weightBoundIndices k
-        (proximity_gap_degree_bound k n m)) → F) >
-          Module.finrank F ((Fin n → constraintIndices m → F)) := by
-        convert numVars_gt_numConstraints k n m using 1
-        · simp [numVars]
-        · simp [numConstraints]
-          norm_num [Module.finrank]
-      have h_inj : ¬ Function.Injective
-          (constraintMap k n m ωs f (proximity_gap_degree_bound k n m)) := by
-        intro h_inj
-        exact h_kernel_nontrivial.not_ge
-          (LinearMap.finrank_range_of_inj h_inj ▸ Submodule.finrank_le _)
-      contrapose! h_inj
-      exact LinearMap.ker_eq_bot.mp (eq_bot_iff.mpr fun x hx ↦
-        by_contra fun hx' ↦ h_inj x hx' <| by simpa using hx)
+    c ≠ 0 ∧ constraintMap k n m ωs f (proximity_gap_degree_bound k n m) c = 0 :=
+  exists_nonzero_solution_of_numVars_gt k n m ωs f _ (numVars_gt_numConstraints k n m)
 
 /-- Generalized existence: non-zero kernel element for arbitrary degree bound D,
     given numVars k D > numConstraints n m. -/
 lemma exists_nonzero_solution_gen (k n m : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F) (D : ℕ)
     (hD : numVars k D > numConstraints n m) :
     ∃ c : (weightBoundIndices k D) → F,
-    c ≠ 0 ∧ constraintMap k n m ωs f D c = 0 := by
-      have h_kernel_nontrivial : Module.finrank F ((weightBoundIndices k D) → F) >
-          Module.finrank F ((Fin n → constraintIndices m → F)) := by
-        convert hD using 1
-        · simp [numVars]
-        · simp [numConstraints]
-          norm_num [Module.finrank]
-      have h_inj : ¬ Function.Injective (constraintMap k n m ωs f D) := by
-        intro h_inj
-        exact h_kernel_nontrivial.not_ge
-          (LinearMap.finrank_range_of_inj h_inj ▸ Submodule.finrank_le _)
-      contrapose! h_inj
-      exact LinearMap.ker_eq_bot.mp (eq_bot_iff.mpr fun x hx ↦
-        by_contra fun hx' ↦ h_inj x hx' <| by simpa using hx)
+    c ≠ 0 ∧ constraintMap k n m ωs f D c = 0 :=
+  exists_nonzero_solution_of_numVars_gt k n m ωs f D hD
 
 /-- The polynomial solution constructed from the non-zero kernel element. -/
 noncomputable def polySol (k n m : ℕ) (ωs : Fin n ↪ F) (f : Fin n → F) : F[X][Y] :=
@@ -765,7 +757,8 @@ lemma rootMultiplicity_le_of_coeff_ne_zero [DecidableEq F] {Q : F[X][Y]} {x y : 
           (natWeightedDegree g 1 1 + 1)) (List.range (natWeightedDegree g 1 1 + 1 )))
       rotate_left
       · exact p.1 + p.2
-      · rw [List.mem_filterMap]; aesop
+      · rw [List.mem_filterMap]
+        exact ⟨p, hp.1, by simp only [if_neg hp.2.2, hp.2.1]⟩
       · cases h : List.min? (List.filterMap (fun p ↦ if Bivariate.coeff g p.1 p.2 = 0
           then Option.none else Option.some (p.1 + p.2)) (List.product (List.range
             (natWeightedDegree g 1 1 + 1)) (List.range (natWeightedDegree g 1 1 + 1)))) <;> aesop

--- a/ArkLib/Data/CodingTheory/JohnsonBound/Basic.lean
+++ b/ArkLib/Data/CodingTheory/JohnsonBound/Basic.lean
@@ -186,7 +186,8 @@ lemma johnson_condition_weak_implies_strong
           sqrt_le_sqrt ineq3'
         have ineq5 :
             (1 - √(1 - ↑frac * ↑d_weak / ↑n)) ≤ (1 - √(1 - ↑frac * ↑d / ↑n)) := by linarith
-        simp_all
+        exact mul_le_mul_of_nonneg_left ineq5
+          (inv_nonneg.mpr (by exact_mod_cast h_frac_pos.le))
       have h_J_cond_weak' : ↑e / ↑n < 1 / (↑frac) * (1 - √(1 - frac * (d_weak / ↑n))) := by
         unfold frac
         unfold q

--- a/ArkLib/Data/CodingTheory/JohnsonBound/Family.lean
+++ b/ArkLib/Data/CodingTheory/JohnsonBound/Family.lean
@@ -336,7 +336,13 @@ lemma plotkin_card_le_ell {n : ℕ} {α : Type*} [Fintype α] [DecidableEq α]
       mul_nonneg (Nat.cast_nonneg _) (sq_nonneg _)
     have hD_eq : frac * JohnsonBound.d B / n = D := by rw [hD_def]; ring
     rw [hD_eq] at hjb
-    nlinarith [hjb, hsq]
+    calc
+      (B.card : ℚ) * (D - 1) ≤
+          (B.card : ℚ) * (1 - frac * (JohnsonBound.e B (fun _ => a) / n)) ^ 2 +
+            B.card * (D - 1) := le_add_of_nonneg_left hsq
+      _ = (B.card : ℚ) *
+          ((1 - frac * (JohnsonBound.e B (fun _ => a) / n)) ^ 2 - (1 - D)) := by ring
+      _ ≤ D := hjb
   -- Failed guard: `D > ℓ/(ℓ-1)`, i.e. `ℓ < D · (ℓ-1)`.
   have hDgt : (ℓ : ℚ) < D * ((ℓ : ℚ) - 1) := by
     have hmd : ((mDist : ℚ) / n) ≤ JohnsonBound.d B / n := by gcongr
@@ -348,8 +354,19 @@ lemma plotkin_card_le_ell {n : ℕ} {α : Type*} [Fintype α] [DecidableEq α]
           mul_lt_mul_of_pos_right h1 hℓQ_pos
       _ = D * ((ℓ : ℚ) - 1) := by rw [hD_def]; field_simp
   -- `D > 1`, then `|B| ≤ D/(D-1) < ℓ`.
-  have hD1 : (1 : ℚ) < D := by nlinarith [hDgt, hℓQ]
-  have hfinal : (B.card : ℚ) < (ℓ : ℚ) := by nlinarith [hmain, hDgt, hD1]
+  have hD1 : (1 : ℚ) < D := by
+    by_contra hD1
+    have hprod_le : D * ((ℓ : ℚ) - 1) ≤ 1 * (ℓ - 1) :=
+      mul_le_mul_of_nonneg_right (le_of_not_gt hD1) (by linarith : (0 : ℚ) ≤ ℓ - 1)
+    exact (not_lt_of_ge (hprod_le.trans (by linarith : (1 : ℚ) * (ℓ - 1) ≤ ℓ))) hDgt
+  have hD_lt : D < (ℓ : ℚ) * (D - 1) := by
+    rw [← sub_pos]
+    convert sub_pos.mpr hDgt using 1
+    all_goals ring
+  have hfinal : (B.card : ℚ) < (ℓ : ℚ) := by
+    by_contra hcard
+    have hmul := mul_le_mul_of_nonneg_right (le_of_not_gt hcard) (sub_nonneg.mpr hD1.le)
+    exact (not_lt_of_ge (hmul.trans hmain)) hD_lt
   exact_mod_cast hfinal.le
 
 /-- The Johnson list-size bound in the regime where the `Jqℓ` radicand is nonnegative, so

--- a/ArkLib/Data/CodingTheory/JohnsonBound/Lemmas.lean
+++ b/ArkLib/Data/CodingTheory/JohnsonBound/Lemmas.lean
@@ -35,14 +35,22 @@ private abbrev K (B : Finset (Fin n → F)) (i : Fin n) (α : F) : ℕ :=
   (Fi B i α).card
 
 /-- The sets `Fi B i α` partition `B` as `α` ranges over `F`. -/
-lemma Fis_cover_B : B = univ.biUnion (Fi B i) := by aesop (add simp [Fi])
+lemma Fis_cover_B : B = univ.biUnion (Fi B i) := by
+  ext x
+  simp only [Finset.mem_biUnion, Finset.mem_univ, true_and, Fi, Finset.mem_filter]
+  constructor
+  · exact fun hx ↦ ⟨x i, hx, rfl⟩
+  · exact fun ⟨_, hx, _⟩ ↦ hx
 
 /-- The sets `Fi B i α` are pairwise disjoint. -/
 @[simp]
 lemma Fis_pairwise_disjoint : Set.PairwiseDisjoint Set.univ (Fi B i) := by
-  unfold Fi
-  rintro x - y - h₁ _ h₂ h₃ _ contra
-  specialize h₂ contra; specialize h₃ contra; aesop
+  intro a _ b _ hab
+  change Disjoint (Fi B i a) (Fi B i b)
+  rw [Finset.disjoint_left]
+  intro x hxa hxb
+  simp only [Fi, Finset.mem_filter, Finset.mem_univ, true_and] at hxa hxb
+  exact hab (hxa.2.symm.trans hxb.2)
 
 /-- The cardinalities `K B i α` sum to `|B|`. -/
 @[simp]
@@ -551,6 +559,14 @@ lemma johnson_worst_case_bound {n : ℕ} {F : Type*} [DecidableEq F]
       (JohnsonBound.d B / n - 2 * JohnsonBound.e B v / n +
       frac * (JohnsonBound.e B v / n) ^ 2) ≤
     (d / n) / (d / n - 2 * e / n + frac * (e / n) ^ 2) := by
+  have h_e_le_d : (e : ℚ) ≤ d := by
+    exact_mod_cast (by
+      nlinarith [h, show (d : ℝ) ≤ n by norm_cast, sqrt_nonneg (n * (n - d)),
+        mul_self_sqrt (show 0 ≤ (n : ℝ) * (n - d) by
+          nlinarith [show (d : ℝ) ≤ n by norm_cast])] : (e : ℝ) ≤ d)
+  have h_e_div_le_d_div : (e / n : ℚ) ≤ d / n := by gcongr
+  have h_frac_e_div_le_one : frac * (e / n : ℚ) ≤ 1 :=
+    (mul_le_mul_of_nonneg_left h_e_div_le_d_div (by positivity)).trans h_d_close_n
   have h_frac_ineq : (JohnsonBound.d B / n : ℚ) * (d / n - 2 * (e / n) +
       frac * (e / n) ^ 2) ≤ (d / n) * (JohnsonBound.d B / n - 2 *
         (JohnsonBound.e B v / n) + frac * (JohnsonBound.e B v / n) ^ 2) := by
@@ -560,31 +576,13 @@ lemma johnson_worst_case_bound {n : ℕ} {F : Type*} [DecidableEq F]
           (2 - frac * (e / n + JohnsonBound.e B v / n)) ≥ 0 := by
       refine ⟨mul_nonneg ?_ ?_, mul_nonneg ?_ ?_⟩
       · exact sub_nonneg_of_le (by gcongr)
-      · have h_frac_le_one : frac * (e / n : ℚ) ≤ 1 := by
-          have h_e_le_d : (e / n : ℚ) ≤ (d / n : ℚ) := by
-            have h_e_le_d : (e : ℝ) ≤ n - √(n * (n - d)) := by grind
-            have h_e_le_d : (e : ℚ) ≤ d := by
-              exact_mod_cast (by nlinarith [
-                show (d : ℝ) ≤ n by norm_cast, sqrt_nonneg (n * (n - d)), mul_self_sqrt (
-                  show 0 ≤ (n : ℝ) * (n - d) by
-                  nlinarith [show (d : ℝ) ≤ n by norm_cast])] : (e : ℝ) ≤ d)
-            gcongr
-          exact le_trans (mul_le_mul_of_nonneg_left h_e_le_d (by positivity)) h_d_close_n
+      ·
         nlinarith [show 0 ≤ (e : ℚ) / n by positivity]
       · exact sub_nonneg_of_le (by gcongr)
-      · have h_frac_e_n_le_1 : frac * (e / n : ℚ) ≤ 1 := by
-          refine le_trans (mul_le_mul_of_nonneg_left (show (e : ℚ) / n ≤ d / n from ?_)
-            (by positivity)) h_d_close_n
-          have h_e_le_d : (e : ℚ) ≤ d := by
-            exact_mod_cast (by nlinarith [
-              show (d : ℝ) ≤ n by norm_cast, sqrt_nonneg (n * (n - d)), mul_self_sqrt (
-                show 0 ≤ (n : ℝ) * (n - d) by
-                nlinarith [show (d : ℝ) ≤ n by norm_cast])] : (e : ℝ) ≤ d)
-          gcongr
-        have h_frac_e_B_v_n_le_1 : frac * (JohnsonBound.e B v / n : ℚ) ≤ 1 :=
+      · have h_frac_e_B_v_n_le_1 : frac * (JohnsonBound.e B v / n : ℚ) ≤ 1 :=
           le_trans (mul_le_mul_of_nonneg_left
             (div_le_div_of_nonneg_right (show (JohnsonBound.e B v : ℚ) ≤ e by
-              exact_mod_cast e_ineq) (Nat.cast_nonneg _)) (by positivity)) h_frac_e_n_le_1
+              exact_mod_cast e_ineq) (Nat.cast_nonneg _)) (by positivity)) h_frac_e_div_le_one
         linarith
     nlinarith [show (0 : ℚ) < n from hn_pos,
       mul_div_cancel₀ (e : ℚ) (by positivity : (n : ℚ) ≠ 0),

--- a/ArkLib/Data/CodingTheory/JohnsonBound/Lemmas.lean
+++ b/ArkLib/Data/CodingTheory/JohnsonBound/Lemmas.lean
@@ -576,8 +576,7 @@ lemma johnson_worst_case_bound {n : ℕ} {F : Type*} [DecidableEq F]
           (2 - frac * (e / n + JohnsonBound.e B v / n)) ≥ 0 := by
       refine ⟨mul_nonneg ?_ ?_, mul_nonneg ?_ ?_⟩
       · exact sub_nonneg_of_le (by gcongr)
-      ·
-        nlinarith [show 0 ≤ (e : ℚ) / n by positivity]
+      · nlinarith [show 0 ≤ (e : ℚ) / n by positivity]
       · exact sub_nonneg_of_le (by gcongr)
       · have h_frac_e_B_v_n_le_1 : frac * (JohnsonBound.e B v / n : ℚ) ≤ 1 :=
           le_trans (mul_le_mul_of_nonneg_left

--- a/ArkLib/Data/CodingTheory/ListDecodability/Bounds/KKH26.lean
+++ b/ArkLib/Data/CodingTheory/ListDecodability/Bounds/KKH26.lean
@@ -330,6 +330,10 @@ theorem usefulFamily_list_lower_bound (domain : ι ↪ F) [Finite F] {d h khat c
     set P : F[X] := (∏ α ∈ S, (X - C α)) - ∏ α ∈ T, (X - C α) with hP
     have hPne : P ≠ 0 := sub_ne_zero.mpr hprod_ne
     -- ... their difference has degree `< k̂` (both are monic of degree `k̂`), ...
+    have hmonicS : (∏ α ∈ S, (X - C α)).Monic :=
+      Polynomial.monic_prod_of_monic _ _ fun α _ ↦ Polynomial.monic_X_sub_C α
+    have hmonicT : (∏ α ∈ T, (X - C α)).Monic :=
+      Polynomial.monic_prod_of_monic _ _ fun α _ ↦ Polynomial.monic_X_sub_C α
     have hdegS : (∏ α ∈ S, (X - C α)).degree = (khat : WithBot ℕ) := by
       rw [Polynomial.degree_prod]
       simp [Polynomial.degree_X_sub_C, hScard]
@@ -339,11 +343,8 @@ theorem usefulFamily_list_lower_bound (domain : ι ↪ F) [Finite F] {d h khat c
     have hPdeg : P.natDegree < khat := by
       rw [Polynomial.natDegree_lt_iff_degree_lt hPne]
       refine lt_of_lt_of_eq (Polynomial.degree_sub_lt_left (hdegS.trans hdegT.symm) ?_ ?_) hdegS
-      · exact (Polynomial.monic_prod_of_monic _ _
-          fun α _ => Polynomial.monic_X_sub_C α).ne_zero
-      · rw [(Polynomial.monic_prod_of_monic _ _ fun α _ =>
-              Polynomial.monic_X_sub_C α).leadingCoeff,
-          (Polynomial.monic_prod_of_monic _ _ fun α _ => Polynomial.monic_X_sub_C α).leadingCoeff]
+      · exact hmonicS.ne_zero
+      · rw [hmonicS.leadingCoeff, hmonicT.leadingCoeff]
     -- ... yet `P(x^d)` vanishes on all `n` domain points: contradiction with `k̂ ≤ h`.
     have hQzero : ∀ i, (P.comp (X ^ d)).eval (domain i) = 0 := by
       intro i

--- a/ArkLib/Data/CodingTheory/ListDecodability/Bounds/LargeAlphabet/Basic.lean
+++ b/ArkLib/Data/CodingTheory/ListDecodability/Bounds/LargeAlphabet/Basic.lean
@@ -268,7 +268,7 @@ theorem balanced_center_arithmetic
     have hprod : p ^ ℓ * (n : ℝ) ≤ 0 :=
       mul_nonpos_of_nonneg_of_nonpos (pow_nonneg hp.le ℓ) hnle
     have hleft : (0 : ℝ) < 8 * ℓ := by positivity
-    nlinarith
+    exact (not_le_of_gt hleft) (hsize.trans hprod)
   have hboost : p ≤ boostedRadius ℓ p := by
     unfold boostedRadius
     have hpow : 0 ≤ p ^ ℓ := by positivity
@@ -279,32 +279,31 @@ theorem balanced_center_arithmetic
     mul_le_mul_of_nonneg_right hboost hnR.le
   have hrle : Nat.floor (p * n) ≤
       Nat.floor (boostedRadius ℓ p * n) := Nat.floor_mono hmul
+  let r := Nat.floor (p * n)
+  let r' := Nat.floor (boostedRadius ℓ p * n)
+  let t := r' - r
+  have htcast : (t : ℝ) = (r' : ℝ) - r := Nat.cast_sub hrle
+  have hr'le : (r' : ℝ) ≤ boostedRadius ℓ p * n :=
+    Nat.floor_le (mul_nonneg hboostPos.le hnR.le)
+  have hr'le' : (r' : ℝ) ≤ p * n + p ^ ℓ * n / (2 * ℓ) := by
+    calc
+      (r' : ℝ) ≤ boostedRadius ℓ p * n := hr'le
+      _ = p * n + p ^ ℓ * n / (2 * ℓ) := by
+        unfold boostedRadius
+        ring
+  have hrlt : p * n < (r : ℝ) + 1 := Nat.lt_floor_add_one _
+  have ht : (t : ℝ) ≤ p ^ ℓ * n / (2 * ℓ) + 1 := by
+    rw [htcast]
+    linarith only [hr'le', hrlt]
+  have hmul_t : (ℓ : ℝ) * t ≤ p ^ ℓ * n / 2 + ℓ := by
+    calc
+      (ℓ : ℝ) * t ≤ (ℓ : ℝ) * (p ^ ℓ * n / (2 * ℓ) + 1) :=
+        mul_le_mul_of_nonneg_left ht hℓR.le
+      _ = p ^ ℓ * n / 2 + ℓ := by field_simp [ne_of_gt hℓR]
   refine ⟨hrle, ?_, ?_, ?_⟩
   · omega
-  · let r := Nat.floor (p * n)
-    let r' := Nat.floor (boostedRadius ℓ p * n)
-    let t := r' - r
-    have htcast : (t : ℝ) = (r' : ℝ) - r := Nat.cast_sub hrle
-    have hr'le : (r' : ℝ) ≤ boostedRadius ℓ p * n :=
-      Nat.floor_le (mul_nonneg hboostPos.le hnR.le)
-    have hr'le' : (r' : ℝ) ≤ p * n + p ^ ℓ * n / (2 * ℓ) := by
-      calc
-        (r' : ℝ) ≤ boostedRadius ℓ p * n := hr'le
-        _ = p * n + p ^ ℓ * n / (2 * ℓ) := by
-          unfold boostedRadius
-          ring
-    have hrlt : p * n < (r : ℝ) + 1 := Nat.lt_floor_add_one _
-    have ht : (t : ℝ) ≤ p ^ ℓ * n / (2 * ℓ) + 1 := by
-      rw [htcast]
-      linarith
-    have hmul_t : (ℓ : ℝ) * t ≤ p ^ ℓ * n / 2 + ℓ := by
-      have h := mul_le_mul_of_nonneg_left ht hℓR.le
-      calc
-        (ℓ : ℝ) * t ≤ (ℓ : ℝ) * (p ^ ℓ * n / (2 * ℓ) + 1) := h
-        _ = p ^ ℓ * n / 2 + ℓ := by
-          field_simp [ne_of_gt hℓR]
-    have hfive : (ℓ : ℝ) * t ≤ 5 * (p ^ ℓ * n) / 8 := by
-      nlinarith
+  · have hfive : (ℓ : ℝ) * t ≤ 5 * (p ^ ℓ * n) / 8 := by
+      nlinarith only [hmul_t, hsize]
     have hpPowLt : p ^ ℓ < p :=
       pow_lt_self_of_lt_one₀ hp hp_lt (by omega)
     have hP_lt : p ^ ℓ * n < p * n :=
@@ -312,34 +311,13 @@ theorem balanced_center_arithmetic
     have hlt : (ℓ : ℝ) * t < (r : ℝ) + 1 := by
       have hfive_lt : 5 * (p ^ ℓ * n) / 8 < p * n := by
         have hPnonneg : 0 ≤ p ^ ℓ * n := by positivity
-        nlinarith
-      nlinarith
+        exact lt_of_le_of_lt (by nlinarith only [hPnonneg]) hP_lt
+      exact hfive.trans_lt (hfive_lt.trans hrlt)
     have hnat : ℓ * t < r + 1 := by exact_mod_cast hlt
     simpa only [r, r', t] using (Nat.lt_succ_iff.mp hnat)
-  · let r := Nat.floor (p * n)
-    let r' := Nat.floor (boostedRadius ℓ p * n)
-    let t := r' - r
-    have htcast : (t : ℝ) = (r' : ℝ) - r := Nat.cast_sub hrle
-    have hr'le : (r' : ℝ) ≤ boostedRadius ℓ p * n :=
-      Nat.floor_le (mul_nonneg hboostPos.le hnR.le)
-    have hr'le' : (r' : ℝ) ≤ p * n + p ^ ℓ * n / (2 * ℓ) := by
-      calc
-        (r' : ℝ) ≤ boostedRadius ℓ p * n := hr'le
-        _ = p * n + p ^ ℓ * n / (2 * ℓ) := by
-          unfold boostedRadius
-          ring
-    have hrlt : p * n < (r : ℝ) + 1 := Nat.lt_floor_add_one _
-    have ht : (t : ℝ) ≤ p ^ ℓ * n / (2 * ℓ) + 1 := by
-      rw [htcast]
-      linarith
-    have hmul_t : (ℓ : ℝ) * t ≤ p ^ ℓ * n / 2 + ℓ := by
-      have h := mul_le_mul_of_nonneg_left ht hℓR.le
-      calc
-        (ℓ : ℝ) * t ≤ (ℓ : ℝ) * (p ^ ℓ * n / (2 * ℓ) + 1) := h
-        _ = p ^ ℓ * n / 2 + ℓ := by
-          field_simp [ne_of_gt hℓR]
+  ·
     have hthree : (ℓ : ℝ) * t ≤ 3 * (p ^ ℓ * n) / 4 := by
-      nlinarith
+      nlinarith only [hmul_t, hsize]
     have hceil : 3 * (p ^ ℓ * n) / 4 ≤
         (Nat.ceil ((3 * p ^ ℓ / 4) * n) : ℝ) := by
       calc

--- a/ArkLib/Data/CodingTheory/ListDecodability/Bounds/LargeAlphabet/Basic.lean
+++ b/ArkLib/Data/CodingTheory/ListDecodability/Bounds/LargeAlphabet/Basic.lean
@@ -315,8 +315,7 @@ theorem balanced_center_arithmetic
       exact hfive.trans_lt (hfive_lt.trans hrlt)
     have hnat : ℓ * t < r + 1 := by exact_mod_cast hlt
     simpa only [r, r', t] using (Nat.lt_succ_iff.mp hnat)
-  ·
-    have hthree : (ℓ : ℝ) * t ≤ 3 * (p ^ ℓ * n) / 4 := by
+  · have hthree : (ℓ : ℝ) * t ≤ 3 * (p ^ ℓ * n) / 4 := by
       nlinarith only [hmul_t, hsize]
     have hceil : 3 * (p ^ ℓ * n) / 4 ≤
         (Nat.ceil ((3 * p ^ ℓ / 4) * n) : ℝ) := by

--- a/ArkLib/Data/CodingTheory/ProximityGap/AHIV22.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/AHIV22.lean
@@ -31,6 +31,27 @@ local instance : Fintype F := Fintype.ofFinite F
 namespace ProximityToRS
 open ReedSolomon NNReal
 
+omit [Finite F] [DecidableEq F] in
+private lemma direction_eq_of_two_affine_values
+    {u v c₀ c₁ r₀ r₁ : F}
+    (h₀ : u + r₀ * v = c₀) (h₁ : u + r₁ * v = c₁) (hr : r₁ ≠ r₀) :
+    v = (r₁ - r₀)⁻¹ * (c₁ - c₀) := by
+  rw [← h₀, ← h₁]
+  field_simp [sub_ne_zero.mpr hr]
+  ring
+
+omit [Finite F] [DecidableEq F] in
+private lemma directions_eq_of_two_affine_values
+    {u v c w r s : F}
+    (hr : u + r * v = c + r * w) (hs : u + s * v = c + s * w) (hrs : r ≠ s) :
+    v = w := by
+  have hzero : (r - s) * (v - w) = 0 := by
+    calc
+      (r - s) * (v - w) =
+          (u + r * v - (c + r * w)) - (u + s * v - (c + s * w)) := by ring
+      _ = 0 := by rw [hr, hs]; ring
+  exact sub_eq_zero.mp ((mul_eq_zero.mp hzero).resolve_left (sub_ne_zero.mpr hrs))
+
 -- Distance-bound form, proved first; the mutual-exclusion corollary `e_le_dist_over_3` follows.
 /-- **Lemma 4.4, [AHIV22] (strong form).**
 
@@ -149,19 +170,10 @@ lemma e_le_dist_over_3_strong
     have hv_eq_w_of_notin (j : ι) (hj0 : j ∉ E r0) (hj1 : j ∉ E r1) : v j = w j := by
       have h1 : (u + r1.1 • v) j = c r1 j := hE_agree r1 j hj1
       have h0 : (u + r0.1 • v) j = c r0 j := hE_agree r0 j hj0
-      have hdiff :
-          (r1.1 - r0.1) * v j = c r1 j - c r0 j := by
-        have : (u + r1.1 • v) j - (u + r0.1 • v) j = c r1 j - c r0 j := by
-          simp [h1, h0]
-        have hdiff' : r1.1 * v j - r0.1 * v j = c r1 j - c r0 j := by
-          simpa [Pi.add_apply, Pi.smul_apply] using (by
-            simpa [Pi.add_apply, Pi.smul_apply] using this)
-        simpa [sub_mul] using hdiff'
-      calc
-        v j = (r1.1 - r0.1)⁻¹ * ((r1.1 - r0.1) * v j) := by
-          simp [hr10]
-        _   = (r1.1 - r0.1)⁻¹ * (c r1 j - c r0 j) := by simp [hdiff]
-        _   = w j := by simp [w, Pi.smul_apply, Pi.sub_apply]
+      simpa [w, Pi.smul_apply, Pi.sub_apply] using
+        direction_eq_of_two_affine_values
+          (by simpa [Pi.add_apply, Pi.smul_apply] using h0)
+          (by simpa [Pi.add_apply, Pi.smul_apply] using h1) (sub_ne_zero.mp hr10)
     -- Define the base codeword so that `c r = cBase + r•w`.
     let cBase : ι → F := c r0 - r0.1 • w
     have hcBase_mem : cBase ∈ CRS := by
@@ -209,19 +221,10 @@ lemma e_le_dist_over_3_strong
               have hv0r : v i = w0r i := by
                 have hr_eq : (u + r.1 • v) i = c r i := hE_agree r i hir
                 have h0_eq : (u + r0.1 • v) i = c r0 i := hE_agree r0 i hi0
-                have hdiff :
-                    (r.1 - r0.1) * v i = c r i - c r0 i := by
-                  have : (u + r.1 • v) i - (u + r0.1 • v) i = c r i - c r0 i := by
-                    simp [hr_eq, h0_eq]
-                  have hdiff' : r.1 * v i - r0.1 * v i = c r i - c r0 i := by
-                    simpa [Pi.add_apply, Pi.smul_apply] using (by
-                      simpa [Pi.add_apply, Pi.smul_apply] using this)
-                  simpa [sub_mul] using hdiff'
-                calc
-                  v i = (r.1 - r0.1)⁻¹ * ((r.1 - r0.1) * v i) := by
-                    simp [hneq]
-                  _   = (r.1 - r0.1)⁻¹ * (c r i - c r0 i) := by simp [hdiff]
-                  _   = w0r i := by simp [w0r, Pi.smul_apply, Pi.sub_apply]
+                simpa [w0r, Pi.smul_apply, Pi.sub_apply] using
+                  direction_eq_of_two_affine_values
+                    (by simpa [Pi.add_apply, Pi.smul_apply] using h0_eq)
+                    (by simpa [Pi.add_apply, Pi.smul_apply] using hr_eq) (sub_ne_zero.mp hneq)
               exact hi (hv0r.symm.trans hvw)
             have hcard_le : (E r0 ∪ E r1 ∪ E r).card ≤ 3 * e := by
               have h01 : (E r0 ∪ E r1).card ≤ (E r0).card + (E r1).card :=
@@ -293,29 +296,7 @@ lemma e_le_dist_over_3_strong
               simpa [Pi.add_apply, Pi.smul_apply] using hr_eq
             have hsj : u j + s.1 * v j = cBase j + s.1 * w j := by
               simpa [Pi.add_apply, Pi.smul_apply] using hs_eq
-            have hrj' : u j - cBase j = r.1 * (w j - v j) := by
-              have h1 := congrArg (fun t ↦ t - cBase j) hrj
-              have h1' : u j + r.1 * v j - cBase j = r.1 * w j := by
-                simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using h1
-              have h2 := congrArg (fun t ↦ t - r.1 * v j) h1'
-              have h2' : u j - cBase j = r.1 * w j - r.1 * v j := by
-                simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using h2
-              simpa [mul_sub] using h2'
-            have hsj' : u j - cBase j = s.1 * (w j - v j) := by
-              have h1 := congrArg (fun t ↦ t - cBase j) hsj
-              have h1' : u j + s.1 * v j - cBase j = s.1 * w j := by
-                simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using h1
-              have h2 := congrArg (fun t ↦ t - s.1 * v j) h1'
-              have h2' : u j - cBase j = s.1 * w j - s.1 * v j := by
-                simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using h2
-              simpa [mul_sub] using h2'
-            have hmul : r.1 * (w j - v j) = s.1 * (w j - v j) := Eq.trans hrj'.symm hsj'
-            have hzero : (r.1 - s.1) * (w j - v j) = 0 := by
-              have : r.1 * (w j - v j) - s.1 * (w j - v j) = 0 := sub_eq_zero.mpr hmul
-              simpa [sub_mul] using this
-            have hrs_ne : (r.1 - s.1) ≠ 0 := sub_ne_zero.mpr hrs_val
-            have : w j - v j = 0 := (mul_eq_zero.mp hzero).resolve_left hrs_ne
-            exact (sub_eq_zero.mp this).symm
+            exact directions_eq_of_two_affine_values hrj hsj hrs_val
           have hu0 : u j = cBase j := by
             have : u j + r.1 * v j = cBase j + r.1 * w j := by
               simpa [Pi.add_apply, Pi.smul_apply] using hr_eq
@@ -611,16 +592,10 @@ lemma dir_close_of_many_close_pts
   have hv_eq_w_of_notin (j : ι) (hj0 : j ∉ E r0) (hj1 : j ∉ E r1) : v j = w j := by
     have h1 : (u + r1.1 • v) j = c r1 j := hE_agree r1 j hj1
     have h0 : (u + r0.1 • v) j = c r0 j := hE_agree r0 j hj0
-    have hdiff : (r1.1 - r0.1) * v j = c r1 j - c r0 j := by
-      have hsub : (u + r1.1 • v) j - (u + r0.1 • v) j = c r1 j - c r0 j := by
-        simp [h1, h0]
-      have hdiff' : r1.1 * v j - r0.1 * v j = c r1 j - c r0 j := by
-        simpa [Pi.add_apply, Pi.smul_apply] using hsub
-      simpa [sub_mul] using hdiff'
-    calc
-      v j = (r1.1 - r0.1)⁻¹ * ((r1.1 - r0.1) * v j) := by simp [hr10]
-      _   = (r1.1 - r0.1)⁻¹ * (c r1 j - c r0 j) := by simp [hdiff]
-      _   = w j := by simp [w, Pi.smul_apply, Pi.sub_apply]
+    simpa [w, Pi.smul_apply, Pi.sub_apply] using
+      direction_eq_of_two_affine_values
+        (by simpa [Pi.add_apply, Pi.smul_apply] using h0)
+        (by simpa [Pi.add_apply, Pi.smul_apply] using h1) (sub_ne_zero.mp hr10)
   -- Define the base codeword so that `c r = cBase + r•w`.
   let cBase : ι → F := c r0 - r0.1 • w
   have hcBase_mem : cBase ∈ CRS := by
@@ -666,18 +641,10 @@ lemma dir_close_of_many_close_pts
             have hv0r : v i = w0r i := by
               have hr_eq : (u + r.1 • v) i = c r i := hE_agree r i hir
               have hr0_eq : (u + r0.1 • v) i = c r0 i := hE_agree r0 i hi0
-              have hdiff :
-                  (r.1 - r0.1) * v i = c r i - c r0 i := by
-                have : (u + r.1 • v) i - (u + r0.1 • v) i = c r i - c r0 i := by
-                  simp [hr_eq, hr0_eq]
-                have hdiff' : r.1 * v i - r0.1 * v i = c r i - c r0 i := by
-                  simpa [Pi.add_apply, Pi.smul_apply] using
-                    (by simpa [Pi.add_apply, Pi.smul_apply] using this)
-                simpa [sub_mul] using hdiff'
-              calc
-                v i = (r.1 - r0.1)⁻¹ * ((r.1 - r0.1) * v i) := by simp [hneq]
-                _ = (r.1 - r0.1)⁻¹ * (c r i - c r0 i) := by simp [hdiff]
-                _ = w0r i := by simp [w0r, Pi.smul_apply, Pi.sub_apply]
+              simpa [w0r, Pi.smul_apply, Pi.sub_apply] using
+                direction_eq_of_two_affine_values
+                  (by simpa [Pi.add_apply, Pi.smul_apply] using hr0_eq)
+                  (by simpa [Pi.add_apply, Pi.smul_apply] using hr_eq) (sub_ne_zero.mp hneq)
             exact hi (hv0r.symm.trans hvw)
           have hcard_le : (E r0 ∪ E r1 ∪ E r).card ≤ 3 * e := by
             have h01 :
@@ -745,33 +712,7 @@ lemma dir_close_of_many_close_pts
             simpa [Pi.add_apply, Pi.smul_apply] using hr_eq
           have hsj : u j + s.1 * v j = cBase j + s.1 * w j := by
             simpa [Pi.add_apply, Pi.smul_apply] using hs_eq
-          have hrj' : u j - cBase j = r.1 * (w j - v j) := by
-            have h1 := congrArg (fun t ↦ t - cBase j) hrj
-            have h1' : u j + r.1 * v j - cBase j = r.1 * w j := by
-              simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using h1
-            have h2 := congrArg (fun t ↦ t - r.1 * v j) h1'
-            have h2' : u j - cBase j = r.1 * w j - r.1 * v j := by
-              simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using h2
-            simpa [mul_sub] using h2'
-          have hsj' : u j - cBase j = s.1 * (w j - v j) := by
-            have h1 := congrArg (fun t ↦ t - cBase j) hsj
-            have h1' : u j + s.1 * v j - cBase j = s.1 * w j := by
-              simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using h1
-            have h2 := congrArg (fun t ↦ t - s.1 * v j) h1'
-            have h2' : u j - cBase j = s.1 * w j - s.1 * v j := by
-              simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using h2
-            simpa [mul_sub] using h2'
-          have hmul : r.1 * (w j - v j) = s.1 * (w j - v j) := Eq.trans hrj'.symm hsj'
-          have hzero : (r.1 - s.1) * (w j - v j) = 0 := by
-            have : r.1 * (w j - v j) - s.1 * (w j - v j) = 0 := sub_eq_zero.mpr hmul
-            simpa [sub_mul] using this
-          have hne : r.1 - s.1 ≠ 0 := sub_ne_zero.mpr hrs_val
-          have : w j - v j = 0 := by
-            have := mul_eq_zero.mp hzero
-            rcases this with h | h
-            · exact False.elim (hne h)
-            · exact h
-          exact (sub_eq_zero.mp this).symm
+          exact directions_eq_of_two_affine_values hrj hsj hrs_val
         have hu_eq : u j = cBase j := by
           have hrj : u j + r.1 * v j = cBase j + r.1 * w j := by
             simpa [Pi.add_apply, Pi.smul_apply] using hr_eq

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
@@ -149,8 +149,9 @@ theorem bucket_exists_common_codeword
             · push Not at hδ_le
               have hδ_real : (1 : ℝ) < (δ : ℝ) := by exact_mod_cast hδ_le
               linarith only [Nat.cast_nonneg' (α := ℝ) (S_x x hx).card,
-                        mul_nonpos_of_nonpos_of_nonneg (by linarith only [hδ_real] : (1 : ℝ) - ↑δ ≤ 0)
-                          (Nat.cast_nonneg' (α := ℝ) (Fintype.card ι))]
+                mul_nonpos_of_nonpos_of_nonneg
+                  (by linarith only [hδ_real] : (1 : ℝ) - ↑δ ≤ 0)
+                  (Nat.cast_nonneg' (α := ℝ) (Fintype.card ι))]
           linarith only [h2]
   have h_cw_bound : closeWords.card < Fintype.card F := by
     apply h_list_bound u₀

--- a/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/BCIKS20/AffineSpaces.lean
@@ -148,10 +148,10 @@ theorem bucket_exists_common_codeword
                     rw [NNReal.coe_mul, NNReal.coe_sub hδ_le, NNReal.coe_one, NNReal.coe_natCast]
             · push Not at hδ_le
               have hδ_real : (1 : ℝ) < (δ : ℝ) := by exact_mod_cast hδ_le
-              linarith [Nat.cast_nonneg' (α := ℝ) (S_x x hx).card,
-                        mul_nonpos_of_nonpos_of_nonneg (by linarith : (1 : ℝ) - ↑δ ≤ 0)
+              linarith only [Nat.cast_nonneg' (α := ℝ) (S_x x hx).card,
+                        mul_nonpos_of_nonpos_of_nonneg (by linarith only [hδ_real] : (1 : ℝ) - ↑δ ≤ 0)
                           (Nat.cast_nonneg' (α := ℝ) (Fintype.card ι))]
-          linarith
+          linarith only [h2]
   have h_cw_bound : closeWords.card < Fintype.card F := by
     apply h_list_bound u₀
     intro v hv
@@ -543,7 +543,8 @@ private lemma gs_degree_bound_le_inv_mu
       field_simp
       nlinarith only [hsqn]
     linarith only [h1, h2]
-  have hdeg_le_2d1 : (deg : ℝ) ≤ 2 * ↑(deg - 1 : ℕ) := by linarith [hdeg1_ge]
+  have hdeg_le_2d1 : (deg : ℝ) ≤ 2 * ↑(deg - 1 : ℕ) := by
+    linarith only [hdeg1_ge]
   have h3 : (deg : ℝ) / (2 * η) / (↑(deg - 1 : ℕ) : ℝ) ≤ 1 / η := by
     have hd1_pos : (0 : ℝ) < ↑(deg - 1 : ℕ) := by exact_mod_cast hdeg1
     rw [div_div, div_le_div_iff₀ (mul_pos (by positivity) hd1_pos) hη_pos, one_mul]
@@ -553,10 +554,11 @@ private lemma gs_degree_bound_le_inv_mu
     rw [div_div, div_le_div_iff₀ (mul_pos (by positivity) hd1_pos) hs_pos]
     nlinarith only [mul_le_mul_of_nonneg_right hdeg_le_2d1 hs_pos.le]
   have h5 : 1 / η ≤ 1 / μ := by
-    rw [div_le_div_iff₀ hη_pos hμ_pos]; linarith [hμ_le_η]
+    rw [div_le_div_iff₀ hη_pos hμ_pos]
+    linarith only [hμ_le_η]
   have h6 : 5 / s ≤ 1 / (4 * μ) := by
     rw [div_le_div_iff₀ hs_pos (by positivity : (0:ℝ) < 4 * μ)]
-    linarith [hμ_le_s20]
+    linarith only [hμ_le_s20]
   calc (↑m + 1/2) * s * (n : ℝ) / (↑(deg - 1 : ℕ) : ℝ)
       ≤ ((deg : ℝ) / (2 * η) + 5 * (deg : ℝ) / (2 * s)) / (↑(deg - 1 : ℕ) : ℝ) :=
         div_le_div_of_nonneg_right h_num (by positivity)
@@ -586,7 +588,8 @@ lemma exists_gs_multiplicity {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
     calc (δ : ℝ) < ((1 - ReedSolomon.sqrtRate deg domain : ℝ≥0) : ℝ) := by exact_mod_cast hδ
       _ = 1 - (ReedSolomon.sqrtRate deg domain : ℝ) := by
           rw [NNReal.coe_sub hsqrt_le, NNReal.coe_one]
-  have hη_pos : 0 < 1 - (ReedSolomon.sqrtRate deg domain : ℝ) - (δ : ℝ) := by linarith
+  have hη_pos : 0 < 1 - (ReedSolomon.sqrtRate deg domain : ℝ) - (δ : ℝ) := by
+    linarith only [hδ_real]
   set s : ℝ := (ReedSolomon.sqrtRate deg domain : ℝ) with hs_def
   set η : ℝ := 1 - s - (δ : ℝ) with hη_def
   -- For deg ≤ 1: degree bound is trivial (Nat division by 0 = 0)
@@ -617,7 +620,7 @@ lemma exists_gs_multiplicity {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
         have h1 : s / (2 * η) ≤ ↑(Nat.ceil (s / (2 * η))) := Nat.le_ceil _
         have h2 : (↑(Nat.ceil (s / (2 * η))) : ℝ) + 1 = (m : ℝ) := by
           simp only [m, Nat.cast_add, Nat.cast_one]
-        linarith
+        linarith only [h1, h2]
       have hs_nn : (0 : ℝ) ≤ s := by positivity
       have hs_div_lt : s / (2 * ↑m) < η := by
         rcases eq_or_lt_of_le hs_nn with hs0 | hs_pos
@@ -626,13 +629,14 @@ lemma exists_gs_multiplicity {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
           rw [div_lt_iff₀ h2m_pos]
           have h2η_pos : (0 : ℝ) < 2 * η := by positivity
           have := (div_lt_iff₀ h2η_pos).mp hm_gt
-          linarith
-      linarith
+          linarith only [this]
+      linarith only [hs_div_lt]
     · -- Degree bound: gs_degree_bound deg n m / (deg - 1) < |F|
       have hn_pos : (0 : ℝ) < Fintype.card ι := by
         exact_mod_cast (show 0 < Fintype.card ι from Fintype.card_pos)
       have hdeg_pos : (0 : ℝ) < deg := by exact_mod_cast (show 0 < deg by omega)
-      have hs_lt_one : s < 1 := by linarith [NNReal.coe_pos.mpr hδ_pos, hδ_real]
+      have hs_lt_one : s < 1 := by
+        linarith only [NNReal.coe_pos.mpr hδ_pos, hδ_real]
       have hs_eq : s = Real.sqrt ((deg : ℝ) / Fintype.card ι) := by
         simp only [s, hs_def, ReedSolomon.sqrtRate]
         rw [Real.coe_sqrt]; congr 1
@@ -651,7 +655,7 @@ lemma exists_gs_multiplicity {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
         have hmul := (div_lt_iff₀ hdeg1_cast).mp h_real
         exact Nat.div_lt_of_lt_mul (by
           have : (gs_degree_bound deg (Fintype.card ι) m : ℝ) <
-            ↑(deg - 1 : ℕ) * ↑(Fintype.card F) := by linarith
+            ↑(deg - 1 : ℕ) * ↑(Fintype.card F) := by linarith only [hmul]
           exact_mod_cast this)
       -- floor ≤ real expression
       have hfloor_le : (gs_degree_bound deg (Fintype.card ι) m : ℝ) ≤
@@ -670,7 +674,8 @@ lemma exists_gs_multiplicity {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
       have hdeg1_cast_eq : (↑(deg - 1 : ℕ) : ℝ) = (deg : ℝ) - 1 := by
         rw [Nat.cast_sub (by omega : 1 ≤ deg), Nat.cast_one]
       have hdeg1_ge : (↑(deg - 1 : ℕ) : ℝ) ≥ (deg : ℝ) / 2 := by
-        rw [hdeg1_cast_eq]; linarith [show (2 : ℝ) ≤ deg from by exact_mod_cast hdeg]
+        rw [hdeg1_cast_eq]
+        linarith only [show (2 : ℝ) ≤ deg from by exact_mod_cast hdeg]
       set μ : ℝ := min η (s / 20) with hμ_def
       have hμ_pos : 0 < μ := lt_min hη_pos (by positivity)
       have hμ_le_η : μ ≤ η := min_le_left _ _
@@ -681,7 +686,7 @@ lemma exists_gs_multiplicity {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
           simp only [m, Nat.cast_add, Nat.cast_one]
         have hceil_le : (↑(Nat.ceil (s / (2 * η))) : ℝ) ≤ s / (2 * η) + 1 :=
           le_of_lt (Nat.ceil_lt_add_one (by positivity : (0 : ℝ) ≤ s / (2 * η)))
-        linarith
+        linarith only [hm_eq, hceil_le]
       have h_le_54μ : (↑m + 1/2) * s * (Fintype.card ι : ℝ) /
           (↑(deg - 1 : ℕ) : ℝ) ≤ 5 / (4 * μ) :=
         gs_degree_bound_le_inv_mu hs_pos hη_pos hs_sq hn_pos hdeg
@@ -734,7 +739,7 @@ lemma exists_gs_multiplicity {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
         have hcast : (↑(↑deg ^ 2 : ℝ≥0) : ℝ) = (↑deg : ℝ) ^ 2 := by push_cast; ring
         rw [hcast] at hlt
         rw [div_lt_iff₀ (by positivity : (0 : ℝ) < 128 * μ ^ 7)]
-        linarith
+        linarith only [hlt]
       calc (gs_degree_bound deg (Fintype.card ι) m : ℝ) / ↑(deg - 1 : ℕ)
           ≤ (↑m + 1/2) * s * ↑(Fintype.card ι) / ↑(deg - 1 : ℕ) :=
             div_le_div_of_nonneg_right hfloor_le (by positivity)
@@ -780,8 +785,8 @@ lemma exists_gs_multiplicity {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
           rw [div_lt_iff₀ h2m_pos]
           have h2η_pos : (0 : ℝ) < 2 * η := by positivity
           have := (div_lt_iff₀ h2η_pos).mp hm_gt
-          linarith
-      linarith
+          linarith only [this]
+      linarith only [hs_div_lt]
     · -- deg = 0: gs_johnson 0 n m = 1 trivially > δ
       have hdeg0 : deg = 0 := by omega
       subst hdeg0
@@ -792,7 +797,7 @@ lemma exists_gs_multiplicity {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
         simp only [gs_johnson, CharP.cast_eq_zero, zero_div, Rat.cast_zero, Real.sqrt_zero,
           sub_zero, Nat.cast_one, mul_one]
       rw [hgs0]
-      linarith [hδ_real, show (0 : ℝ) ≤ s from by positivity]
+      linarith only [hδ_real, show (0 : ℝ) ≤ s from by positivity]
 
 omit [DecidableEq ι] in
 theorem rs_listDecoding_card_lt_field {deg : ℕ} {domain : ι ↪ F} {δ : ℝ≥0}
@@ -845,7 +850,8 @@ theorem rs_listDecoding_card_lt_field {deg : ℕ} {domain : ι ↪ F} {δ : ℝ�
         simpa [ReedSolomon.code_zero] using (hclose v hv).1
       have : closeWords.card ≤ 1 :=
         Finset.card_le_one_iff.mpr (fun hx hy => (hcode_triv _ hx).trans (hcode_triv _ hy).symm)
-      linarith [Fintype.one_lt_card_iff_nontrivial.mpr (Field.toNontrivial : Nontrivial F)]
+      linarith only [this,
+        Fintype.one_lt_card_iff_nontrivial.mpr (Field.toNontrivial : Nontrivial F)]
     · -- deg = 1: each poly has degree < 1, so is constant: p = C(p.coeff 0).
       -- Inject closeWords into F via coeff 0. Strict < follows from injectivity.
       have hinj_F : ∀ (v₁ : ι → F) (hv₁ : v₁ ∈ closeWords)
@@ -1012,7 +1018,7 @@ theorem rs_listDecoding_card_lt_field {deg : ℕ} {domain : ι ↪ F} {δ : ℝ�
                 1 / Fintype.card ι := by
               have h : (Fintype.card ι - 1 : ℝ) / Fintype.card ι =
                   1 - 1 / Fintype.card ι := by field_simp
-              linarith [hrel_val, hrel_le_delta, h_add_real]
+              linarith only [hrel_val, hrel_le_delta, h_add_real, h]
             -- sqrtRate > 1/n: √rate > rate ≥ 1/n
             have hrate_pos : (0 : ℝ≥0) <
                 (LinearCode.rate (ReedSolomon.code domain 1) : ℝ≥0) := by
@@ -1059,7 +1065,7 @@ theorem rs_listDecoding_card_lt_field {deg : ℕ} {domain : ι ↪ F} {δ : ℝ�
                 calc (1 : ℝ≥0) / _ ≤ _ := hrate_ge_inv
                   _ < NNReal.sqrt _ := h_sqrt_gt
                   _ = ReedSolomon.sqrtRate 1 domain := by simp [ReedSolomon.sqrtRate]
-            linarith
+            linarith only [hsqrt_le_inv, hsqrt_gt_inv]
         · -- range(w).card < |F|
           calc closeWords.card ≤ (Finset.image w Finset.univ).card := hcard_le_range
             _ < Fintype.card F := by omega
@@ -1114,7 +1120,8 @@ theorem rs_listDecoding_card_lt_field {deg : ℕ} {domain : ι ↪ F} {δ : ℝ�
           (C := (ReedSolomon.code domain deg : Set (ι → F))) :=
         (Code.dist_le_UDR_iff_relDist_le_relUDR _ _).2 h_v₂_le
       exact eq_of_le_uniqueDecodingRadius _ w hv₁_code hv₂_code hudr₁ hudr₂
-    linarith [Fintype.one_lt_card_iff_nontrivial.mpr (Field.toNontrivial : Nontrivial F)]
+    linarith only [hcard_le_one,
+      Fintype.one_lt_card_iff_nontrivial.mpr (Field.toNontrivial : Nontrivial F)]
   -- Johnson regime: use Guruswami-Sudan with parameterized multiplicity m.
   suffices ∃ (Q : Polynomial (Polynomial F)), Q ≠ 0 ∧ Q.natDegree < Fintype.card F ∧
       ∀ P ∈ polys, (Polynomial.X - Polynomial.C P) ∣ Q by

--- a/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/Frs.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/CapacityBounds/Frs.lean
@@ -64,11 +64,11 @@ private theorem strongLineDecodable_of_subspaceDesign
           ((Module.finrank F (lineCloseSpan f₀ f₁ U (δ : ℝ)) : ℝ) + ε) ≤
         ((linePinnedSeedsOn T f₀ f₁ U S).card : ℝ) * ((r : ℝ) + ε) := by
     apply mul_le_mul_of_nonneg_left _ hA0
-    linarith
+    linarith only [hdR]
   have hchain : (b : ℝ) * ((r : ℝ) + ε) ≤
       ((linePinnedSeedsOn T f₀ f₁ U S).card : ℝ) * ((r : ℝ) + ε) :=
     hretain.trans (haeps.trans (hpot.trans hdim))
-  have hden : 0 < (r : ℝ) + ε := by linarith
+  have hden : 0 < (r : ℝ) + ε := by linarith only [hrR, hεpos]
   have hbR : (b : ℝ) ≤ (linePinnedSeedsOn T f₀ f₁ U S).card :=
     le_of_mul_le_mul_right hchain hden
   have hbNat : b ≤ (linePinnedSeedsOn T f₀ f₁ U S).card := by
@@ -108,7 +108,7 @@ private theorem strongLineDecodable_two_mul_of_profile_le
     have hid : 1 / (2 * (t : ℝ)) + 3 / (2 * (t : ℝ)) = 2 / (t : ℝ) := by
       field_simp
       ring
-    nlinarith
+    nlinarith only [hprofile, hδ, hid]
   have heps : 2 / (((2 * t : ℕ) : ℝ)) < 3 / (2 * (t : ℝ)) := by
     push_cast
     exact div_lt_div_of_pos_right (by norm_num) hden
@@ -118,10 +118,10 @@ private theorem strongLineDecodable_two_mul_of_profile_le
     have hsq : (9 : ℝ) ≤ (t : ℝ) ^ 2 := by
       have hmul : (0 : ℝ) ≤ ((t : ℝ) - 3) * ((t : ℝ) + 3) :=
         mul_nonneg (sub_nonneg.mpr htR3) (by linarith)
-      nlinarith
+      nlinarith only [hmul]
     push_cast
     field_simp
-    nlinarith
+    nlinarith only [hsq]
   exact strongLineDecodable_of_subspaceDesign τ C hdesign (by omega)
     (3 / (2 * (t : ℝ))) heps δ hrad (by omega) hret
 
@@ -176,20 +176,19 @@ private theorem frs_mcaError_le_proof
   · have htR0 : (0 : ℝ) < t := by exact_mod_cast _ht_pos
     have hR0' : 0 ≤ R := by dsimp [R]; positivity
     dsimp [δr] at hδpos
-    interval_cases t <;> norm_num at hδpos ⊢ <;> nlinarith
+    interval_cases t <;> norm_num at hδpos ⊢ <;> nlinarith only [hδpos, hR0']
   have ht3 : 3 ≤ t := by omega
   have htR : (0 : ℝ) < t := by exact_mod_cast (show 0 < t by omega)
-  have hs_pos : 0 < s := by nlinarith [_hs_gt]
+  have hs_pos : 0 < s := lt_of_le_of_lt (Nat.zero_le _) _hs_gt
   have hFn : Fintype.card ι < Fintype.card F := by
-    have hnpos : 0 < Fintype.card ι := Fintype.card_pos
-    nlinarith [_hcard]
+    exact lt_of_le_of_lt (Nat.le_mul_of_pos_left _ hs_pos) _hcard
   have hR0 : 0 ≤ R := by dsimp [R]; positivity
   have hR1 : R ≤ 1 := by
     dsimp [δr] at hδ0
-    nlinarith [div_pos (show (0 : ℝ) < 2 by norm_num) htR]
+    nlinarith only [hδ0, div_pos (show (0 : ℝ) < 2 by norm_num) htR]
   have hRlt : R < 1 := by
     dsimp [δr] at hδ0
-    nlinarith [div_pos (show (0 : ℝ) < 2 by norm_num) htR]
+    nlinarith only [hδ0, div_pos (show (0 : ℝ) < 2 by norm_num) htR]
   have hsn_pos : (0 : ℝ) < (s : ℝ) * Fintype.card ι := by positivity
   have hkR : (k : ℝ) < (s : ℝ) * Fintype.card ι := by
     rw [← div_lt_one hsn_pos]
@@ -209,7 +208,8 @@ private theorem frs_mcaError_le_proof
   have hrate : (LinearCode.alphabetRate C : ℝ) = R := by
     simpa only [C, R, Nat.cast_mul] using
       (ReedSolomon.Folded.alphabetRate_frsCode domain k s ω _hadm _hω hk)
-  have h2tle : 2 * t ≤ s := by nlinarith [_hs_gt, sq_nonneg ((t : ℝ) - 1)]
+  have h2tle : 2 * t ≤ s := by
+    nlinarith only [_hs_gt, sq_nonneg ((t : ℝ) - 1)]
   have ht_le_s : t ≤ s := le_trans (by omega : t ≤ 2 * t) h2tle
   change IsSubspaceDesign s (sharpSubspaceProfile (ι := ι) s R) C at hdesign
   have hdesignList := hdesign
@@ -238,7 +238,7 @@ private theorem frs_mcaError_le_proof
       change δr < (1 : ℝ)
       dsimp [δr]
       have htwo : (0 : ℝ) < 2 / t := div_pos (by norm_num) htR
-      nlinarith
+      nlinarith only [hR0, htwo]
     have hmca := IsLineDecodable.mcaError_le C δ
       (Fintype.card ι * t + 3 * t ^ 3)
       (by exact_mod_cast hδpos) hδlt hline
@@ -258,7 +258,7 @@ private theorem frs_mcaError_le_proof
   · have hq : Fintype.card F ≤ (t + 1) ^ 2 := by omega
     have hqP : Fintype.card F ≤ Fintype.card ι * t + 3 * t ^ 3 := by
       have hn : 1 ≤ Fintype.card ι := Fintype.card_pos
-      nlinarith [sq_nonneg (t - 1)]
+      nlinarith only [hq, hn, ht3, sq_nonneg (t - 1)]
     refine (mcaError_le_one (AffineLineGenerator F) C δr).trans ?_
     rw [← ENNReal.ofReal_one]
     apply ENNReal.ofReal_le_ofReal

--- a/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
@@ -784,10 +784,21 @@ lemma folded_rate_eq {d : ℕ} [FoldingContext k d n] :
     LinearCode.rate
       (ReedSolomon.code (domain.subdomain k : Fin (2 ^ (n - k)) ↪ F) (2 ^ (d - k))) =
     LinearCode.rate (ReedSolomon.code (domain : Fin (2 ^ n) ↪ F) (2 ^ d)) := by
-  aesop
-    (add simp [rateOfLinearCode_eq_min_div, min_def])
-    (add unsafe (by rw [←pow_add, ←pow_add]))
-    (add safe [(by grind), (by field_simp)])
+  simp only [rateOfLinearCode_eq_min_div, Fintype.card_fin]
+  rw [min_def, min_def]
+  have hdk : 2 ^ (d - k) ≤ 2 ^ (n - k) :=
+    Nat.pow_le_pow_right (by omega) (Nat.sub_le_sub_right FoldingContextRight.d_le_n k)
+  have hdn : 2 ^ d ≤ 2 ^ n :=
+    Nat.pow_le_pow_right (by omega) FoldingContextRight.d_le_n
+  rw [if_pos hdk, if_pos hdn]
+  field_simp
+  norm_cast
+  rw [← pow_add]
+  have hk_d : k ≤ d := FoldingContextLeft.k_le_d
+  have hd_n : d ≤ n := FoldingContextRight.d_le_n
+  have hexp : d - k + n = n - k + d := by omega
+  rw [hexp]
+  exact pow_add 2 (n - k) d
 
 omit [DecidableEq F] in
 /-- The square root of the rate of the folded RS-code is the same. -/

--- a/ArkLib/Data/CodingTheory/SubspaceDesign.lean
+++ b/ArkLib/Data/CodingTheory/SubspaceDesign.lean
@@ -288,7 +288,7 @@ theorem subspaceDesign_tau_lower_of_ne_bot
       ((Finset.univ.filter (fun i => a i = 0)).card : ℝ) := by
     rw [hcards, Nat.cast_sub hwt_le_n]
     have : ((Finset.univ.filter (fun i => a i ≠ 0)).card : ℝ) ≤ d := by exact_mod_cast hwt_le_d
-    linarith
+    linarith only [this]
   have hkey : (Module.finrank F C : ℝ) / (s * Fintype.card ι) - 1 / Fintype.card ι ≤
       ((Fintype.card ι : ℝ) - d) / Fintype.card ι := by
     have hdiv : (Module.finrank F C : ℝ) / (s * Fintype.card ι) ≤
@@ -302,7 +302,7 @@ theorem subspaceDesign_tau_lower_of_ne_bot
         ((Fintype.card ι : ℝ) - d) / Fintype.card ι := by
       rw [div_sub_div_same]
       ring_nf
-    linarith
+    linarith only [hdiv, hsplit]
   calc (Module.finrank F C : ℝ) / (s * Fintype.card ι) - 1 / Fintype.card ι
       ≤ ((Fintype.card ι : ℝ) - d) / Fintype.card ι := hkey
     _ ≤ ((Finset.univ.filter (fun i => a i = 0)).card : ℝ) / Fintype.card ι := by gcongr
@@ -618,7 +618,7 @@ theorem isSubspaceDesign_frsCode_sub_one
       rw [← Nat.cast_sum]
       exact_mod_cast hnat
     rw [div_le_iff₀ hn_pos, sub_mul, div_mul_cancel₀ _ (ne_of_gt hn_pos)]
-    linarith
+    linarith only [hcast]
   -- Near-saturation escape: for `τ r ≥ 1 - 1/(n*s)` the sharper count already suffices.
   by_cases hτnear : 1 - 1 / ((Fintype.card ι : ℝ) * s) ≤ τ r
   case pos =>
@@ -626,12 +626,12 @@ theorem isSubspaceDesign_frsCode_sub_one
     rw [mul_sub, mul_one]
     have hkey : (σ : ℝ) * (1 / ((Fintype.card ι : ℝ) * s)) ≤ 1 / Fintype.card ι := by
       rw [mul_one_div, div_le_div_iff₀ (by positivity) hn_pos]
-      nlinarith
-    linarith
+      nlinarith only [hσs_real]
+    linarith only [hkey]
   rw [not_le] at hτnear
   have hτ1 : τ r < 1 := by
     have : (0 : ℝ) < 1 / ((Fintype.card ι : ℝ) * s) := by positivity
-    linarith
+    linarith only [hτnear, this]
   have hτrate : τ r =
       ((s : ℝ) * (LinearCode.alphabetRate (ReedSolomon.Folded.frsCode domain k s ω) : ℝ)
           - 1 / Fintype.card ι) /
@@ -639,7 +639,7 @@ theorem isSubspaceDesign_frsCode_sub_one
     rw [hτdef r, if_pos hrmem]
   have hb_pos : (0 : ℝ) < (s : ℝ) - r + 1 := by
     have : (r : ℝ) ≤ s := by exact_mod_cast hrs
-    linarith
+    linarith only [this]
   have hcast_b : (((s - r + 1 : ℕ)) : ℝ) = (s : ℝ) - r + 1 := by
     push_cast [Nat.cast_sub hrs]; ring
   have hk_le : k ≤ s * Fintype.card ι := by
@@ -658,7 +658,7 @@ theorem isSubspaceDesign_frsCode_sub_one
     rw [hτrate, hrate] at hτnear
     have hden_le : (s : ℝ) - r + 1 ≤ s := by
       have : (1 : ℝ) ≤ r := by exact_mod_cast hr1
-      linarith
+      linarith only [this]
     have hfac_nonneg : (0 : ℝ) ≤ 1 - 1 / ((Fintype.card ι : ℝ) * s) := by
       have hn1 : (1 : ℝ) ≤ Fintype.card ι := by exact_mod_cast Fintype.card_pos
       have hs1 : (1 : ℝ) ≤ s := by exact_mod_cast (show 1 ≤ s by omega)
@@ -918,11 +918,11 @@ theorem isSubspaceDesign_frsCode
   · simp only [hr, if_true]
     have hb_pos : (0 : ℝ) < (s : ℝ) - r + 1 := by
       have : (r : ℝ) ≤ s := by exact_mod_cast (Finset.mem_Icc.mp hr).2
-      linarith
+      linarith only [this]
     have hn_pos : (0 : ℝ) < Fintype.card ι := by exact_mod_cast Fintype.card_pos
     rw [sub_div]
     have hdrop : (0 : ℝ) ≤ (1 / (Fintype.card ι : ℝ)) / ((s : ℝ) - r + 1) := by positivity
-    linarith
+    linarith only [hdrop]
   · simp [hr]
 
 /-- Univariate multiplicity codes are subspace designs for the profile
@@ -1015,7 +1015,7 @@ theorem isSubspaceDesign_umCode_sub_one
       rw [← Nat.cast_sum]
       exact_mod_cast hnat
     rw [div_le_iff₀ hn_pos, sub_mul, div_mul_cancel₀ _ (ne_of_gt hn_pos)]
-    linarith
+    linarith only [hcast]
   -- Near-saturation escape: for `τ r ≥ 1 - 1/(n*s)` the sharper count already suffices.
   by_cases hτnear : 1 - 1 / ((Fintype.card ι : ℝ) * s) ≤ τ r
   case pos =>
@@ -1023,12 +1023,12 @@ theorem isSubspaceDesign_umCode_sub_one
     rw [mul_sub, mul_one]
     have hkey : (σ : ℝ) * (1 / ((Fintype.card ι : ℝ) * s)) ≤ 1 / Fintype.card ι := by
       rw [mul_one_div, div_le_div_iff₀ (by positivity) hn_pos]
-      nlinarith
-    linarith
+      nlinarith only [hσs_real]
+    linarith only [hkey]
   rw [not_le] at hτnear
   have hτ1 : τ r < 1 := by
     have : (0 : ℝ) < 1 / ((Fintype.card ι : ℝ) * s) := by positivity
-    linarith
+    linarith only [hτnear, this]
   have hτrate : τ r =
       ((s : ℝ) * (LinearCode.alphabetRate
         (ReedSolomon.Multiplicity.umCode domain k s) : ℝ) - 1 / Fintype.card ι) /
@@ -1036,7 +1036,7 @@ theorem isSubspaceDesign_umCode_sub_one
     rw [hτdef r, if_pos hrmem]
   have hb_pos : (0 : ℝ) < (s : ℝ) - r + 1 := by
     have : (r : ℝ) ≤ s := by exact_mod_cast hrs
-    linarith
+    linarith only [this]
   have hk_le : k ≤ s * Fintype.card ι := by
     by_contra hk
     have hdim : Module.finrank F (ReedSolomon.Multiplicity.umCode domain k s) =
@@ -1054,7 +1054,7 @@ theorem isSubspaceDesign_umCode_sub_one
     rw [hτrate, hrate] at hτnear
     have hden_le : (s : ℝ) - r + 1 ≤ s := by
       have : (1 : ℝ) ≤ r := by exact_mod_cast hr1
-      linarith
+      linarith only [this]
     have hfac_nonneg : (0 : ℝ) ≤ 1 - 1 / ((Fintype.card ι : ℝ) * s) := by
       have hn1 : (1 : ℝ) ≤ Fintype.card ι := by exact_mod_cast Fintype.card_pos
       have hs1 : (1 : ℝ) ≤ s := by exact_mod_cast (show 1 ≤ s by omega)
@@ -1257,11 +1257,11 @@ theorem isSubspaceDesign_umCode
   · simp only [hr, if_true]
     have hb_pos : (0 : ℝ) < (s : ℝ) - r + 1 := by
       have : (r : ℝ) ≤ s := by exact_mod_cast (Finset.mem_Icc.mp hr).2
-      linarith
+      linarith only [this]
     have hn_pos : (0 : ℝ) < Fintype.card ι := by exact_mod_cast Fintype.card_pos
     rw [sub_div]
     have hdrop : (0 : ℝ) ≤ (1 / (Fintype.card ι : ℝ)) / ((s : ℝ) - r + 1) := by positivity
-    linarith
+    linarith only [hdrop]
   · simp [hr]
 
 end CodingTheory

--- a/ArkLib/ProofSystem/Binius/BinaryBasefold/Prelude.lean
+++ b/ArkLib/ProofSystem/Binius/BinaryBasefold/Prelude.lean
@@ -845,27 +845,23 @@ theorem fold_advances_evaluation_poly
       · omega
       · omega
     ⟩)
+  have h_eval_qMap (k : Fin 2) : (AdditiveNTT.qMap 𝔽q β ⟨i, by omega⟩
+      (by simp only; omega)).eval (fiberMap k).val = y := by
+    have h := iteratedQuotientMap_k_eq_1_is_qMap 𝔽q β h_ℓ_add_R_rate
+      (i := ⟨i, by omega⟩) (destIdx := ⟨i + 1, by omega⟩)
+      (h_destIdx := by simp) (h_destIdx_le := by simp only; omega) (fiberMap k)
+    simp only [Subtype.ext_iff] at h
+    rw [h.symm]
+    have h_res := is_fiber_iff_generates_quotient_point 𝔽q β i (steps := 1) (by omega)
+      (x := fiberMap k) (y := y).mpr
+        (by rw [pointToIterateQuotientIndex_qMap_total_fiber_eq_self])
+    rw [h_res]
   have h_eval_qMap_x₀ : (AdditiveNTT.qMap 𝔽q β ⟨i, by omega⟩
       (by simp only; omega)).eval x₀.val = y := by
-    have h := iteratedQuotientMap_k_eq_1_is_qMap 𝔽q β h_ℓ_add_R_rate
-      (i := ⟨i, by omega⟩) (destIdx := ⟨i + 1, by omega⟩)
-      (h_destIdx := by simp) (h_destIdx_le := by simp only; omega) x₀
-    simp only [Subtype.ext_iff] at h
-    rw [h.symm]
-    have h_res := is_fiber_iff_generates_quotient_point 𝔽q β i (steps := 1) (by omega)
-      (x := x₀) (y := y).mpr (by rw [pointToIterateQuotientIndex_qMap_total_fiber_eq_self])
-    rw [h_res]
-    -- exact qMap_eval_fiber_eq_self ⟦L⟧ ⟨i + 1, by omega⟩ (by simp only; omega) h_i_succ_lt y 0
+    simpa only [x₀] using h_eval_qMap 0
   have h_eval_qMap_x₁ : (AdditiveNTT.qMap 𝔽q β ⟨i, by omega⟩
       (by simp only; omega)).eval x₁.val = y := by
-    have h := iteratedQuotientMap_k_eq_1_is_qMap 𝔽q β h_ℓ_add_R_rate
-      (i := ⟨i, by omega⟩) (destIdx := ⟨i + 1, by omega⟩)
-      (h_destIdx := by simp) (h_destIdx_le := by simp only; omega) x₁
-    simp only [Subtype.ext_iff] at h
-    rw [h.symm]
-    have h_res := is_fiber_iff_generates_quotient_point 𝔽q β i (steps := 1) (by omega)
-      (x := x₁) (y := y).mpr (by rw [pointToIterateQuotientIndex_qMap_total_fiber_eq_self])
-    rw [h_res]
+    simpa only [x₁] using h_eval_qMap 1
   have hx₀ := qMap_total_fiber_basis_sum_repr 𝔽q β i (steps := 1)
     (h_i_add_steps := by omega) y 0
   have hx₁ := qMap_total_fiber_basis_sum_repr 𝔽q β i (steps := 1)

--- a/ArkLib/ProofSystem/Binius/BinaryBasefold/Prelude.lean
+++ b/ArkLib/ProofSystem/Binius/BinaryBasefold/Prelude.lean
@@ -912,17 +912,18 @@ theorem fold_advances_evaluation_poly
       ↓reduceDIte, add_tsub_cancel_right, Fin.eta, imp_self, implies_true]
   set P_i_plus_1 := intermediateEvaluationPoly 𝔽q β h_ℓ_add_R_rate
     (i := ⟨i + 1, by omega⟩) (h_i := by simp only; omega) new_coeffs
+  have h_odd_coeff_index (j : Fin (2 ^ (ℓ - (i + 1)))) :
+      j.val * 2 + 1 < 2 ^ (ℓ - i) := by
+    have h1 : ℓ - (i + 1) + 1 = ℓ - i := by omega
+    have h2 : 2 ^ (ℓ - (i + 1) + 1) = 2 ^ (ℓ - i) := by rw [h1]
+    have h3 : 2 ^ (ℓ - (i + 1)) * 2 = 2 ^ (ℓ - (i + 1) + 1) := by rw [pow_succ]
+    rw [← h2, ← h3]
+    omega
   -- Set up the even and odd refinement polynomials
   set P₀_coeffs := fun j : Fin (2^(ℓ - (i + 1))) => coeffs ⟨j.val * 2, by
-    have h1 : ℓ - (i + 1) + 1 = ℓ - i := by omega
-    have h2 : 2^(ℓ - (i + 1) + 1) = 2^(ℓ - i) := by rw [h1]
-    have h3 : 2^(ℓ - (i + 1)) * 2 = 2^(ℓ - (i + 1) + 1) := by rw [pow_succ]
-    rw [← h2, ← h3]; omega⟩
+    exact Nat.lt_of_succ_lt (h_odd_coeff_index j)⟩
   set P₁_coeffs := fun j : Fin (2^(ℓ - (i + 1))) => coeffs ⟨j.val * 2 + 1, by
-    have h1 : ℓ - (i + 1) + 1 = ℓ - i := by omega
-    have h2 : 2^(ℓ - (i + 1) + 1) = 2^(ℓ - i) := by rw [h1]
-    have h3 : 2^(ℓ - (i + 1)) * 2 = 2^(ℓ - (i + 1) + 1) := by rw [pow_succ]
-    rw [← h2, ← h3]; omega⟩
+    exact h_odd_coeff_index j⟩
   set P₀ := evenRefinement 𝔽q β h_ℓ_add_R_rate
     (i := ⟨i, by omega⟩) (h_i := by simp only; omega) coeffs
   set P₁ := oddRefinement 𝔽q β h_ℓ_add_R_rate

--- a/ArkLib/ProofSystem/Stir/Combine.lean
+++ b/ArkLib/ProofSystem/Stir/Combine.lean
@@ -318,17 +318,20 @@ private lemma combine_eq_flat'''
         · exact Finset.mem_filter.mp
             (Finset.max'_mem (Finset.univ.filter
               (Combine.block_start dstar degs · ≤ l)) _) |>.2
-        · aesop (add safe Finset.le_max')
+        · intro j hj
+          exact Finset.le_max' _ j (Finset.mem_filter.mpr ⟨Finset.mem_univ _, hj⟩)
   convert Combine.combine_eq_flat'' φ dstar r fs degs using 1
   funext x
   exact Finset.sum_congr rfl <| fun l _ ↦ by
     obtain ⟨i, hi, hi'⟩ := h_block l
     have hi_eq : (Finset.max'
-      (filter (Combine.block_start dstar degs · ≤ l) Finset.univ)
-      Combine.block_start_filter_nonempty) = i :=
-        le_antisymm
-          (by simp_all [Finset.max'])
-          (by aesop (add simp [Finset.max']))
+        (filter (Combine.block_start dstar degs · ≤ l) Finset.univ)
+        Combine.block_start_filter_nonempty) = i := by
+      apply le_antisymm
+      · apply Finset.max'_le
+        intro j hj
+        exact hi' j (Finset.mem_filter.mp hj).2
+      · exact Finset.le_max' _ i (Finset.mem_filter.mpr ⟨Finset.mem_univ _, hi⟩)
     rw [hi_eq, ←Nat.add_sub_of_le hi]
     ring_nf
     simp only [block_start, Nat.succ_eq_add_one, block_size, sum_add_distrib, sum_const,

--- a/ArkLib/ProofSystem/Stir/Combine.lean
+++ b/ArkLib/ProofSystem/Stir/Combine.lean
@@ -86,11 +86,15 @@ lemma combine_eq_cases {F ι : Type*} [Field F] [DecidableEq F]
       else ∑ i, (ri dstar degs r i) * (fs i x) *  (dstar - degs i + 1) := by
   funext x
   simp only [combine]
-  split_ifs
-  · aesop
-      (add simp [geom_sum_cases])
-      (add safe (by ring))
-  · simp_all
+  split_ifs with hq
+  · simp_rw [geom_sum_cases, if_pos hq]
+    apply Finset.sum_congr rfl
+    intro i _
+    ring
+  · simp_rw [geom_sum_cases, if_neg hq]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [Nat.cast_add, Nat.cast_sub (hdegs i), Nat.cast_one]
 
 open Finset
 open BigOperators
@@ -330,7 +334,9 @@ private lemma combine_eq_flat'''
     simp only [block_start, Nat.succ_eq_add_one, block_size, sum_add_distrib, sum_const,
       smul_eq_mul, mul_comm, one_mul, add_tsub_cancel_left, mul_assoc, mul_left_comm,
       mul_eq_mul_left_iff]
-    rw [show filter _ _ = Finset.Iio i by ext j; simp]
+    rw [show filter _ _ = Finset.Iio i by
+      ext j
+      simp only [mem_filter, mem_univ, true_and, mem_Iio]]
     aesop (add safe (by ring))
 
 omit [DecidableEq F] in

--- a/ArkLib/ProofSystem/ToyProblem/SoundnessBounds.lean
+++ b/ArkLib/ProofSystem/ToyProblem/SoundnessBounds.lean
@@ -792,13 +792,7 @@ theorem exists_winningSetFor_ncard_ge_of_lambda_lt_card {k : ℕ}
   -- ENUMERATION (bijection codewords ↔ message pairs via the injective `enc`).
   -- `encStack enc` is injective: its two columns determine `enc m.1, enc m.2`, hence (by
   -- `hinj`) `m.1, m.2`.
-  have hencStack_inj : Function.Injective (encStack enc) := by
-    intro p q hpq
-    have h1 : enc p.1 = enc q.1 := by
-      rw [← encStack_transpose_zero enc p, ← encStack_transpose_zero enc q, hpq]
-    have h2 : enc p.2 = enc q.2 := by
-      rw [← encStack_transpose_one enc p, ← encStack_transpose_one enc q, hpq]
-    exact Prod.ext (hinj h1) (hinj h2)
+  have hencStack_inj : Function.Injective (encStack enc) := encStack_injective hinj
   have hSmsgN : Smsg.card = N := by
     -- ABF26-L6.12 enumeration: `encStack enc` is a bijection from the message pairs `Smsg`
     -- onto `closeCodewordsRel C^{≡2} fStar δ`. Injective by `hencStack_inj`; surjective
@@ -822,20 +816,15 @@ theorem exists_winningSetFor_ncard_ge_of_lambda_lt_card {k : ℕ}
           exact hV.1 1
         obtain ⟨m₀, hm₀⟩ := hcol0
         obtain ⟨m₁, hm₁⟩ := hcol1
-        refine ⟨(m₀, m₁), ?_, ?_⟩
-        · -- `encStack enc (m₀, m₁) ∈ closeCodewordsRel`, since it equals `V`.
-          have hVeq : encStack enc (m₀, m₁) = V := by
-            funext i j; fin_cases j
-            · change encStack enc (m₀, m₁) i 0 = V i 0
-              rw [encStack_apply_zero]; exact congrFun hm₀ i
-            · change encStack enc (m₀, m₁) i 1 = V i 1
-              rw [encStack_apply_one]; exact congrFun hm₁ i
-          rw [hVeq]; exact hV
-        · funext i j; fin_cases j
+        have hVeq : encStack enc (m₀, m₁) = V := by
+          funext i j; fin_cases j
           · change encStack enc (m₀, m₁) i 0 = V i 0
             rw [encStack_apply_zero]; exact congrFun hm₀ i
           · change encStack enc (m₀, m₁) i 1 = V i 1
             rw [encStack_apply_one]; exact congrFun hm₁ i
+        refine ⟨(m₀, m₁), ?_, hVeq⟩
+        rw [hVeq]
+        exact hV
     calc Smsg.card
         = (Smsg : Set ((Fin k → F) × (Fin k → F))).ncard := (Set.ncard_coe_finset _).symm
       _ = (encStack enc '' (Smsg : Set ((Fin k → F) × (Fin k → F)))).ncard :=


### PR DESCRIPTION
## Summary

This PR is a proof-level efficiency pass over all 20 modules that remained at or above 17 seconds in ArkLib's previous clean CI build. It is based directly on the merged `main` from PR #833.

Every target was rebuilt and profiled locally against warm dependencies. Fourteen modules received substantive proof refactors; six were deliberately left unchanged after profiling because the bounded alternatives would relocate work, duplicate abstractions, or make dense matrix/asymptotic arguments more brittle.

Across the 14 changed targets, the sum of representative local wall minima fell from 80.90s to 69.72s (13.8%), with no file splitting or import manipulation. The strongest reductions were:

- `CapacityBounds.Frs`: 5.59s → 3.44s (38.5%);
- `LargeAlphabet.Basic`: 4.66s → 3.17s (32.0%);
- `SubspaceDesign`: 5.47s → 4.39s (19.7%);
- Binary Basefold `Prelude`: 6.21s → 5.24s (15.6%);
- `AHIV22`: 6.53s → 5.55s (15.0%);
- `AffineSpaces`: 5.37s → 4.61s (14.2%);
- STIR `Combine`: 6.12s → 5.32s (13.1%).

The lowest baseline among the 20 files was 4.33s, so 4.33s was used as a directional local floor rather than a noise-sensitive pass/fail gate. Three changed modules now beat that floor (`Frs`, `KKH26`, and `LargeAlphabet.Basic`), while `SubspaceDesign` is within 0.06s.

### Exact diff

- Base: `116734a45bd7f41f130ace6aa47c09f277fe6497`
- Head: `56a1eae02cdc251202cf4c1b0e9e97b9f77def05`
- Commits: 12
- Files: 14
- Diff: 269 insertions, 328 deletions

## Measurement contract and results

Each file was compiled directly on the same Mac with artifact fetching disabled and warm dependencies. The recorded value is the minimum of two warm runs; a third run was used when the pair differed by more than 10%. CPU is `user + sys`. These numbers measure direct module checking on this machine, not CI wall time, and small changes should be read in light of normal noise.

| Target | Wall baseline → final | CPU baseline → final | Result |
|---|---:|---:|---|
| `JohnsonBound/Lemmas` | 7.11s → 6.42s | 24.85s → 23.59s | changed |
| `GuruswamiSudan/Basic` | 6.49s → 5.88s | 36.52s → 34.15s | changed |
| `ProximityGap/AHIV22` | 6.53s → 5.55s | 11.89s → 10.48s | changed |
| `SubspaceDesign` | 5.47s → 4.39s | 9.79s → 7.93s | changed |
| `BerlekampWelch/Condition` | 6.98s → 6.69s | 10.61s → 10.31s | profiled; no source change |
| `JohnsonBound/Family` | 6.23s → 5.96s | 14.60s → 12.73s | changed |
| Binary Basefold `Prelude` | 6.21s → 5.24s | 9.60s → 8.39s | changed |
| `KKH26` | 4.34s → 4.06s | 8.32s → 7.62s | changed |
| `JohnsonBound/Basic` | 6.51s → 6.22s | 10.16s → 9.80s | changed |
| STIR `Combine` | 6.12s → 5.32s | 13.35s → 10.72s | changed |
| `CapacityBounds/Frs` | 5.59s → 3.44s | 6.37s → 3.90s | changed |
| `BWMatrix` | 4.66s → 4.38s | 12.97s → 13.06s | profiled; no source change |
| `JointAgreement` | 5.26s → 4.80s | 6.16s → 5.59s | profiled; no source change |
| `Folding` | 5.26s → 4.74s | 13.89s → 12.82s | changed |
| `LargeAlphabet/Basic` | 4.66s → 3.17s | 6.47s → 4.96s | changed |
| `Bounds/ReedSolomon` | 5.30s → 5.23s | 5.61s → 5.53s | profiled; no source change |
| `UniqueDecoding/Internal` | 4.86s → 4.59s | 10.77s → 10.41s | profiled; no source change |
| `AffineSpaces` | 5.37s → 4.61s | 10.04s → 8.52s | changed |
| `CapacityBounds/Powers` | 4.33s → 4.15s | 7.34s → 7.25s | profiled; no source change |
| `ToyProblem/SoundnessBounds` | 5.01s → 4.72s | 8.60s → 7.51s | changed |

For the six unchanged files, the small before/after movement is measurement noise, not an attributable code improvement. Their profiles identify the next structural targets: `BerlekampWelchCondition_to_Solution`; determinant/kernel and inverse-Vandermonde work in `BWMatrix`; `RS_jointAgreement`; the `rs_lambda_large_prime` asymptotic shell; Unique Decoding parameter/double-counting facts; and `powers_bad_seed_finset_card_le`.

## Proof refactors

### Coding-theory bounds

- replaces broad partition automation in Johnson lemmas with explicit cover/disjoint proofs;
- hoists a duplicated nonlinear Johnson coercion derivation;
- gives `JohnsonBound.Basic` a direct monotonicity proof and `JohnsonBound.Family` a structural Plotkin arithmetic chain;
- shares the generalized Guruswami–Sudan nonzero-kernel argument and constructs a `filterMap` witness directly instead of searching with `aesop`;
- shares KKH26 monicity certificates;
- factors the duplicated floor/radius arithmetic in the large-alphabet balanced-center theorem.

### Proximity and capacity bounds

- introduces two private scalar affine identities used six times in `AHIV22`, replacing repeated `simp`/`ring` chains;
- scopes arithmetic solvers to the facts they consume in `SubspaceDesign`, `Frs`, and `AffineSpaces`;
- replaces nonlinear cardinality derivations in `Frs` with direct natural-number order lemmas;
- proves the Folding rate preservation through explicit `min` branches, power monotonicity, and the exponent identity.

### Proof-system hotspots

- replaces broad `aesop`/`simp_all` search in STIR combination identities with explicit cases, finite-sum congruence, membership normalization, and maximum bounds;
- shares Basefold quotient-fiber evaluation and odd-coefficient index facts;
- reuses the existing `encStack_injective` theorem and one matrix equality in toy-problem soundness instead of reconstructing both proofs.

## Trust, compatibility, and review

- No exported theorem statement, assumption, conclusion, definition, or import changed.
- No new `sorry`, `admit`, axiom, unsafe/native trust mechanism, option, linter suppression, or blanket import was added.
- Source audit: admissions 184 → 184; examples 135 → 135; explicit axioms 0 → 0; native trust constructs 0 → 0.
- Axiom sweep: 11,023 declarations across 429 modules; 314 existing `sorryAx`-tainted declarations; zero non-standard-axiom-tainted declarations; regression check passed.
- Independent `review-lean-formalization` audit checked all 14 changed modules and the exact base-to-head trust surface. Its sole documentation nit was fixed in the final commit; the exact-head verdict is **PASS** with no P0–P3 findings remaining.

The diff-scoped tactic census also moves away from broad search: `aesop` 111 → 104, `simp_all` 39 → 36, `linarith` 245 → 237, `nlinarith` 82 → 73, and `grind` 42 → 40; explicit `ring` uses increase from 112 to 116.

## Validation

Passed locally with artifact fetching disabled:

- direct isolated compilation of all 20 target modules;
- targeted Lake builds for every changed module;
- full `./scripts/validate.sh --lint --axioms` at the proof head, covering the full project build, Data warning budget, toy-problem and Hachi runtime checks, blanket/import discipline, timing fixtures, docs and knowledge-base integrity, axiom fixtures/regression, and Lean style;
- direct compilation of `GuruswamiSudan.Basic` after the final documentation-only commit;
- `git diff --check`.

All hosted checks are green on the exact audited head. The build job completed in 21m54s; its timing artifact records a 929.24s clean build, 2.55s warm rebuild, 29.80s native build, and 13.23s validation test path.

## Reviewer map

1. `GuruswamiSudan/Basic`, `JohnsonBound/{Basic,Family,Lemmas}`, `KKH26`, and `LargeAlphabet/Basic` for coding-bound proof structure.
2. `AHIV22`, `SubspaceDesign`, `CapacityBounds/Frs`, `Folding`, and `AffineSpaces` for affine/arithmetic refactors.
3. `ProofSystem/Stir/Combine`, Binary Basefold `Prelude`, and toy-problem `SoundnessBounds` for proof-system changes.
4. The measurement table and trust/validation sections for the sprint-level evidence.