### PR TITLE
perf: replace broad proof search with structural lemmas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,11 @@ Start with [`README.md`](README.md) for project overview.
   `dependency_graphs/`, or `home_page/docs/`.
 - Pre-existing `sorry` blocks exist in active formalizations; distinguish existing gaps from new
   regressions.
+- Prefer proof scripts that expose the key mathematical steps and compose predictably. Broad
+  automation is welcome when it closes a well-scoped goal quickly and clearly; for a slow proof,
+  profile first, then narrow imports, local hypotheses, simp sets, or automation rules, or move a
+  recurring argument into its owner layer. Do not mechanically expand a short, stable terminal
+  `simp` into a brittle `simp only` list.
 - If a PR changes commands, repo structure, generated outputs, or the blueprint/citation
   workflow, update the matching page in [`docs/wiki/`](docs/wiki/README.md) in the same PR.
 - Promote recurring agent learnings into [`docs/wiki/`](docs/wiki/README.md); do not let stable

--- a/ArkLib/Data/CodingTheory/BerlekampWelch/Condition.lean
+++ b/ArkLib/Data/CodingTheory/BerlekampWelch/Condition.lean
@@ -84,7 +84,9 @@ lemma linsolve_is_berlekamp_welch_solution
 lemma is_berlekamp_welch_solution_ext
     (h : ∀ i, (Matrix.mulVec (BerlekampWelchMatrix e k ωs f) v) i = -(f i) * (ωs i) ^ e) :
     IsBerlekampWelchSolution e k ωs f v := by
-  aesop (add simp [IsBerlekampWelchSolution, Rhs])
+  rw [IsBerlekampWelchSolution]
+  funext i
+  simpa only [Rhs] using h i
 
 @[simp]
 lemma Rhs_add_one : Rhs (e + 1) ωs f = fun i ↦ Rhs e ωs f i * ωs i := by
@@ -107,7 +109,10 @@ def truncate (p : Polynomial F) (n : ℕ) : Polynomial F :=
 lemma coeff_truncate : (truncate p n).coeff k = if k < n then p.coeff k else 0 := rfl
 
 @[simp]
-lemma truncate_zero_eq_zero : (truncate p 0) = 0 := by aesop
+lemma truncate_zero_eq_zero : (truncate p 0) = 0 := by
+  ext i
+  simp only [coeff_truncate, Nat.not_lt_zero, ↓reduceIte]
+  rfl
 
 @[simp]
 lemma natDegree_truncate [φ : NeZero n] : (truncate p n).natDegree < n := by

--- a/ArkLib/Data/CodingTheory/PolishchukSpielman/Degrees.lean
+++ b/ArkLib/Data/CodingTheory/PolishchukSpielman/Degrees.lean
@@ -107,24 +107,19 @@ lemma ps_coeff_mul_sum_monomial {R : Type} [CommRing R]
   grind only [cases Or]
 
 private lemma ps_swap_coeff {F : Type} [CommRing F] (g : F[X][Y]) (i j : ℕ) :
