### PR TITLE
feat(interaction): add oracle type trees and paths

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -277,6 +277,8 @@ import ArkLib.Data.Probability.Combinatorial
 import ArkLib.Data.Probability.Instances
 import ArkLib.Data.Probability.KoalaBear
 import ArkLib.Data.Probability.Notation
+import ArkLib.Interaction.Oracle.TypeTree
+import ArkLib.Interaction.Oracle.TypeTree.MixedExample
 import ArkLib.Interaction.Reduction
 import ArkLib.Interaction.Reduction.DependentExample
 import ArkLib.OracleReduction.BCS.Basic

--- a/ArkLib/Interaction/Oracle/TypeTree.lean
+++ b/ArkLib/Interaction/Oracle/TypeTree.lean
@@ -122,6 +122,26 @@ def runtimeLens : PFunctor.Lens basePFunctor _root_.Interaction.TypeTree.basePFu
     | .public _, move => move
     | .oracle _, _ => PUnit.unit
 
+@[simp]
+theorem runtimeLens_toFunA_public (Moves : Type u) :
+    runtimeLens.toFunA (.public Moves) = Moves :=
+  rfl
+
+@[simp]
+theorem runtimeLens_toFunA_oracle (Messages : Type u) :
+    runtimeLens.toFunA (.oracle Messages) = Messages :=
+  rfl
+
+@[simp]
+theorem runtimeLens_toFunB_public (Moves : Type u) (move : Moves) :
+    runtimeLens.toFunB (.public Moves) move = move :=
+  rfl
+
+@[simp]
+theorem runtimeLens_toFunB_oracle (Messages : Type u) (message : Messages) :
+    runtimeLens.toFunB (.oracle Messages) message = PUnit.unit :=
+  rfl
+
 /-- Erase the public/oracle distinction to the generic runtime type tree. -/
 def toTypeTree (tree : TypeTree) : _root_.Interaction.TypeTree :=
   tree.mapLens runtimeLens

