### PR TITLE
feat(interaction): add dependent reduction kernel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@ Start with [`README.md`](README.md) for project overview.
 ## Where To Work
 
 - `ArkLib/Data/` - reusable math, coding theory, polynomials, and supporting definitions.
-- `ArkLib/OracleReduction/` - core IOR abstractions and security theory.
+- `ArkLib/Interaction/` - typed interactions and dependent reduction foundations.
+- `ArkLib/OracleReduction/` - legacy IOR abstractions and security theory.
 - `ArkLib/ProofSystem/` - protocol formalizations built on the core.
 - `ArkLib/Commitments/` - commitments and opening arguments.
 - `ArkLib/ToMathlib/` - local extensions intended for upstreaming.

--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -277,6 +277,8 @@ import ArkLib.Data.Probability.Combinatorial
 import ArkLib.Data.Probability.Instances
 import ArkLib.Data.Probability.KoalaBear
 import ArkLib.Data.Probability.Notation
+import ArkLib.Interaction.Reduction
+import ArkLib.Interaction.Reduction.DependentExample
 import ArkLib.OracleReduction.BCS.Basic
 import ArkLib.OracleReduction.Basic
 import ArkLib.OracleReduction.Cast

--- a/ArkLib/Interaction/Reduction.lean
+++ b/ArkLib/Interaction/Reduction.lean
@@ -28,12 +28,12 @@ There are two distinct execution laws in PolyFun:
 * `TwoParty.run_comp_append` factors a general effectful suffix constructor under
   `TwoParty.LawfulCommMonad`.
 
-ArkLib's prover setup is effectful in general, so `Reduction.run_comp` deliberately exposes the
-second boundary. Stateful clients without commutative effects must thread state explicitly rather
-than use this factorization theorem.
+ArkLib's prover setup is effectful in general, so `Reduction.execute_comp` deliberately exposes
+the second boundary. Stateful clients without commutative effects must thread state explicitly
+rather than use this factorization theorem.
 -/
 
-universe u v w
+universe u v w x
 
 namespace Interaction
 
@@ -84,6 +84,21 @@ theorem splitLiftAppend_packAppend
   PFunctor.FreeM.Path.liftAppendProd_packAppend
     ctx₁ ctx₂ StatementOut WitnessOut tr₁ tr₂ out
 
+/-- Split the honest-prover payload in a complete run of an appended interaction. -/
+def splitLiftAppendRun
+    (ctx₁ : TypeTree) (ctx₂ : TypeTree.Path ctx₁ → TypeTree)
+    (StatementOut WitnessOut : (tr₁ : TypeTree.Path ctx₁) → TypeTree.Path (ctx₂ tr₁) → Type u)
+    (run : (tr : TypeTree.Path (ctx₁.append ctx₂)) ×
+      PFunctor.FreeM.Path.liftAppend ctx₁ ctx₂
+        (fun tr₁ tr₂ => HonestProverOutput (StatementOut tr₁ tr₂) (WitnessOut tr₁ tr₂)) tr ×
+      PFunctor.FreeM.Path.liftAppend ctx₁ ctx₂ StatementOut tr) :
+    ((tr : TypeTree.Path (ctx₁.append ctx₂)) ×
+      HonestProverOutput
+        (PFunctor.FreeM.Path.liftAppend ctx₁ ctx₂ StatementOut tr)
+        (PFunctor.FreeM.Path.liftAppend ctx₁ ctx₂ WitnessOut tr) ×
+      PFunctor.FreeM.Path.liftAppend ctx₁ ctx₂ StatementOut tr) :=
+  ⟨run.1, splitLiftAppend ctx₁ ctx₂ StatementOut WitnessOut run.1 run.2.1, run.2.2⟩
+
 end HonestProverOutput
 
 /-- A prover performs monadic setup and returns the focal strategy for the selected input. -/
@@ -91,7 +106,8 @@ abbrev Prover (m : Type u → Type u)
     (SharedIn : Type v)
     (Context : SharedIn → TypeTree)
     (Roles : (i : SharedIn) → RoleDecoration (Context i))
-    (StatementIn WitnessIn : SharedIn → Type w)
+    (StatementIn : SharedIn → Type w)
+    (WitnessIn : SharedIn → Type x)
     (StatementOut WitnessOut : (i : SharedIn) → TypeTree.Path (Context i) → Type u) :=
   (i : SharedIn) → StatementIn i → WitnessIn i →
     m (StrategyOver (SyntaxOver.TwoParty.pairedTypeTree m) Participant.focal
@@ -114,7 +130,8 @@ structure Reduction (m : Type u → Type u)
     (SharedIn : Type v)
     (Context : SharedIn → TypeTree)
     (Roles : (i : SharedIn) → RoleDecoration (Context i))
-    (StatementIn WitnessIn : SharedIn → Type w)
+    (StatementIn : SharedIn → Type w)
+    (WitnessIn : SharedIn → Type x)
     (StatementOut WitnessOut : (i : SharedIn) → TypeTree.Path (Context i) → Type u) where
   prover : Prover m SharedIn Context Roles StatementIn WitnessIn StatementOut WitnessOut
   verifier : Verifier m SharedIn Context Roles StatementIn StatementOut
@@ -126,7 +143,8 @@ def Reduction.execute {m : Type u → Type u} [Monad m]
     {SharedIn : Type v}
     {Context : SharedIn → TypeTree}
     {Roles : (i : SharedIn) → RoleDecoration (Context i)}
-    {StatementIn WitnessIn : SharedIn → Type w}
+    {StatementIn : SharedIn → Type w}
+    {WitnessIn : SharedIn → Type x}
     {StatementOut WitnessOut : (i : SharedIn) → TypeTree.Path (Context i) → Type u}
     (reduction : Reduction m SharedIn Context Roles StatementIn WitnessIn StatementOut WitnessOut)
     (i : SharedIn) (stmt : StatementIn i) (wit : WitnessIn i) :
@@ -140,7 +158,8 @@ theorem Reduction.execute_eq_run {m : Type u → Type u} [Monad m]
     {SharedIn : Type v}
     {Context : SharedIn → TypeTree}
     {Roles : (i : SharedIn) → RoleDecoration (Context i)}
-    {StatementIn WitnessIn : SharedIn → Type w}
+    {StatementIn : SharedIn → Type w}
+    {WitnessIn : SharedIn → Type x}
     {StatementOut WitnessOut : (i : SharedIn) → TypeTree.Path (Context i) → Type u}
     (reduction : Reduction m SharedIn Context Roles StatementIn WitnessIn StatementOut WitnessOut)
     (i : SharedIn) (stmt : StatementIn i) (wit : WitnessIn i) :
@@ -172,7 +191,8 @@ Its statement and witness inputs are exactly the first reduction's outputs. The 
 families use `PFunctor.FreeM.Path.liftAppend`, preserving their dependence on both paths. -/
 def Reduction.comp {m : Type u → Type u} [Monad m]
     {SharedIn : Type v}
-    {StatementIn WitnessIn : SharedIn → Type w}
+    {StatementIn : SharedIn → Type w}
+    {WitnessIn : SharedIn → Type x}
     {ctx₁ : SharedIn → TypeTree}
     {roles₁ : (i : SharedIn) → RoleDecoration (ctx₁ i)}
     {StmtMid WitMid : (i : SharedIn) → TypeTree.Path (ctx₁ i) → Type u}
@@ -191,7 +211,7 @@ def Reduction.comp {m : Type u → Type u} [Monad m]
       (fun shared tr₂ => WitOut shared.1 shared.2.2 tr₂)) :
     Reduction m SharedIn
       (fun i => (ctx₁ i).append (ctx₂ i))