-    Bivariate.coeff (swap g) i j = Bivariate.coeff g j i := by
-  have h_swap_coeff : ∀ (g : F[X][Y]) (i j : ℕ),
-      Bivariate.coeff (swap g) i j = Bivariate.coeff g j i := by
-    unfold Bivariate.coeff
-    -- By definition of swap, we have that swap g = ∑ i, ∑ j, g.coeff j * X^i * Y^j.
-    have h_swap_def : ∀ g : F[X][Y], swap g = ∑ i ∈ g.support,
-        ∑ j ∈ (g.coeff i).support, monomial j (monomial i ((g.coeff i).coeff j)) := by
-      intro g
-      simp [swap, eval_finsetSum, aeval_def, eval₂_eq_sum, sum_def,
-        ← C_mul_X_pow_eq_monomial, Finset.sum_mul _ _ _ ]
-      ac_rfl
-    simp only [h_swap_def, finsetSum_coeff, coeff_monomial, sum_ite_eq', mem_support_iff, ne_eq]
-    intro g i j
-    rw [Finset.sum_eq_single i] <;> simp_all only [swap_apply, mem_support_iff, ne_eq]
-    · split_ifs <;> simp_all
-    · intro b hb hb'; split_ifs <;> simp_all [coeff_monomial]
-    · push Not; intro h; simp [h]
-  exact h_swap_coeff g i j
+    ((swap g).coeff j).coeff i = (g.coeff i).coeff j := by
+  -- By definition of swap, we have that swap g = ∑ i, ∑ j, g.coeff j * X^i * Y^j.
+  have h_swap_def : ∀ g : F[X][Y], swap g = ∑ i ∈ g.support,
+      ∑ j ∈ (g.coeff i).support, monomial j (monomial i ((g.coeff i).coeff j)) := by
+    intro g
+    simp [swap, eval_finsetSum, aeval_def, eval₂_eq_sum, sum_def,
+      ← C_mul_X_pow_eq_monomial, Finset.sum_mul _ _ _ ]
+    ac_rfl
+  simp only [h_swap_def, finsetSum_coeff, coeff_monomial, sum_ite_eq', mem_support_iff, ne_eq]
+  rw [Finset.sum_eq_single i] <;> simp_all only [swap_apply, mem_support_iff, ne_eq]
+  · split_ifs <;> simp_all
+  · intro b hb hb'; split_ifs <;> simp_all [coeff_monomial]
+  · push Not; intro h; simp [h]
 
 private lemma ps_degree_x_swap_le {F : Type} [CommRing F] (f : F[X][Y]) :
     degreeX (swap f) ≤ natDegreeY f := by
@@ -135,7 +130,7 @@ private lemma ps_degree_x_swap_le {F : Type} [CommRing F] (f : F[X][Y]) :
   obtain ⟨m, hm⟩ : ∃ m > f.natDegree, ((swap f).coeff n).coeff m ≠ 0 := by
     exact ⟨((swap f).coeff n).natDegree, hn.2.2.2, by aesop⟩
   have h_coeff_swap : ((swap f).coeff n).coeff m = (f.coeff m).coeff n := by
-    convert ps_swap_coeff f m n using 1 <;> rfl
+    exact ps_swap_coeff f m n
   exact hm.2 (h_coeff_swap.symm ▸ by rw [coeff_eq_zero_of_natDegree_lt hm.1]; aesop)
 
 private lemma ps_degree_x_swap_ge {F : Type} [CommRing F] (f : F[X][Y]) (hf : f ≠ 0) :
@@ -146,8 +141,8 @@ private lemma ps_degree_x_swap_ge {F : Type} [CommRing F] (f : F[X][Y]) (hf : f 
   obtain ⟨n, hn⟩ : ∃ n, n = (f.coeff N).natDegree ∧ (f.coeff N).coeff n ≠ 0 := by
     contrapose! hN; aesop;
   have h_swap_coeff_nonzero : ((swap f).coeff n).coeff N ≠ 0 := by
-    convert hn.2 using 1;
-    convert ps_swap_coeff f N n using 1 <;> rfl
+    rw [ps_swap_coeff f N n]
+    exact hn.2
   have h_swap_coeff_nonzero_natDegree : (swap f).coeff n ≠ 0 :=
     (ne_of_apply_ne Polynomial.coeff fun a ↦ h_swap_coeff_nonzero (congrFun a.symm N)).symm
   have h_swap_coeff_nonzero_natDegree_le : Nat.max (((swap f).coeff n).natDegree)

--- a/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGap/Folding.lean
@@ -376,7 +376,7 @@ theorem foldWord_codeword {d : ℕ} [FoldingContext k d n]
     toPolynomial, LinearMap.coe_mk, AddHom.coe_mk,
     FoldingPolynomial.polyFold]
   rw [eval_comm, interpolate_eq_folding_poly_eval (by simp)]
-  aesop
+  rfl
 
 theorem foldWord_evalOnPoints [FoldingContextMiddle k n]
     {α : F} {p : Polynomial F}

--- a/ArkLib/Data/MvPolynomial/EvenAndOdd.lean
+++ b/ArkLib/Data/MvPolynomial/EvenAndOdd.lean
@@ -220,17 +220,40 @@ private lemma shiftDown_shiftUp_eq (q : MvPolynomial (Fin n) R) :
     change i.val - 1 + 1 = i.val
     omega
 
+private lemma substNoX0_eq_self_of_aeval (c : R) (q : MvPolynomial (Fin n) R) :
+    (q.aeval (fun i ↦ if i = 0 then C c else X i)).aeval
+      (fun i ↦ if i = 0 then 0 else X i) =
+        q.aeval (fun i ↦ if i = 0 then C c else X i) := by
+  induction q using MvPolynomial.induction_on with
+  | C a => simp
+  | add q r hq hr => simp only [map_add, hq, hr]
+  | mul_X q i hq =>
+    simp only [map_mul, aeval_X]
+    rw [hq]
+    by_cases hi : i = 0
+    · subst i
+      simp
+    · simp only [hi, ↓reduceIte, aeval_X]
+
+private lemma substNoX0_eq_self_of_substPlus (q : MvPolynomial (Fin n) R) :
+    (substPlus q).aeval (fun i ↦ if i = 0 then 0 else X i) = substPlus q := by
+  simpa only [substPlus, map_one] using substNoX0_eq_self_of_aeval 1 q
+
+private lemma substNoX0_eq_self_of_substMinus (q : MvPolynomial (Fin n) R) :
+    (substMinus q).aeval (fun i ↦ if i = 0 then 0 else X i) = substMinus q := by
+  simpa only [substMinus, map_neg, map_one] using substNoX0_eq_self_of_aeval (-1) q
+
 private lemma substNoX0_eq_self_of_even
   (p : restrictDegree (Fin n) R 1) :
   (even p).1.aeval
     (fun i : Fin n ↦
       if _ : i = (0 : Fin n) then (0 : MvPolynomial (Fin n) R) else X i) = (even p).1 := by
   unfold even
-  simp only [aeval_eq_bind₁, substPlus, substMinus, map_mul, map_add, algHom_C, algebraMap_eq,
-    mul_eq_mul_right_iff, map_eq_zero, inv_eq_zero]
-  left
-  congr! 1
-  all_goals induction p.val using MvPolynomial.induction_on <;> aesop
+  simp only [map_mul, map_add, algHom_C, algebraMap_eq]
+  exact congrArg (fun q : MvPolynomial (Fin n) R ↦ q * C (2⁻¹))
+    (congrArg₂ (fun a b ↦ a + b)
+      (substNoX0_eq_self_of_substPlus p.val)
+      (substNoX0_eq_self_of_substMinus p.val))
 
 private lemma substNoX0_eq_self_of_odd
   (p : restrictDegree (Fin n) R 1) :
@@ -238,10 +261,11 @@ private lemma substNoX0_eq_self_of_odd
     (fun i : Fin n ↦
       if _ : i = (0 : Fin n) then (0 : MvPolynomial (Fin n) R) else X i) = (odd p).1 := by
   unfold odd
-  unfold MvPolynomial.substPlus MvPolynomial.substMinus
-  simp only [aeval_eq_bind₁, sub_mul, map_sub, map_mul, algHom_C, algebraMap_eq]
-  congr! 2
-  all_goals induction p.val using MvPolynomial.induction_on <;> aesop
+  simp only [map_mul, map_sub, algHom_C, algebraMap_eq]
+  exact congrArg (fun q : MvPolynomial (Fin n) R ↦ q * C (2⁻¹))
+    (congrArg₂ (fun a b ↦ a - b)
+      (substNoX0_eq_self_of_substPlus p.val)
+      (substNoX0_eq_self_of_substMinus p.val))
 
 -- For the case m 0 ≠ 0: the product contains a zero factor
 private lemma aeval_shift_monomial_zero_case {n : ℕ} [NeZero n]

--- a/ArkLib/Data/Polynomial/FoldingPolynomial.lean
+++ b/ArkLib/Data/Polynomial/FoldingPolynomial.lean
@@ -401,8 +401,8 @@ lemma eval_property_of_folding_polynomial {q f : F[X]} {x : F} :
 lemma eval_property_of_folding_polynomial_x_k {f : F[X]} {k : ℕ} {x : F} :
     ((foldingPolynomial (X ^ k) f).map (Polynomial.evalRingHom (x ^ k))).eval x =
     f.eval x := by
-  have := eval_property_of_folding_polynomial (f := f) (q := X ^ k) (x := x)
-  aesop
+  simpa only [Polynomial.eval_X_pow] using
+    (eval_property_of_folding_polynomial (f := f) (q := X ^ k) (x := x))
 
 /-- The degree of `foldingPolynomial` is less than `q.degree` in the second variable,
   when `q` is not a constant polynomial.

--- a/ArkLib/Data/Polynomial/SplitFold.lean
+++ b/ArkLib/Data/Polynomial/SplitFold.lean
@@ -122,7 +122,10 @@ private lemma splitNthNoncomputable_coeff {n : ℕ} {f : 𝔽[X]} (i : Fin n) (m
   · aesop (add safe [cases Fin, (by omega)])
 
 private lemma splitNth_eq_splitNthNoncomputable {n : ℕ} {f : 𝔽[X]} :
-  splitNth f n = splitNthNoncomputable f n := by aesop
+  splitNth f n = splitNthNoncomputable f n := by
+  funext i
+  ext m
+  rw [splitNth_coeff, splitNthNoncomputable_coeff]
 
 /-- The key identity `splitNth` satisfies: `f` is recovered from its `n` components. -/
 lemma eq_sum_splitNth (n : ℕ) [inst : NeZero n] (f : 𝔽[X]) :
@@ -224,7 +227,9 @@ theorem foldingPolynomial_sum {𝔽 : Type} [Field 𝔽]
     {n : ℕ} {u : Fin n → 𝔽[X]} [inst : NeZero n] :
   FoldingPolynomial.foldingPolynomial (X ^ n)
     (∑ i, Polynomial.X ^ i.val * (u i).comp (Polynomial.X ^ n)) =
-      ∑ i, Polynomial.X ^ i.val * C (u i) := by simp_all
+      ∑ i, Polynomial.X ^ i.val * C (u i) := by
+  rw [folding_polynomial_eq_sum_splitNth]
+  simp only [splitNth_of_sum_comp, mul_comm]
 
 /-- `polyFold` of an `n`-way recombination `∑ i, X^i * (u i)(X^n)` is the
     polynomial `∑ i, r^i * u i`. -/
@@ -234,11 +239,8 @@ theorem polyFold_sum {𝔽 : Type} [Field 𝔽] {r : 𝔽}
   FoldingPolynomial.polyFold
     (∑ i, Polynomial.X ^ i.val * (u i).comp (Polynomial.X ^ n)) n r =
       ∑ i, r ^ i.val • (u i) := by
-  aesop
-    (add simp [FoldingPolynomial.polyFold,
-               Polynomial.eval_finsetSum,
-               Polynomial.smul_eq_C_mul])
-    (add safe (by grind))
+  rw [polyFold_eq_sum_of_splitNth]
+  simp only [splitNth_of_sum_comp, Polynomial.smul_eq_C_mul]
 
 /--
 Lemma bridges the coefficient-level identity `eq_sum_splitNth` and

--- a/ArkLib/ProofSystem/Stir/Combine.lean
+++ b/ArkLib/ProofSystem/Stir/Combine.lean
@@ -130,7 +130,7 @@ private lemma block_start_filter_nonempty
   {dstar : ℕ} {degs : Fin m.succ → ℕ} {l : ℕ} :
   (univ.filter (fun j ↦ block_start dstar degs j ≤ l)).Nonempty := by
   exists 0
-  aesop (add simp [block_start])
+  simp [block_start]
 
 private lemma block_idx_eq_max
   {dstar : ℕ} {degs : Fin m → ℕ}
@@ -276,8 +276,10 @@ private lemma combine_eq_flat'
   exact Finset.sum_equiv (Equiv.refl _) (by simp) <| fun i hi ↦ by
     have h : Finset.max {j | block_start dstar degs j ≤ i} =
       Finset.max' {j | block_start dstar degs j ≤ i} block_start_filter_nonempty := by
-        aesop (add simp [Finset.max, Finset.max'])
-    aesop
+      exact (Finset.coe_max' block_start_filter_nonempty).symm
+    rw [h]
+    simp [Finset.mem_range.mp hi]
+    rfl
 
 omit [DecidableEq F] in
 private lemma combine_eq_flat''
@@ -340,7 +342,9 @@ private lemma combine_eq_flat'''
     rw [show filter _ _ = Finset.Iio i by
       ext j
       simp only [mem_filter, mem_univ, true_and, mem_Iio]]
-    aesop (add safe (by ring))
+    left
+    simp only [Fin.card_Iio]
+    ring
 
 omit [DecidableEq F] in
 private lemma combine_eq_flat_final
@@ -363,7 +367,7 @@ private lemma combine_eq_flat_final
       Finset.max {j | block_start dstar degs j ≤ ↑l} =
         Finset.max' {j | block_start dstar degs j ≤ ↑l}
           block_start_filter_nonempty := by
-      aesop (add simp [Finset.max, Finset.max'])
+      exact (Finset.coe_max' block_start_filter_nonempty).symm
     rw [combine_eq_flat''' φ dstar r fs degs]
     funext x
     simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,26 @@ We aim for consistent representations of equivalent statements:
 
 ### Tactic Mode & Performance
 
-* **Squeezing Simp**: Do not "squeeze" terminal `simp` calls (replacing `simp` with `simp only [...]`) unless necessary for performance or stability. Un-squeezed `simp` is often more readable and robust to minor library changes.
+* **Expose the mathematical structure**: Prefer proofs whose intermediate statements and named
+  helper lemmas make the argument visible. If the same induction, extensionality argument, cast,
+  or normalization step recurs, look for a missing lemma in the module that owns the underlying
+  definition.
+* **Use automation on well-scoped goals**: `simp`, `aesop`, `grind`, `omega`, `linarith`, and
+  `nlinarith` are all acceptable. They are best used as terminal steps, or after an explicit
+  transformation that leaves a clear goal. Avoid using broad automation as an intermediate step
+  before a tactic that depends on a particular goal shape.
+* **Profile before rewriting for speed**: For a slow proof, use Lean's profiler to locate the
+  expensive declaration and tactic. Then consider narrower imports, fewer local hypotheses,
+  `simp only`, `grind only`, `linarith only`, or `nlinarith only`, or replace repeated search with
+  a reusable structural lemma. Do not perform repository-wide mechanical tactic substitutions
+  without measured evidence.
+* **Do not squeeze stable terminal `simp` calls by default**: Replacing a short terminal `simp`
+  with a long `simp only [...]` list can obscure the important lemmas and make renames more
+  disruptive. Squeeze when it improves stability or produces a measured performance benefit.
+  This follows Mathlib's guidance on
+  [squeezing simp calls](https://leanprover-community.github.io/contribute/style.html#squeezing-simp-calls),
+  [nonterminal simplification](https://leanprover-community.github.io/extras/simp.html#non-terminal-simps),
+  and [profiling slow proofs](https://leanprover-community.github.io/extras/speedup.html).
 * **Comments**: Use `--` for inline comments and `/- ... -/` for block comments.
 
 ### Transparency and API Design


### PR DESCRIPTION
## Summary

This PR replaces expensive broad proof search with explicit structural arguments in seven measured
hotspot modules, while documenting a Mathlib-aligned automation policy for future contributors and
agents.

It deliberately does not ban tactics or add diagnostic/count gates. Broad automation remains
welcome when it closes a well-scoped goal clearly and quickly.

### Diff metadata

- Base: `17338c9146db628ee71b924b6824ca91919198cf` (`main`)
- Head: `edb261ffad1a27c4f5350aec15a8e6641791b4c8`
- Commits: 1
- Files changed: 9
- Diff: 102 insertions, 48 deletions

## Motivation

ArkLib still contained proofs where `aesop`, `simp_all`, or automation-triggered unfolding was
solving goals that already had a direct owner-level lemma or structural induction. Besides hiding
the argument, these proofs repeatedly paid for simplification, typeclass inference, congruence,
and definitional-equality search.

This pass follows measured cost rather than mechanically rewriting every automation call.

## Change surface

| Area | Before | After |
|---|---|---|
| Even/odd substitution | Two repeated `congr!` + Aesop inductions | One reusable structural `aeval` lemma, specialized to plus/minus |
| Polynomial split/fold | Broad search rediscovered existing bridge theorems | Direct coefficient extensionality and named split/fold rewrites |
| Polynomial coordinate swap | Consumers crossed `Bivariate.coeff` through expensive `convert ...; rfl` | Private coefficient lemma states the representation actually consumed |
| STIR flattening | Aesop unfolded finite maxima and searched algebraic side goals | `Finset.coe_max'`, explicit range facts, and direct ring reasoning |
| Small specialization proofs | Aesop for direct extensional/definitional consequences | `funext`, `simpa only`, or `rfl` after named rewrites |
| Contributor policy | One note about terminal `simp` | Guidance on owner-level lemmas, well-scoped automation, profiling, and context narrowing |

Repository-wide lexical counts under `ArkLib/**/*.lean` change as follows:

| Tactic | Base | Head | Change |
|---|---:|---:|---:|
| `aesop` | 538 | 525 | -13 |
| `simp_all` | 228 | 227 | -1 |
| `grind` | 186 | 185 | -1 |

These counts are descriptive, not a new policy gate.

## Measured proof-checking effects

Local single-module profiles used `--profile -Dprofiler.threshold=100`. Cumulative categories can
overlap and are not wall-clock totals, but they identify the proof work removed by this diff.

| Module | Selected cumulative profiler reductions |
|---|---|
| `EvenAndOdd` | `aesop` 2.36s -> 0.71s; `simp` 21.1s -> 8.97s; tactic execution 10.0s -> 4.95s; typeclass inference 15.8s -> 7.47s |
| `SplitFold` | `simp` 7.06s -> 4.26s; tactic execution 12.6s -> 4.73s |
| Polishchuk-Spielman `Degrees` | `aesop` 3.92s -> 1.46s; `simp` 22.0s -> 5.16s; tactic execution 13.1s -> 3.24s; typeclass inference 10.6s -> 2.75s |
| STIR `Combine` | `aesop` 1.20s -> 0.62s; `simp` 21.4s -> 11.3s; typeclass inference 16.8s -> 9.33s |
| Berlekamp-Welch `Condition` | `aesop` 3.35s -> 2.15s; `simp` 7.34s -> 5.82s; typeclass inference 6.96s -> 5.15s |

## Mathlib alignment

The new guidance follows Mathlib's current position rather than imposing a local anti-automation
rule:

- keep short, stable terminal `simp` calls unless squeezing improves stability or measured speed;
- avoid broad nonterminal simplification when a later tactic depends on a precise goal shape;
- profile slow proofs first, then narrow imports, hypotheses, simp sets, or solver rule sets;
- accept `aesop`, `grind`, `omega`, `linarith`, and `nlinarith` on well-scoped terminal goals.

The contributor guide links Mathlib's style, simplification, and proof-profiling documentation.

## Compatibility and trust

- No exported declaration statement or public API changes.
- New helpers are private and consumed within their owner module.
- No new `sorry`, axiom, unsafe/native trust, linter suppression, import, or heartbeat override.
- No automation ban, lexical enforcement, diagnostic job, or CI timing gate.

## Validation completed at `edb261ff`

`LAKE_ARTIFACT_CACHE=false LAKE_NO_CACHE=true ./scripts/validate.sh --lint --axioms` passed:

- full `lake build`;
- zero non-`sorry` warnings under `ArkLib/Data`;
- toy-problem and nonrecursive-Hachi compiled runtime checks;
- umbrella import, timing-fixture, docs-integrity, and knowledge-base checks;
- axiom-sweep fixture matrix and repository baseline (`11026` declarations, `314` existing
  `sorryAx`-tainted declarations, no regression);
- Lean style lint.

All seven changed Lean modules also compiled directly and as explicit Lake targets.

## Reviewer map

1. `ArkLib/Data/MvPolynomial/EvenAndOdd.lean`
2. `ArkLib/Data/Polynomial/SplitFold.lean`
3. `ArkLib/Data/CodingTheory/PolishchukSpielman/Degrees.lean`
4. `ArkLib/ProofSystem/Stir/Combine.lean`
5. The smaller Berlekamp-Welch, folding-polynomial, and proximity-folding rewrites
6. `CONTRIBUTING.md` and `AGENTS.md`