--- a/ArkLib/Interaction/Oracle/TypeTree.lean
+++ b/ArkLib/Interaction/Oracle/TypeTree.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import PolyFun.Interaction.Basic.TypeTree
+
+/-!
+# Oracle interaction type trees
+
+This file refines PolyFun's generic `Interaction.TypeTree` with two node positions:
+
+* `.public Moves` records a public move that selects the next subtree;
+* `.oracle Messages` records an opaque oracle message while exposing only a `PUnit` structural
+  branch.
+
+The runtime lens turns both positions into ordinary PolyFun move nodes. Consequently,
+`BranchPath` records only structural choices, while `ExecutionPath` retains every concrete runtime
+message. This module contains shape and path data only; roles and oracle interfaces belong to the
+next layer.
+-/
+
+universe u v
+
+namespace Interaction.Oracle
+
+/-! ## Polynomial substrate -/
+
+/-- The two node positions in an oracle interaction tree.
+
+A public move controls the continuation. An oracle message is retained at runtime, but its
+structural branch is the unique `PUnit` value. -/
+inductive Position : Type (u + 1) where
+  | «public» : (Moves : Type u) → Position
+  | «oracle» : (Messages : Type u) → Position
+
+namespace Position
+
+/-- The structural branch type selected by an oracle-tree position. -/
+@[reducible]
+def Branch : Position.{u} → Type u
+  | .public Moves => Moves
+  | .oracle _ => PUnit
+
+end Position
+
+namespace TypeTree
+
+/-- The polynomial generating oracle interaction type trees. -/
+@[reducible]
+def basePFunctor : PFunctor.{u + 1, u} where
+  A := Position
+  B := Position.Branch
+
+end TypeTree
+
+/-- A dependent interaction tree distinguishing public moves from opaque oracle messages. -/
+abbrev TypeTree : Type (u + 1) :=
+  PFunctor.FreeM TypeTree.basePFunctor.{u} PUnit.{u + 1}
+
+namespace TypeTree
+
+/-! ## Constructors and elimination -/
+
+/-- Terminal oracle interaction tree. -/
+@[match_pattern, reducible]
+def done : TypeTree := PFunctor.FreeM.pure PUnit.unit
+
+/-- Public node whose concrete move selects the continuation. -/
+@[match_pattern, reducible]
+def «public» (Moves : Type u) (rest : Moves → TypeTree) : TypeTree :=
+  PFunctor.FreeM.liftBind (.public Moves) rest
+
+/-- Oracle node whose concrete message cannot affect the structural continuation. -/
+@[match_pattern, reducible]
+def «oracle» (Messages : Type u) (rest : PUnit.{u + 1} → TypeTree) : TypeTree :=
+  PFunctor.FreeM.liftBind (.oracle Messages) rest
+
+/-- Cases eliminator exposing the `done`, `public`, and `oracle` tree shapes. -/
+@[elab_as_elim, cases_eliminator]
+def casesOn {motive : TypeTree.{u} → Sort v}
+    (tree : TypeTree)
+    (done : motive TypeTree.done)
+    («public» : (Moves : Type u) → (rest : Moves → TypeTree) →
+      motive (TypeTree.public Moves rest))
+    («oracle» : (Messages : Type u) → (rest : PUnit.{u + 1} → TypeTree) →
+      motive (TypeTree.oracle Messages rest)) :
+    motive tree :=
+  match tree with
+  | .done => done
+  | .public Moves rest => «public» Moves rest
+  | .oracle Messages rest => «oracle» Messages rest
+
+/-- Structural recursor exposing induction hypotheses for every continuation. -/
+@[elab_as_elim, induction_eliminator]
+def recOn {motive : TypeTree.{u} → Sort v}
+    (tree : TypeTree)
+    (done : motive TypeTree.done)
+    («public» : (Moves : Type u) → (rest : Moves → TypeTree) →
+      ((move : Moves) → motive (rest move)) → motive (TypeTree.public Moves rest))
+    («oracle» : (Messages : Type u) → (rest : PUnit.{u + 1} → TypeTree) →
+      motive (rest PUnit.unit) → motive (TypeTree.oracle Messages rest)) :
+    motive tree :=
+  match tree with
+  | .done => done
+  | .public Moves rest =>
+      «public» Moves rest (fun move => recOn (rest move) done «public» «oracle»)
+  | .oracle Messages rest =>
+      «oracle» Messages rest (recOn (rest PUnit.unit) done «public» «oracle»)
+
+/-! ## Runtime lens -/
+
+/-- Expose an oracle interaction tree as a generic runtime `Interaction.TypeTree`.
+
+Both positions carry their concrete message type at runtime. The backwards direction is identity
+at public nodes and forgets an oracle payload to the unique structural branch. -/
+def runtimeLens : PFunctor.Lens basePFunctor _root_.Interaction.TypeTree.basePFunctor where
+  toFunA
+    | .public Moves => Moves
+    | .oracle Messages => Messages
+  toFunB
+    | .public _, move => move
+    | .oracle _, _ => PUnit.unit
+
+/-- Erase the public/oracle distinction to the generic runtime type tree. -/
+def toTypeTree (tree : TypeTree) : _root_.Interaction.TypeTree :=
+  tree.mapLens runtimeLens
+
+@[simp]
+theorem toTypeTree_done : TypeTree.done.toTypeTree = _root_.Interaction.TypeTree.done :=
+  rfl
+
+@[simp]
+theorem toTypeTree_public (Moves : Type u) (rest : Moves → TypeTree) :
+    (TypeTree.public Moves rest).toTypeTree =
+      _root_.Interaction.TypeTree.node Moves (fun move => (rest move).toTypeTree) :=
+  rfl
+
+@[simp]
+theorem toTypeTree_oracle (Messages : Type u) (rest : PUnit.{u + 1} → TypeTree) :
+    (TypeTree.oracle Messages rest).toTypeTree =
+      _root_.Interaction.TypeTree.node Messages (fun _ => (rest PUnit.unit).toTypeTree) :=
+  rfl
+
+/-! ## Structural and runtime paths -/
+
+/-- Complete structural choices through an oracle interaction tree. -/
+abbrev BranchPath (tree : TypeTree.{u}) : Type u :=
+  PFunctor.FreeM.Path tree
+
+/-- Complete concrete runtime messages through an oracle interaction tree. -/
+abbrev ExecutionPath (tree : TypeTree.{u}) : Type u :=
+  PFunctor.FreeM.PathAlong runtimeLens tree
+
+namespace ExecutionPath
+
+/-- View an execution path as a path through the erased runtime type tree. -/
+def toTypeTreePath {tree : TypeTree.{u}} (path : ExecutionPath tree) :
+    _root_.Interaction.TypeTree.Path tree.toTypeTree :=
+  PFunctor.FreeM.pathAlongToMapLensPath runtimeLens tree path
+
+/-- Recover an execution path from a path through the erased runtime type tree. -/
+def ofTypeTreePath {tree : TypeTree.{u}}
+    (path : _root_.Interaction.TypeTree.Path tree.toTypeTree) : ExecutionPath tree :=
+  PFunctor.FreeM.mapLensPathToPathAlong runtimeLens tree path
+
+/-- Forget opaque oracle payloads while preserving public structural choices. -/
+def toBranchPath {tree : TypeTree.{u}} (path : ExecutionPath tree) : BranchPath tree :=
+  PFunctor.FreeM.projectPathAlong runtimeLens tree path
+
+@[simp]
+theorem toTypeTreePath_ofTypeTreePath {tree : TypeTree.{u}}
+    (path : _root_.Interaction.TypeTree.Path tree.toTypeTree) :
+    (ofTypeTreePath path).toTypeTreePath = path :=
+  PFunctor.FreeM.pathAlongToMapLensPath_toPathAlong runtimeLens tree path
+
+@[simp]
+theorem ofTypeTreePath_toTypeTreePath {tree : TypeTree.{u}} (path : ExecutionPath tree) :
+    ofTypeTreePath path.toTypeTreePath = path :=
+  PFunctor.FreeM.mapLensPathToPathAlong_toMapLensPath runtimeLens tree path
+
+@[simp]
+theorem toBranchPath_done (path : ExecutionPath TypeTree.done) :
+    path.toBranchPath = PUnit.unit :=
+  rfl
+
+@[simp]
+theorem toBranchPath_public (Moves : Type u) (rest : Moves → TypeTree)
+    (path : ExecutionPath (TypeTree.public Moves rest)) :
+    path.toBranchPath = ⟨path.1, ExecutionPath.toBranchPath path.2⟩ :=
+  rfl
+
+@[simp]
+theorem toBranchPath_oracle (Messages : Type u) (rest : PUnit.{u + 1} → TypeTree)
+    (path : ExecutionPath (TypeTree.oracle Messages rest)) :
+    path.toBranchPath = ⟨PUnit.unit, ExecutionPath.toBranchPath path.2⟩ :=
+  rfl
+
+end ExecutionPath
+
+end TypeTree
+end Interaction.Oracle