-      (fun i => (roles₁ i).append (roles₂ i))
+      (fun i => (roles₁ i).append (fun tr₁ => roles₂ i tr₁))
       StatementIn WitnessIn
       (fun i => PFunctor.FreeM.Path.liftAppend (ctx₁ i) (ctx₂ i) (StmtOut i))
       (fun i => PFunctor.FreeM.Path.liftAppend (ctx₁ i) (ctx₂ i) (WitOut i)) where
@@ -206,16 +226,18 @@ def Reduction.comp {m : Type u → Type u} [Monad m]
     StrategyOver.TwoParty.Counterpart.append (reduction₁.verifier i stmt) (fun tr₁ stmtMid =>
       reduction₂.verifier ⟨i, stmt, tr₁⟩ stmtMid)
 
-/-- The raw strategy used by `Reduction.comp` factors into prefix execution followed by the
-path-indexed suffix execution.
+/-- Executing a composed reduction factors into prefix execution and its path-indexed suffix.
 
-This is the general effectful factorization law and therefore requires
-`TwoParty.LawfulCommMonad`. The pure-suffix counterpart is PolyFun's
-`TwoParty.run_compFlat_appendFlat_pure`, which only requires `LawfulMonad`. -/
-theorem Reduction.run_comp
+The final `splitLiftAppendRun` map only converts PolyFun's factored honest-prover payload into
+ArkLib's separately lifted statement and witness outputs. All interaction effects occur in the two
+executions inside the mapped computation. General effectful suffix construction requires
+`TwoParty.LawfulCommMonad`; use PolyFun's `TwoParty.run_compFlat_appendFlat_pure` when the suffix
+constructor is pure and only `LawfulMonad` is available. -/
+theorem Reduction.execute_comp
     {m : Type u → Type u} [Monad m] [TwoParty.LawfulCommMonad m]
     {SharedIn : Type v}
-    {StatementIn WitnessIn : SharedIn → Type w}
+    {StatementIn : SharedIn → Type w}
+    {WitnessIn : SharedIn → Type x}
     {ctx₁ : SharedIn → TypeTree}
     {roles₁ : (i : SharedIn) → RoleDecoration (ctx₁ i)}
     {StmtMid WitMid : (i : SharedIn) → TypeTree.Path (ctx₁ i) → Type u}
@@ -234,17 +256,10 @@ theorem Reduction.run_comp
       (fun shared tr₂ => StmtOut shared.1 shared.2.2 tr₂)
       (fun shared tr₂ => WitOut shared.1 shared.2.2 tr₂))
     (i : SharedIn) (stmt : StatementIn i) (wit : WitnessIn i) :
-    (do
-      let strategy₁ ← reduction₁.prover i stmt wit
-      let strategy ← StrategyOver.TwoParty.Focal.comp strategy₁ (fun tr₁ midOut =>
-        reduction₂.prover ⟨i, stmt, tr₁⟩ midOut.stmt midOut.wit)
-      TwoParty.run ((ctx₁ i).append (ctx₂ i)) ((roles₁ i).append (roles₂ i)) strategy
-        (StrategyOver.TwoParty.Counterpart.append (reduction₁.verifier i stmt) (fun tr₁ stmtMid =>
-          reduction₂.verifier ⟨i, stmt, tr₁⟩ stmtMid))) =
-      (do
-        let strategy₁ ← reduction₁.prover i stmt wit
-        let ⟨tr₁, midOut, stmtMid⟩ ←
-          TwoParty.run (ctx₁ i) (roles₁ i) strategy₁ (reduction₁.verifier i stmt)
+    (Reduction.comp reduction₁ reduction₂).execute i stmt wit =
+      HonestProverOutput.splitLiftAppendRun
+        (ctx₁ i) (ctx₂ i) (StmtOut i) (WitOut i) <$> (do
+        let ⟨tr₁, midOut, stmtMid⟩ ← reduction₁.execute i stmt wit
         let strategy₂ ← reduction₂.prover ⟨i, stmt, tr₁⟩ midOut.stmt midOut.wit
         let ⟨tr₂, out, stmtOut⟩ ←
           TwoParty.run (ctx₂ i tr₁) (roles₂ i tr₁) strategy₂
@@ -253,14 +268,60 @@ theorem Reduction.run_comp
           PFunctor.FreeM.Path.packAppend (ctx₁ i) (ctx₂ i)
             (fun tr₁ tr₂ => HonestProverOutput (StmtOut i tr₁ tr₂) (WitOut i tr₁ tr₂))
             tr₁ tr₂ out,
-          PFunctor.FreeM.Path.packAppend (ctx₁ i) (ctx₂ i) (StmtOut i)
+          PFunctor.FreeM.Path.packAppend (ctx₁ i) (ctx₂ i) (fun tr₁ tr₂ => StmtOut i tr₁ tr₂)
             tr₁ tr₂ stmtOut⟩) := by
+  simp only [execute, comp, bind_assoc, pure_bind, map_bind, map_pure]
   refine congrArg (fun k => reduction₁.prover i stmt wit >>= k) ?_
   funext strategy₁
-  exact TwoParty.run_comp_append
-    (strat₁ := strategy₁)
-    (f := fun tr₁ midOut => reduction₂.prover ⟨i, stmt, tr₁⟩ midOut.stmt midOut.wit)
-    (cpt₁ := reduction₁.verifier i stmt)
-    (cpt₂ := fun tr₁ stmtMid => reduction₂.verifier ⟨i, stmt, tr₁⟩ stmtMid)
+  let mapOut := HonestProverOutput.splitLiftAppend
+    (ctx₁ i) (ctx₂ i) (StmtOut i) (WitOut i)
+  let mapRun :
+      ((tr : TypeTree.Path ((ctx₁ i).append (ctx₂ i))) ×
+        PFunctor.FreeM.Path.liftAppend (ctx₁ i) (ctx₂ i)
+          (fun tr₁ tr₂ => HonestProverOutput (StmtOut i tr₁ tr₂) (WitOut i tr₁ tr₂)) tr ×
+        PFunctor.FreeM.Path.liftAppend (ctx₁ i) (ctx₂ i) (StmtOut i) tr) →
+      ((tr : TypeTree.Path ((ctx₁ i).append (ctx₂ i))) ×
+        HonestProverOutput
+          (PFunctor.FreeM.Path.liftAppend (ctx₁ i) (ctx₂ i) (StmtOut i) tr)
+          (PFunctor.FreeM.Path.liftAppend (ctx₁ i) (ctx₂ i) (WitOut i) tr) ×
+        PFunctor.FreeM.Path.liftAppend (ctx₁ i) (ctx₂ i) (StmtOut i) tr) :=
+    HonestProverOutput.splitLiftAppendRun
+      (ctx₁ i) (ctx₂ i) (StmtOut i) (WitOut i)
+  let counterpart := StrategyOver.TwoParty.Counterpart.append
+    (reduction₁.verifier i stmt) (fun tr₁ stmtMid =>
+      reduction₂.verifier ⟨i, stmt, tr₁⟩ stmtMid)
+  have hmap :
+      (do
+        let strategy ← StrategyOver.TwoParty.Focal.comp strategy₁ (fun tr₁ midOut =>
+          reduction₂.prover ⟨i, stmt, tr₁⟩ midOut.stmt midOut.wit)
+        TwoParty.run ((ctx₁ i).append (ctx₂ i))
+          ((roles₁ i).append (fun tr₁ => roles₂ i tr₁))
+          (StrategyOver.TwoParty.Focal.mapOutput mapOut strategy) counterpart) =
+        (do
+          let strategy ← StrategyOver.TwoParty.Focal.comp strategy₁ (fun tr₁ midOut =>
+            reduction₂.prover ⟨i, stmt, tr₁⟩ midOut.stmt midOut.wit)
+          mapRun <$>
+            TwoParty.run ((ctx₁ i).append (ctx₂ i))
+            ((roles₁ i).append (fun tr₁ => roles₂ i tr₁)) strategy counterpart) := by
+    refine congrArg
+      (fun k => StrategyOver.TwoParty.Focal.comp strategy₁ (fun tr₁ midOut =>
+        reduction₂.prover ⟨i, stmt, tr₁⟩ midOut.stmt midOut.wit) >>= k) ?_
+    funext strategy
+    have mapRun_eq : mapRun =
+        fun z => ⟨z.1, mapOut z.1 z.2.1, z.2.2⟩ := rfl
+    rw [mapRun_eq]
+    simpa only [StrategyOver.TwoParty.Counterpart.mapOutput_id] using
+      (TwoParty.run_mapOutput_mapOutput
+        (fP := mapOut) (fC := fun _ out => out) strategy counterpart)
+  rw [hmap]
+  convert congrArg (fun run => mapRun <$> run) (TwoParty.run_comp_append
+      (r₂ := fun tr₁ => roles₂ i tr₁)
+      (FP := fun tr₁ tr₂ => HonestProverOutput (StmtOut i tr₁ tr₂) (WitOut i tr₁ tr₂))
+      (FC := fun tr₁ tr₂ => StmtOut i tr₁ tr₂)
+      (strat₁ := strategy₁)
+      (f := fun tr₁ midOut => reduction₂.prover ⟨i, stmt, tr₁⟩ midOut.stmt midOut.wit)
+      (cpt₁ := reduction₁.verifier i stmt)
+      (cpt₂ := fun tr₁ stmtMid => reduction₂.verifier ⟨i, stmt, tr₁⟩ stmtMid)) using 1 <;>
+    simp only [mapRun, counterpart, map_bind, map_pure] <;> rfl
 
 end Interaction

--- a/ArkLib/Interaction/Reduction.lean
+++ b/ArkLib/Interaction/Reduction.lean
@@ -1,0 +1,266 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import PolyFun.Interaction.TwoParty.Compose
+
+/-!
+# Plain dependent reductions
+
+This file packages the smallest ArkLib reduction layer over PolyFun's typed interaction trees.
+A reduction pairs:
+
+* a focal prover strategy, constructed monadically from a statement and witness; and
+* a counterpart verifier strategy, constructed from the same public statement.
+
+The interaction tree, role decoration, and terminal output families may all depend on the shared
+input. `Reduction.execute` is only a transparent wrapper around `TwoParty.run`.
+
+## Sequential composition
+
+`Reduction.comp` appends a second reduction whose tree and roles may depend on the complete first
+path. The first prover and verifier outputs become the second reduction's inputs.
+
+There are two distinct execution laws in PolyFun:
+
+* `TwoParty.run_compFlat_appendFlat_pure` factors a pure suffix constructor under `LawfulMonad`;
+* `TwoParty.run_comp_append` factors a general effectful suffix constructor under
+  `TwoParty.LawfulCommMonad`.
+
+ArkLib's prover setup is effectful in general, so `Reduction.run_comp` deliberately exposes the
+second boundary. Stateful clients without commutative effects must thread state explicitly rather
+than use this factorization theorem.
+-/
+
+universe u v w
+
+namespace Interaction
+
+open TwoParty
+
+/-! ## Participants -/
+
+/-- The next statement and witness produced by an honest prover. -/
+abbrev HonestProverOutput (StatementOut : Type u) (WitnessOut : Type v) :=
+  StatementOut × WitnessOut
+
+namespace HonestProverOutput
+
+/-- The statement component of an honest prover output. -/
+abbrev stmt {StatementOut : Type u} {WitnessOut : Type v}
+    (out : HonestProverOutput StatementOut WitnessOut) : StatementOut :=
+  out.1
+
+/-- The witness component of an honest prover output. -/
+abbrev wit {StatementOut : Type u} {WitnessOut : Type v}
+    (out : HonestProverOutput StatementOut WitnessOut) : WitnessOut :=
+  out.2
+
+/-- Split a lifted honest-prover output into separately lifted statement and witness outputs. -/
+def splitLiftAppend
+    (ctx₁ : TypeTree) (ctx₂ : TypeTree.Path ctx₁ → TypeTree)
+    (StatementOut WitnessOut : (tr₁ : TypeTree.Path ctx₁) → TypeTree.Path (ctx₂ tr₁) → Type u)
+    (tr : TypeTree.Path (ctx₁.append ctx₂))
+    (out : PFunctor.FreeM.Path.liftAppend ctx₁ ctx₂
+      (fun tr₁ tr₂ => HonestProverOutput (StatementOut tr₁ tr₂) (WitnessOut tr₁ tr₂)) tr) :
+    HonestProverOutput
+      (PFunctor.FreeM.Path.liftAppend ctx₁ ctx₂ StatementOut tr)
+      (PFunctor.FreeM.Path.liftAppend ctx₁ ctx₂ WitnessOut tr) :=
+  PFunctor.FreeM.Path.liftAppendProd ctx₁ ctx₂ StatementOut WitnessOut tr out
+
+theorem splitLiftAppend_packAppend
+    (ctx₁ : TypeTree) (ctx₂ : TypeTree.Path ctx₁ → TypeTree)
+    (StatementOut WitnessOut : (tr₁ : TypeTree.Path ctx₁) → TypeTree.Path (ctx₂ tr₁) → Type u)
+    (tr₁ : TypeTree.Path ctx₁) (tr₂ : TypeTree.Path (ctx₂ tr₁))
+    (out : HonestProverOutput (StatementOut tr₁ tr₂) (WitnessOut tr₁ tr₂)) :
+    splitLiftAppend ctx₁ ctx₂ StatementOut WitnessOut
+        (PFunctor.FreeM.Path.append ctx₁ ctx₂ tr₁ tr₂)
+        (PFunctor.FreeM.Path.packAppend ctx₁ ctx₂
+          (fun tr₁ tr₂ => HonestProverOutput (StatementOut tr₁ tr₂) (WitnessOut tr₁ tr₂))
+          tr₁ tr₂ out) =
+      (PFunctor.FreeM.Path.packAppend ctx₁ ctx₂ StatementOut tr₁ tr₂ out.stmt,
+        PFunctor.FreeM.Path.packAppend ctx₁ ctx₂ WitnessOut tr₁ tr₂ out.wit) :=
+  PFunctor.FreeM.Path.liftAppendProd_packAppend
+    ctx₁ ctx₂ StatementOut WitnessOut tr₁ tr₂ out
+
+end HonestProverOutput
+
+/-- A prover performs monadic setup and returns the focal strategy for the selected input. -/
+abbrev Prover (m : Type u → Type u)
+    (SharedIn : Type v)
+    (Context : SharedIn → TypeTree)
+    (Roles : (i : SharedIn) → RoleDecoration (Context i))
+    (StatementIn WitnessIn : SharedIn → Type w)
+    (StatementOut WitnessOut : (i : SharedIn) → TypeTree.Path (Context i) → Type u) :=
+  (i : SharedIn) → StatementIn i → WitnessIn i →
+    m (StrategyOver (SyntaxOver.TwoParty.pairedTypeTree m) Participant.focal
+      (Context i) (Roles i)
+      (fun tr => HonestProverOutput (StatementOut i tr) (WitnessOut i tr)))
+
+/-- A verifier returns the counterpart strategy for the selected input and public statement. -/
+abbrev Verifier (m : Type u → Type u)
+    (SharedIn : Type v)
+    (Context : SharedIn → TypeTree)
+    (Roles : (i : SharedIn) → RoleDecoration (Context i))
+    (StatementIn : SharedIn → Type w)
+    (StatementOut : (i : SharedIn) → TypeTree.Path (Context i) → Type u) :=
+  (i : SharedIn) → StatementIn i →
+    StrategyOver (SyntaxOver.TwoParty.pairedTypeTree m) Participant.counterpart
+      (Context i) (Roles i) (StatementOut i)
+
+/-- A plain dependent reduction pairs a prover and verifier for one typed interaction. -/
+structure Reduction (m : Type u → Type u)
+    (SharedIn : Type v)
+    (Context : SharedIn → TypeTree)
+    (Roles : (i : SharedIn) → RoleDecoration (Context i))
+    (StatementIn WitnessIn : SharedIn → Type w)
+    (StatementOut WitnessOut : (i : SharedIn) → TypeTree.Path (Context i) → Type u) where
+  prover : Prover m SharedIn Context Roles StatementIn WitnessIn StatementOut WitnessOut
+  verifier : Verifier m SharedIn Context Roles StatementIn StatementOut
+
+/-! ## Execution -/
+
+/-- Execute a reduction with PolyFun's canonical two-party runner. -/
+def Reduction.execute {m : Type u → Type u} [Monad m]
+    {SharedIn : Type v}
+    {Context : SharedIn → TypeTree}
+    {Roles : (i : SharedIn) → RoleDecoration (Context i)}
+    {StatementIn WitnessIn : SharedIn → Type w}
+    {StatementOut WitnessOut : (i : SharedIn) → TypeTree.Path (Context i) → Type u}
+    (reduction : Reduction m SharedIn Context Roles StatementIn WitnessIn StatementOut WitnessOut)
+    (i : SharedIn) (stmt : StatementIn i) (wit : WitnessIn i) :
+    m ((tr : TypeTree.Path (Context i)) ×
+      HonestProverOutput (StatementOut i tr) (WitnessOut i tr) × StatementOut i tr) := do
+  let strategy ← reduction.prover i stmt wit
+  TwoParty.run (Context i) (Roles i) strategy (reduction.verifier i stmt)
+
+/-- Honest execution is definitionally PolyFun's two-party runner after prover setup. -/
+theorem Reduction.execute_eq_run {m : Type u → Type u} [Monad m]
+    {SharedIn : Type v}
+    {Context : SharedIn → TypeTree}
+    {Roles : (i : SharedIn) → RoleDecoration (Context i)}
+    {StatementIn WitnessIn : SharedIn → Type w}
+    {StatementOut WitnessOut : (i : SharedIn) → TypeTree.Path (Context i) → Type u}
+    (reduction : Reduction m SharedIn Context Roles StatementIn WitnessIn StatementOut WitnessOut)
+    (i : SharedIn) (stmt : StatementIn i) (wit : WitnessIn i) :
+    reduction.execute i stmt wit = (do
+      let strategy ← reduction.prover i stmt wit
+      TwoParty.run (Context i) (Roles i) strategy (reduction.verifier i stmt)) := rfl
+
+/-- Run a focal strategy against an input-indexed verifier. -/
+def Verifier.run {m : Type u → Type u} [Monad m]
+    {SharedIn : Type v}
+    {Context : SharedIn → TypeTree}
+    {Roles : (i : SharedIn) → RoleDecoration (Context i)}
+    {StatementIn : SharedIn → Type w}
+    {StatementOut : (i : SharedIn) → TypeTree.Path (Context i) → Type u}
+    (verifier : Verifier m SharedIn Context Roles StatementIn StatementOut)
+    (i : SharedIn) (stmt : StatementIn i)
+    {OutputP : TypeTree.Path (Context i) → Type u}
+    (prover : StrategyOver (SyntaxOver.TwoParty.pairedTypeTree m) Participant.focal
+      (Context i) (Roles i) OutputP) :
+    m ((tr : TypeTree.Path (Context i)) × OutputP tr × StatementOut i tr) :=
+  TwoParty.run (Context i) (Roles i) prover (verifier i stmt)
+
+/-! ## Sequential composition -/
+
+/-- Compose a reduction with a continuation reduction indexed by the complete prefix path.
+
+The second shared input remembers the original public statement as well as the realized prefix.
+Its statement and witness inputs are exactly the first reduction's outputs. The combined terminal
+families use `PFunctor.FreeM.Path.liftAppend`, preserving their dependence on both paths. -/
+def Reduction.comp {m : Type u → Type u} [Monad m]
+    {SharedIn : Type v}
+    {StatementIn WitnessIn : SharedIn → Type w}
+    {ctx₁ : SharedIn → TypeTree}
+    {roles₁ : (i : SharedIn) → RoleDecoration (ctx₁ i)}
+    {StmtMid WitMid : (i : SharedIn) → TypeTree.Path (ctx₁ i) → Type u}
+    {ctx₂ : (i : SharedIn) → TypeTree.Path (ctx₁ i) → TypeTree}
+    {roles₂ : (i : SharedIn) → (tr₁ : TypeTree.Path (ctx₁ i)) → RoleDecoration (ctx₂ i tr₁)}
+    {StmtOut WitOut : (i : SharedIn) → (tr₁ : TypeTree.Path (ctx₁ i)) →
+      TypeTree.Path (ctx₂ i tr₁) → Type u}
+    (reduction₁ : Reduction m SharedIn ctx₁ roles₁ StatementIn WitnessIn StmtMid WitMid)
+    (reduction₂ : Reduction m
+      ((i : SharedIn) × StatementIn i × TypeTree.Path (ctx₁ i))
+      (fun shared => ctx₂ shared.1 shared.2.2)
+      (fun shared => roles₂ shared.1 shared.2.2)
+      (fun shared => StmtMid shared.1 shared.2.2)
+      (fun shared => WitMid shared.1 shared.2.2)
+      (fun shared tr₂ => StmtOut shared.1 shared.2.2 tr₂)
+      (fun shared tr₂ => WitOut shared.1 shared.2.2 tr₂)) :
+    Reduction m SharedIn
+      (fun i => (ctx₁ i).append (ctx₂ i))
+      (fun i => (roles₁ i).append (roles₂ i))
+      StatementIn WitnessIn
+      (fun i => PFunctor.FreeM.Path.liftAppend (ctx₁ i) (ctx₂ i) (StmtOut i))
+      (fun i => PFunctor.FreeM.Path.liftAppend (ctx₁ i) (ctx₂ i) (WitOut i)) where
+  prover i stmt wit := do
+    let strategy₁ ← reduction₁.prover i stmt wit
+    let strategy ← StrategyOver.TwoParty.Focal.comp strategy₁ (fun tr₁ midOut =>
+      reduction₂.prover ⟨i, stmt, tr₁⟩ midOut.stmt midOut.wit)
+    pure <| StrategyOver.TwoParty.Focal.mapOutput
+      (HonestProverOutput.splitLiftAppend (ctx₁ i) (ctx₂ i) (StmtOut i) (WitOut i))
+      strategy
+  verifier i stmt :=
+    StrategyOver.TwoParty.Counterpart.append (reduction₁.verifier i stmt) (fun tr₁ stmtMid =>
+      reduction₂.verifier ⟨i, stmt, tr₁⟩ stmtMid)
+
+/-- The raw strategy used by `Reduction.comp` factors into prefix execution followed by the
+path-indexed suffix execution.
+
+This is the general effectful factorization law and therefore requires
+`TwoParty.LawfulCommMonad`. The pure-suffix counterpart is PolyFun's
+`TwoParty.run_compFlat_appendFlat_pure`, which only requires `LawfulMonad`. -/
+theorem Reduction.run_comp
+    {m : Type u → Type u} [Monad m] [TwoParty.LawfulCommMonad m]
+    {SharedIn : Type v}
+    {StatementIn WitnessIn : SharedIn → Type w}
+    {ctx₁ : SharedIn → TypeTree}
+    {roles₁ : (i : SharedIn) → RoleDecoration (ctx₁ i)}
+    {StmtMid WitMid : (i : SharedIn) → TypeTree.Path (ctx₁ i) → Type u}
+    {ctx₂ : (i : SharedIn) → TypeTree.Path (ctx₁ i) → TypeTree}
+    {roles₂ : (i : SharedIn) → (tr₁ : TypeTree.Path (ctx₁ i)) →
+      RoleDecoration (ctx₂ i tr₁)}
+    {StmtOut WitOut : (i : SharedIn) → (tr₁ : TypeTree.Path (ctx₁ i)) →
+      TypeTree.Path (ctx₂ i tr₁) → Type u}
+    (reduction₁ : Reduction m SharedIn ctx₁ roles₁ StatementIn WitnessIn StmtMid WitMid)
+    (reduction₂ : Reduction m
+      ((i : SharedIn) × StatementIn i × TypeTree.Path (ctx₁ i))
+      (fun shared => ctx₂ shared.1 shared.2.2)
+      (fun shared => roles₂ shared.1 shared.2.2)
+      (fun shared => StmtMid shared.1 shared.2.2)
+      (fun shared => WitMid shared.1 shared.2.2)
+      (fun shared tr₂ => StmtOut shared.1 shared.2.2 tr₂)
+      (fun shared tr₂ => WitOut shared.1 shared.2.2 tr₂))
+    (i : SharedIn) (stmt : StatementIn i) (wit : WitnessIn i) :
+    (do
+      let strategy₁ ← reduction₁.prover i stmt wit
+      let strategy ← StrategyOver.TwoParty.Focal.comp strategy₁ (fun tr₁ midOut =>
+        reduction₂.prover ⟨i, stmt, tr₁⟩ midOut.stmt midOut.wit)
+      TwoParty.run ((ctx₁ i).append (ctx₂ i)) ((roles₁ i).append (roles₂ i)) strategy
+        (StrategyOver.TwoParty.Counterpart.append (reduction₁.verifier i stmt) (fun tr₁ stmtMid =>
+          reduction₂.verifier ⟨i, stmt, tr₁⟩ stmtMid))) =
+      (do
+        let strategy₁ ← reduction₁.prover i stmt wit
+        let ⟨tr₁, midOut, stmtMid⟩ ←
+          TwoParty.run (ctx₁ i) (roles₁ i) strategy₁ (reduction₁.verifier i stmt)
+        let strategy₂ ← reduction₂.prover ⟨i, stmt, tr₁⟩ midOut.stmt midOut.wit
+        let ⟨tr₂, out, stmtOut⟩ ←
+          TwoParty.run (ctx₂ i tr₁) (roles₂ i tr₁) strategy₂
+            (reduction₂.verifier ⟨i, stmt, tr₁⟩ stmtMid)
+        pure ⟨PFunctor.FreeM.Path.append (ctx₁ i) (ctx₂ i) tr₁ tr₂,
+          PFunctor.FreeM.Path.packAppend (ctx₁ i) (ctx₂ i)
+            (fun tr₁ tr₂ => HonestProverOutput (StmtOut i tr₁ tr₂) (WitOut i tr₁ tr₂))
+            tr₁ tr₂ out,
+          PFunctor.FreeM.Path.packAppend (ctx₁ i) (ctx₂ i) (StmtOut i)
+            tr₁ tr₂ stmtOut⟩) := by
+  refine congrArg (fun k => reduction₁.prover i stmt wit >>= k) ?_
+  funext strategy₁
+  exact TwoParty.run_comp_append
+    (strat₁ := strategy₁)
+    (f := fun tr₁ midOut => reduction₂.prover ⟨i, stmt, tr₁⟩ midOut.stmt midOut.wit)
+    (cpt₁ := reduction₁.verifier i stmt)
+    (cpt₂ := fun tr₁ stmtMid => reduction₂.verifier ⟨i, stmt, tr₁⟩ stmtMid)
+
+end Interaction

--- a/ArkLib/Interaction/Reduction/DependentExample.lean
+++ b/ArkLib/Interaction/Reduction/DependentExample.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import ArkLib.Interaction.Reduction
+
+/-!
+# A genuinely dependent composed reduction
+
+This executable acceptance client prevents `Reduction.comp` from collapsing to a fixed suffix.
+The prefix sends a `Bool`. A `false` prefix selects a `Bool` suffix message, while a `true` prefix
+selects a `Fin 3` suffix message. Both branches execute through the same composed reduction.
+-/
+
+namespace Interaction.Reduction.DependentExample
+
+open TwoParty
+
+/-- The first interaction sends one Boolean. -/
+def prefixTree : TypeTree := TypeTree.node Bool (fun _ => TypeTree.done)
+
+/-- The focal participant sends the prefix Boolean. -/
+def prefixRoles : RoleDecoration prefixTree := ⟨Role.sender, fun _ => ⟨⟩⟩
+
+/-- The continuation tree changes its message type according to the complete prefix path. -/
+def suffixTree : TypeTree.Path prefixTree → TypeTree
+  | ⟨false, ⟨⟩⟩ => TypeTree.node Bool (fun _ => TypeTree.done)
+  | ⟨true, ⟨⟩⟩ => TypeTree.node (Fin 3) (fun _ => TypeTree.done)
+
+/-- The focal participant also sends the suffix message. -/
+def suffixRoles : (tr : TypeTree.Path prefixTree) → RoleDecoration (suffixTree tr)
+  | ⟨false, ⟨⟩⟩ => ⟨Role.sender, fun _ => ⟨⟩⟩
+  | ⟨true, ⟨⟩⟩ => ⟨Role.sender, fun _ => ⟨⟩⟩
+
+abbrev PrefixStatement (_ : Unit) := Unit
+abbrev PrefixWitness (_ : Unit) := Bool
+abbrev MidStatement (_ : Unit) (_ : TypeTree.Path prefixTree) := Bool
+abbrev MidWitness (_ : Unit) (_ : TypeTree.Path prefixTree) := Unit
+
+/-- The prefix reduction forwards the sent Boolean as its next statement. -/
+def prefixReduction : Reduction Id Unit (fun _ => prefixTree) (fun _ => prefixRoles)
+    PrefixStatement PrefixWitness MidStatement MidWitness where
+  prover _ _ bit := ⟨bit, ⟨bit, ()⟩⟩
+  verifier _ _ bit := bit
+
+abbrev SuffixShared := (i : Unit) × PrefixStatement i × TypeTree.Path prefixTree
+abbrev SuffixStatement (shared : SuffixShared) := MidStatement shared.1 shared.2.2
+abbrev SuffixWitness (shared : SuffixShared) := MidWitness shared.1 shared.2.2
+
+/-- The suffix emits a branch-specific message and turns it into a natural-number statement.
+
+The explicit dependent match is the acceptance canary: the two branches cannot be replaced by one
+constant continuation tree because their move types differ. -/
+def suffixReduction : Reduction Id SuffixShared
+    (fun shared => suffixTree shared.2.2)
+    (fun shared => suffixRoles shared.2.2)
+    SuffixStatement SuffixWitness
+    (fun _ _ => Nat) (fun _ _ => Unit) where
+  prover shared _ _ :=
+    match shared with
+    | ⟨(), (), ⟨false, ⟨⟩⟩⟩ => ⟨false, ⟨0, ()⟩⟩
+    | ⟨(), (), ⟨true, ⟨⟩⟩⟩ => ⟨(2 : Fin 3), ⟨2, ()⟩⟩
+  verifier shared _ :=
+    match shared with
+    | ⟨(), (), ⟨false, ⟨⟩⟩⟩ => fun (bit : Bool) => (if bit then 1 else 0 : Nat)
+    | ⟨(), (), ⟨true, ⟨⟩⟩⟩ => fun (value : Fin 3) => value.val
+
+/-- The dependent two-stage reduction produced by `Reduction.comp`. -/
+def composed := Reduction.comp
+  (ctx₂ := fun _ => suffixTree)
+  (roles₂ := fun _ => suffixRoles)
+  (StmtOut := fun _ _ _ => Nat)
+  (WitOut := fun _ _ _ => Unit)
+  prefixReduction suffixReduction
+
+/-- The false prefix selects the Boolean continuation branch. -/
+example : (composed.execute () () false).1 =
+    ⟨false, false, ⟨⟩⟩ := rfl
+
+/-- The true prefix selects the `Fin 3` continuation branch. -/
+example : (composed.execute () () true).1 =
+    ⟨true, (2 : Fin 3), ⟨⟩⟩ := rfl
+
+/-- Both honest participants agree on the final statement in the Boolean branch. -/
+example : composed.execute () () false =
+    let tr₁ : TypeTree.Path prefixTree := ⟨false, ⟨⟩⟩
+    let tr₂ : TypeTree.Path (suffixTree tr₁) := ⟨false, ⟨⟩⟩
+    ⟨PFunctor.FreeM.Path.append prefixTree suffixTree tr₁ tr₂,
+      ⟨PFunctor.FreeM.Path.packAppend prefixTree suffixTree (fun _ _ => Nat) tr₁ tr₂ 0,
+        PFunctor.FreeM.Path.packAppend prefixTree suffixTree (fun _ _ => Unit) tr₁ tr₂ ()⟩,
+      PFunctor.FreeM.Path.packAppend prefixTree suffixTree (fun _ _ => Nat) tr₁ tr₂ 0⟩ := rfl
+
+/-- Both honest participants agree on the final statement in the `Fin 3` branch. -/
+example : composed.execute () () true =
+    let tr₁ : TypeTree.Path prefixTree := ⟨true, ⟨⟩⟩
+    let tr₂ : TypeTree.Path (suffixTree tr₁) := ⟨(2 : Fin 3), ⟨⟩⟩
+    ⟨PFunctor.FreeM.Path.append prefixTree suffixTree tr₁ tr₂,
+      ⟨PFunctor.FreeM.Path.packAppend prefixTree suffixTree (fun _ _ => Nat) tr₁ tr₂ 2,
+        PFunctor.FreeM.Path.packAppend prefixTree suffixTree (fun _ _ => Unit) tr₁ tr₂ ()⟩,
+      PFunctor.FreeM.Path.packAppend prefixTree suffixTree (fun _ _ => Nat) tr₁ tr₂ 2⟩ := rfl
+
+end Interaction.Reduction.DependentExample

--- a/ArkLib/Interaction/Reduction/DependentExample.lean
+++ b/ArkLib/Interaction/Reduction/DependentExample.lean
@@ -33,9 +33,16 @@ def suffixRoles : (tr : TypeTree.Path prefixTree) → RoleDecoration (suffixTree
   | ⟨false, ⟨⟩⟩ => ⟨Role.sender, fun _ => ⟨⟩⟩
   | ⟨true, ⟨⟩⟩ => ⟨Role.sender, fun _ => ⟨⟩⟩
 
+/-- The public input family for the prefix reduction. -/
 abbrev PrefixStatement (_ : Unit) := Unit
+
+/-- The private input family carrying the prefix bit. -/
 abbrev PrefixWitness (_ : Unit) := Bool
+
+/-- The prefix exposes its sent bit as the suffix statement. -/
 abbrev MidStatement (_ : Unit) (_ : TypeTree.Path prefixTree) := Bool
+
+/-- The prefix does not pass private data to the suffix. -/
 abbrev MidWitness (_ : Unit) (_ : TypeTree.Path prefixTree) := Unit
 
 /-- The prefix reduction forwards the sent Boolean as its next statement. -/
@@ -44,9 +51,31 @@ def prefixReduction : Reduction Id Unit (fun _ => prefixTree) (fun _ => prefixRo
   prover _ _ bit := ⟨bit, ⟨bit, ()⟩⟩
   verifier _ _ bit := bit
 
+/-- The suffix index remembers the original input and complete prefix path. -/
 abbrev SuffixShared := (i : Unit) × PrefixStatement i × TypeTree.Path prefixTree
+
+/-- The suffix statement is selected by its remembered prefix path. -/
 abbrev SuffixStatement (shared : SuffixShared) := MidStatement shared.1 shared.2.2
+
+/-- The suffix witness is selected by its remembered prefix path. -/
 abbrev SuffixWitness (shared : SuffixShared) := MidWitness shared.1 shared.2.2
+
+section UniverseCanary
+
+universe uShared uStatement uWitness uInteraction
+
+/-- Compile-time canary that shared, statement, witness, and interaction universes remain
+independent. -/
+abbrev UniverseSeparatedReduction
+    (Shared : Type uShared)
+    (Context : Shared → TypeTree.{uInteraction})
+    (Roles : (i : Shared) → RoleDecoration (Context i))
+    (Statement : Shared → Type uStatement)
+    (Witness : Shared → Type uWitness)
+    (StatementOut WitnessOut : (i : Shared) → TypeTree.Path (Context i) → Type uInteraction) :=
+  Reduction Id Shared Context Roles Statement Witness StatementOut WitnessOut
+
+end UniverseCanary
 
 /-- The suffix emits a branch-specific message and turns it into a natural-number statement.
 

--- a/docs/design/00-current-status.md
+++ b/docs/design/00-current-status.md
@@ -15,7 +15,7 @@ The first implementation train uses one tested dependency chain:
 
 | Repository | Revision | Role |
 |---|---|---|
-| ArkLib | `3f3f045dd295834c262bd6f0d9dfdfee07cc8e76` | clean default-branch base |
+| ArkLib | `22dbd4e836c15a21f68889afa69b7130da04abbb` | AR-1 comparison base |
 | VCVio | `f9dc47d9dacfc5cb51dae9f92f1e34cb5ce2cc24` | direct ArkLib dependency |
 | PolyFun | `c0c923693fc827a41d17116579a0c16ed4873b19` | revision selected and tested by VCVio |
 | Lean | `v4.33.1` | common toolchain |

--- a/docs/design/00-current-status.md
+++ b/docs/design/00-current-status.md
@@ -1,6 +1,6 @@
 # Current status and first implementation train
 
-**Status date:** 2026-08-29. **Scope:** the supported starting point for implementing ArkLib's
+**Status date:** 2026-09-03. **Scope:** the supported starting point for implementing ArkLib's
 typed oracle-reduction architecture.
 
 The core implementation can begin now. PolyFun's typed interaction, cursor, restriction, append,
@@ -134,8 +134,11 @@ Every implementation PR starts from current `main` and leaves the legacy layer w
 | 6 | Typed composition and legacy bridge | Exercise dependent append and virtual substitution; prove a two-way protocol bridge | unblocked after slice 5 |
 | 7 | Execution artifact and ordinary security | Add or upstream the artifact and outcome boundaries; prove admissibility-aware composition | blocked on named VCVio gaps |
 
-The first code PR introduces the smallest plain reduction wrapper whose execution is definitionally
-the current PolyFun runner. It does not port the archive's whole `ArkLib/Interaction` tree.
+AR-1 introduces the smallest plain reduction wrapper whose execution is definitionally the current
+PolyFun runner. It supports complete-path-dependent append and exposes the general effectful
+factorization boundary through `LawfulCommMonad`; PolyFun's pure-suffix theorem remains available
+under `LawfulMonad`. The executable acceptance client selects different suffix message types from
+the first complete path. AR-1 does not port the archive's whole `ArkLib/Interaction` tree.
 
 ## Deferred work
 

--- a/docs/design/01a-foundation-pr-plan.md
+++ b/docs/design/01a-foundation-pr-plan.md
@@ -91,6 +91,9 @@ declaration; historical upstream plans no longer appear as live work.
 
 ### AR-1 — plain dependent reduction kernel
 
+**Status.** Implemented by the first typed-interaction PR. The next independent core slices are
+AR-2A and AR-4A.
+
 **Goal.** Add the smallest ArkLib prover, verifier, and reduction packages over PolyFun
 `Interaction.TypeTree`, two-party roles, strategies, and execution.
 

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -8,6 +8,7 @@ Many developments are paper-scoped and spread across several modules.
 ```text
 ArkLib/
   Data/               foundational math, coding theory, polynomials, probability, etc.
+  Interaction/        typed prover, verifier, and reduction foundations
   OracleReduction/    core IOR abstractions and security theory
   Commitments/        commitments and opening arguments
   ProofSystem/        protocol families and higher-level proofs
@@ -22,7 +23,10 @@ home_page/            site assets and assembled website root
 
 ## Conceptual Layering
 
-- `ArkLib/OracleReduction/` is the conceptual center of the library.
+- `ArkLib/Interaction/` is the new typed-interaction foundation. Its plain reduction layer is
+  intentionally independent of oracle, probability, and legacy protocol semantics.
+- `ArkLib/OracleReduction/` remains the conceptual center of the legacy reduction and security
+  layer while protocol clients migrate.
 - `ArkLib/Data/`, `ArkLib/ToMathlib/`, `ArkLib/ToCompPoly/`, and `ArkLib/ToVCVio/` support the
   core with reusable definitions and lemmas.
 - `ArkLib/Commitments/` and `ArkLib/ProofSystem/` build on top of those foundations.
@@ -32,7 +36,8 @@ home_page/            site assets and assembled website root
 ## Where To Start By Task
 
 - Extending foundational math or coding theory: start in `ArkLib/Data/`.
-- Changing core reduction or security abstractions: start in `ArkLib/OracleReduction/`.
+- Changing typed interaction or dependent reduction foundations: start in `ArkLib/Interaction/`.
+- Changing legacy reduction or security abstractions: start in `ArkLib/OracleReduction/`.
 - Working on protocol statements or proofs: start in `ArkLib/ProofSystem/`.
 - Updating commitment interfaces or concrete schemes: start in `ArkLib/Commitments/`
   (`Ordinary/` for plain commit-and-open schemes whose definition comes from the VCV-io


### PR DESCRIPTION
## Summary

This PR lands AR-1: the smallest plain dependent-reduction kernel over PolyFun's typed two-party interactions.

It adds:

- typed `Prover`, `Verifier`, and `Reduction` packages over `Interaction.TypeTree`, role decorations, and strategies;
- transparent honest execution through `Reduction.execute`, with `Reduction.execute_eq_run` holding by `rfl`;
- complete-path-dependent sequential composition through `Reduction.comp` and a public `Reduction.execute_comp` factorization theorem;
- an executable dependent client whose prefix selects either a `Bool` or `Fin 3` suffix message type;
- repository and design-document routing for the new `ArkLib/Interaction/` layer.

Normative implementation plan: [`docs/design/01a-foundation-pr-plan.md`](docs/design/01a-foundation-pr-plan.md).

### Diff metadata

- Base: `22dbd4e836c15a21f68889afa69b7130da04abbb` (`main`)
- Head: `9daf3dccfe5ea55cceab904309e283b4b77f79a1`
- Commits: 2
- Files changed: 7
- Diff: 480 insertions, 7 deletions

## Motivation

ArkLib's legacy `OracleReduction` layer couples plain interaction structure to later oracle, probability, claim, and security concerns. AR-1 establishes a deliberately smaller foundation: honest prover/verifier execution and dependent composition are expressed directly using the supported PolyFun interaction API, without introducing parallel runners or protocol semantics.

## Change-surface overview

| Area | Before | After |
|---|---|---|
| Plain reduction API | No ArkLib package over current PolyFun typed interactions | `Prover`, `Verifier`, and `Reduction` in `ArkLib.Interaction` |
| Execution | Clients assembled PolyFun strategies and runners directly | `Reduction.execute` is a transparent wrapper around `TwoParty.run` |
| Composition | Only upstream strategy-level composition was available | `Reduction.comp` packages dependent append; `Reduction.execute_comp` factors its public execution |
| Dependency | No path-dependent ArkLib acceptance client | A prefix `Bool` selects a `Bool` or `Fin 3` suffix tree |
| Repository routing | `OracleReduction` appeared to own all reduction foundations | `Interaction` owns the new typed foundation; `OracleReduction` is explicitly legacy |

## Core API

`ArkLib/Interaction/Reduction.lean` introduces the canonical AR-1 surface:

- `HonestProverOutput` records the prover's next statement and witness.
- `Prover` performs monadic setup and returns a focal strategy.
- `Verifier` builds the counterpart strategy from public input only.
- `Reduction` pairs those participants while allowing the interaction tree, roles, and terminal families to depend on shared input.
- `Reduction.execute` performs prover setup and delegates to `TwoParty.run`; `Reduction.execute_eq_run` is definitional.

Shared input, statement input, witness input, and interaction/output types remain universe-independent. The acceptance module contains a compile-time universe canary for that boundary.

## Dependent composition

`Reduction.comp` appends a continuation whose tree and roles depend on the complete prefix path. The first reduction's statement and witness outputs become the continuation's inputs, and `Path.liftAppend` transports the terminal families over the combined path.

`Reduction.execute_comp` is the supported public execution law. It factors execution of the actual mapped composite reduction into prefix execution followed by the selected suffix execution, then separates the lifted honest-prover statement/witness pair.

The effect boundary is explicit:

- PolyFun's pure-suffix factorization is available under `LawfulMonad`;
- general effectful suffix construction, and therefore `Reduction.execute_comp`, requires `TwoParty.LawfulCommMonad`.

This PR does not claim the general factorization for stateful noncommutative effects.

## Acceptance client

`ArkLib/Interaction/Reduction/DependentExample.lean` exercises genuine dependent append:

1. the prefix sends a `Bool`;
2. `false` selects a suffix that sends `Bool`;
3. `true` selects a suffix that sends `Fin 3`;
4. both branches execute through the same composed reduction and definitionally agree on the final statement.

The different suffix move types prevent this example from collapsing to a fixed continuation tree.

## Safety and compatibility

- No new `sorry`, custom axiom, or native-compiler trust is introduced.
- The axiom sweep reports no new `sorryAx` or non-standard-axiom taint.
- The legacy `ArkLib/OracleReduction/` implementation and its clients remain intact.
- No serialization, transcript, probability, resource, oracle-node, or relation semantics change in this slice.

## Commit map

- `f1cf3af8` — add the dependent reduction kernel, acceptance client, generated import, and design routing.
- `9daf3dcc` — complete the independent review gate: factor public composite execution, separate statement/witness universes, and tighten documentation.

## Validation completed at `9daf3dcc`

The following passed on the exact head above:

- `lake build ArkLib.Interaction.Reduction ArkLib.Interaction.Reduction.DependentExample`
- `./scripts/validate.sh`
- `./scripts/validate.sh --axioms`
- `git diff --check`
- independent `$review-lean-formalization` gate: PASS, with no blockers or hardening requests

## Deferred scope

This PR intentionally does not add oracle nodes, resource metadata, claims, probability, legacy migration, state restoration, or stateful noncommutative factorization. Those remain in the later AR slices described by the implementation plan.

## Reviewer map

Suggested review order:

1. [`docs/design/01a-foundation-pr-plan.md`](docs/design/01a-foundation-pr-plan.md) — AR-1 goal and scope
2. [`ArkLib/Interaction/Reduction.lean`](ArkLib/Interaction/Reduction.lean) — canonical API, execution, and composition law
3. [`ArkLib/Interaction/Reduction/DependentExample.lean`](ArkLib/Interaction/Reduction/DependentExample.lean) — dependent acceptance client and universe canary
4. [`docs/design/00-current-status.md`](docs/design/00-current-status.md) — supported baseline and landed status
5. [`AGENTS.md`](AGENTS.md) and [`docs/wiki/repo-map.md`](docs/wiki/repo-map.md) — repository routing