--- a/ArkLib/Interaction/Oracle/TypeTree/MixedExample.lean
+++ b/ArkLib/Interaction/Oracle/TypeTree/MixedExample.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import ArkLib.Interaction.Oracle.TypeTree
+
+/-!
+# Mixed public/oracle path acceptance client
+
+This file exercises the AR-2A distinction between structural branch paths and concrete execution
+paths. A public Boolean selects one of two oracle-message types. Concrete oracle payloads remain in
+the execution path but project to the same `PUnit` structural branch.
+-/
+
+namespace Interaction.Oracle.TypeTree.MixedExample
+
+section UniverseCanary
+
+universe uPosition uTree uBranch uExecution
+
+/-- Compile-time canary that oracle positions are not pinned to the default universe. -/
+abbrev UniversePosition := Oracle.Position.{uPosition}
+
+/-- Compile-time canary that oracle type trees are not pinned to the default universe. -/
+abbrev UniverseTypeTree := Oracle.TypeTree.{uTree}
+
+/-- Compile-time canary that structural paths elaborate independently of the other canaries. -/
+abbrev UniverseBranchPath (tree : Oracle.TypeTree.{uBranch}) := tree.BranchPath
+
+/-- Compile-time canary that execution paths elaborate independently of the other canaries. -/
+abbrev UniverseExecutionPath (tree : Oracle.TypeTree.{uExecution}) := tree.ExecutionPath
+
+end UniverseCanary
+
+/-- A public Boolean selects either a Boolean oracle message or a `Fin 3` oracle message. -/
+def mixedTree : Oracle.TypeTree :=
+  .public Bool fun
+    | false => .oracle Bool fun _ => .done
+    | true => .oracle (Fin 3) fun _ => .done
+
+/-- Execution taking the false public branch and carrying a false oracle payload. -/
+def falsePayload : mixedTree.ExecutionPath :=
+  ⟨false, false, PUnit.unit⟩
+
+/-- A second execution on the same public branch with a distinct oracle payload. -/
+def truePayload : mixedTree.ExecutionPath :=
+  ⟨false, true, PUnit.unit⟩
+
+/-- Execution taking the true public branch and carrying a `Fin 3` oracle payload. -/
+def finPayload : mixedTree.ExecutionPath :=
+  ⟨true, (2 : Fin 3), PUnit.unit⟩
+
+/-- Distinct oracle payloads remain distinct in the concrete execution path. -/
+example : falsePayload ≠ truePayload := by
+  intro h
+  cases h
+
+/-- Opaque payloads on the same public branch have the same structural projection. -/
+example : falsePayload.toBranchPath = truePayload.toBranchPath :=
+  rfl
+
+/-- The false public branch records its choice and a unit oracle marker. -/
+example : falsePayload.toBranchPath = ⟨false, PUnit.unit, PUnit.unit⟩ :=
+  rfl
+
+/-- The true public branch records its choice but not the `Fin 3` payload. -/
+example : finPayload.toBranchPath = ⟨true, PUnit.unit, PUnit.unit⟩ :=
+  rfl
+
+/-- Erasing the oracle distinction preserves the concrete `Fin 3` runtime message. -/
+example : finPayload.toTypeTreePath = ⟨true, (2 : Fin 3), PUnit.unit⟩ :=
+  rfl
+
+end Interaction.Oracle.TypeTree.MixedExample

--- a/docs/design/00-current-status.md
+++ b/docs/design/00-current-status.md
@@ -140,6 +140,10 @@ factorization boundary through `LawfulCommMonad`; PolyFun's pure-suffix theorem 
 under `LawfulMonad`. The executable acceptance client selects different suffix message types from
 the first complete path. AR-1 does not port the archive's whole `ArkLib/Interaction` tree.
 
+AR-2A adds the structural oracle refinement: public moves choose continuations, opaque oracle
+payloads remain in `ExecutionPath`, and `ExecutionPath.toBranchPath` replaces each oracle payload
+with the unique `PUnit` branch. Roles and oracle-interface decorations remain in AR-2B.
+
 ## Deferred work
 
 The first train deliberately excludes:

--- a/docs/design/01a-foundation-pr-plan.md
+++ b/docs/design/01a-foundation-pr-plan.md
@@ -108,6 +108,9 @@ the first complete path.
 
 ### AR-2A — oracle type trees and path projections
 
+**Status.** Implemented by the second typed-interaction PR. AR-2B adds the decorations that depend
+on this structural path boundary.
+
 **Goal.** Add `Oracle.Position`, `Oracle.TypeTree`, the runtime lens to generic `TypeTree`,
 `BranchPath`, `ExecutionPath`, and projection from execution to structural branch.
 

--- a/docs/design/02-oracle-reduction-core.md
+++ b/docs/design/02-oracle-reduction-core.md
@@ -194,7 +194,10 @@ Total (all real uses in the repo are); never load-bearing for security; the hone
 
 ## 8. Universe and notation discipline
 
-Pinned universes matching the current stack (`Oracle.TypeTree : Type 1`, families in `Type`,
-`OracleSpec.{0,0}`); polymorphization is a tracked follow-up. Naming: `srcSpec` for bare
-signatures, `Src : SourceCtx` for contexts; `OStatementIn/Out` spellings per the consensus note;
-declaration-name references, not line numbers.
+The structural layer is universe-polymorphic: `Oracle.TypeTree.{u} : Type (u + 1)`, and its
+branch and execution paths retain that generality. Later query and runtime layers preserve
+independent universes until an `OracleInterface` or `OracleSpec` operation forces a concrete
+constraint; existing legacy clients commonly use `OracleSpec.{0,0}`, but that is not a
+foundation-wide pin. Naming: `srcSpec` for bare signatures, `Src : SourceCtx` for contexts;
+`OStatementIn/Out` spellings per the consensus note; declaration-name references, not line
+numbers.

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -25,6 +25,8 @@ home_page/            site assets and assembled website root
 
 - `ArkLib/Interaction/` is the new typed-interaction foundation. Its plain reduction layer is
   intentionally independent of oracle, probability, and legacy protocol semantics.
+- `ArkLib/Interaction/Oracle/` refines generic type trees with public/oracle positions and keeps
+  structural `BranchPath` separate from concrete `ExecutionPath` messages.
 - `ArkLib/OracleReduction/` remains the conceptual center of the legacy reduction and security
   layer while protocol clients migrate.
 - `ArkLib/Data/`, `ArkLib/ToMathlib/`, `ArkLib/ToCompPoly/`, and `ArkLib/ToVCVio/` support the


### PR DESCRIPTION
Builds on merged #851 and now targets `main`.

## Summary

This PR lands AR-2A: the structural oracle type-tree and path layer for the typed-interaction redesign.

It adds:

- `Interaction.Oracle.Position` and `Interaction.Oracle.TypeTree`, distinguishing public moves from opaque oracle messages;
- `Oracle.TypeTree.runtimeLens` and `toTypeTree`, exposing the refined tree as PolyFun's generic runtime `Interaction.TypeTree`;
- public computation equations for both fields of `runtimeLens`;
- `BranchPath` and `ExecutionPath`, with `ExecutionPath.toBranchPath` erasing oracle payloads to `PUnit` while preserving public continuation choices;
- a mixed-tree acceptance client showing that concrete oracle payloads remain available at runtime but do not enter the structural branch path.

Normative design: [`docs/design/01a-foundation-pr-plan.md`](docs/design/01a-foundation-pr-plan.md) and [`docs/design/01b-type-tree-rename-cutover.md`](docs/design/01b-type-tree-rename-cutover.md).

### Diff metadata

- Base: `cfebaa19dd43fa3e70d6b735ef602c2b68d90a5f` (`main`, merged #851)
- Head: `ce9b988ec2b4af99176b86fa69285a762d354680`
- Commits: 3
- Files changed: 7
- Diff: 315 insertions, 4 deletions

## Motivation

AR-1 supplies the generic dependent reduction kernel, but its underlying runtime tree treats every node as an ordinary move. Oracle reduction also needs a structural view in which:

- public values select dependent continuations;
- oracle messages remain available to execution;
- opaque oracle payloads do not become structural branch indices.

AR-2A makes that distinction explicit before roles and oracle-interface metadata are introduced.

## Change surface

| Area | Before | After |
|---|---|---|
| Typed tree shape | Generic `Interaction.TypeTree` nodes | Public/oracle positions over the same PolyFun substrate |
| Runtime path | Generic concrete path only | `ExecutionPath` retains public and oracle payloads |
| Structural path | No oracle-specific projection | `BranchPath` retains public choices and uses `PUnit` at oracle nodes |
| Lens API | Definition only | Constructor equations expose both position and branch maps to clients |
| Oracle metadata | Not present | Still deferred to AR-2B |

## Core API

`Interaction.Oracle.Position` has two position forms. A `.public Moves` position branches structurally over `Moves`; an `.oracle Messages` position branches structurally over `PUnit`.

`Oracle.TypeTree.runtimeLens` maps both positions to their concrete runtime message type. Its backwards map is the identity for public moves and forgets an oracle payload to `PUnit.unit`. Four `@[simp]` equations make both lens fields directly observable at public and oracle positions. This single lens owns both runtime erasure and execution-to-branch projection.

The path API also provides both directions between `ExecutionPath tree` and the generic path through `tree.toTypeTree`, with round-trip simp theorems. The structural layer remains universe-polymorphic; later VCVio-facing APIs may constrain universes where `OracleInterface` and `OracleSpec` require it.

## Acceptance client

`ArkLib/Interaction/Oracle/TypeTree/MixedExample.lean` constructs a tree where a public `Bool` chooses between a `Bool` oracle message and a `Fin 3` oracle message. It checks that:

- distinct oracle payloads remain distinct execution paths;
- those payloads project to the same structural path on the same public branch;
- both public choices remain visible in `BranchPath`;
- erasure to the generic runtime tree preserves the concrete `Fin 3` payload;
- positions, trees, branch paths, and execution paths remain universe-polymorphic.

## Safety, compatibility, and scope

This is an additive shape-and-path layer. It does not alter legacy `ArkLib/OracleReduction`, serialization, transcript formats, prover/verifier behavior, or security claims. It introduces no compatibility aliases for the archived prototype names.

Roles, node ownership, and oracle-interface decorations are intentionally deferred to AR-2B.

## Commit map

- `aa714615` — add oracle type trees, runtime/structural paths, acceptance client, and documentation routing;
- `246a6931` — align design guidance with the implemented universe-polymorphic structural layer;
- `2c619962` — expose direct public/oracle equations for both runtime-lens fields.

## Validation at `ce9b988e`

The branch was rebased onto merged #851. Its entire Git tree is identical to the reviewed original head `2c619962ac0cfc8ecefe01c2f229efdaa3efd565`.

- `./scripts/validate.sh --axioms` passed again after rebasing: full build, source policy, runtime checks, imports, docs/knowledge-base checks, axiom fixtures, and regression baseline.
- `git diff --check` passed.
- Review covered the dependent eliminators, both runtime-lens components, constructor equations, mixed public/oracle paths, both conversion directions, and universe boundaries; no correctness blockers were found.

Required hosted checks are running after retargeting to `main`; their live status is authoritative.

## Reviewer map

Suggested review order:

1. `docs/design/01a-foundation-pr-plan.md` — AR-2A acceptance boundary
2. `ArkLib/Interaction/Oracle/TypeTree.lean` — canonical positions, lens, and path APIs
3. `ArkLib/Interaction/Oracle/TypeTree/MixedExample.lean` — executable acceptance canary
4. `docs/design/02-oracle-reduction-core.md` — corrected universe boundary
5. generated umbrella import and documentation routing updates
