### PR TITLE
feat(polynomial): add finite Hasse jets, Taylor truncations, and backward residuals

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -418,6 +418,13 @@ import ArkLib.ToMathlib.Polynomial.CompositionDegree
 import ArkLib.ToMathlib.Polynomial.DegreeLT
 import ArkLib.ToMathlib.Polynomial.DivByXPowAddOne
 import ArkLib.ToMathlib.Polynomial.EvalExt
+import ArkLib.ToMathlib.Polynomial.HasseTaylor
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.FiniteJet
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.FiniteJetCanary
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.Forward
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.ForwardCanary
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.Shift
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.ShiftCanary
 import ArkLib.ToMathlib.Polynomial.NatDegreeOfSum
 import ArkLib.ToMathlib.Polynomial.RootMultiplicity
 import ArkLib.ToMathlib.Set.Finite

--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -423,6 +423,7 @@ import ArkLib.ToMathlib.Polynomial.HasseTaylor.FiniteJet
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.FiniteJetCanary
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.Forward
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.ForwardCanary
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.JetDivisibility
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.Shift
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.ShiftCanary
 import ArkLib.ToMathlib.Polynomial.NatDegreeOfSum

--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -424,6 +424,7 @@ import ArkLib.ToMathlib.Polynomial.HasseTaylor.FiniteJetCanary
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.Forward
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.ForwardCanary
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.JetDivisibility
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.JetDivisibilityCanary
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.Shift
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.ShiftCanary
 import ArkLib.ToMathlib.Polynomial.NatDegreeOfSum

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.FiniteJet
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.Forward
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.Shift
+
+/-!
+# Characteristic-safe Hasse--Taylor infrastructure
+
+This module exports ArkLib's reusable univariate Hasse--Taylor API.  It builds on Mathlib's
+`Polynomial.hasseDeriv` and `Polynomial.taylor` without introducing factorial denominators or
+characteristic lower bounds.
+
+The API has three layers:
+
+* `HasseTaylor.FiniteJet` packages derivative orders `< m` as the linear map `hasseJet` and gives
+  exact degree lowering and finite-coordinate equivalences;
+* `HasseTaylor.Forward` gives explicit finite forward truncations with a canonical `X ^ m`
+  remainder quotient;
+* `HasseTaylor.Shift` gives Hasse vanishing/divisibility bridges and the moving-point backward
+  identity, including the normalized error used by hidden-derivative interpolation.
+
+Concrete convention and small-characteristic tests live in the sibling `*Canary` modules so this
+umbrella does not import test-only arithmetic dependencies.
+-/

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor.lean
@@ -16,7 +16,7 @@ This module exports ArkLib's reusable univariate Hasse--Taylor API.  It builds o
 `Polynomial.hasseDeriv` and `Polynomial.taylor` without introducing factorial denominators or
 characteristic lower bounds.
 
-The API has three layers:
+The API has four layers:
 
 * `HasseTaylor.FiniteJet` packages derivative orders `< m` as the linear map `hasseJet` and gives
   exact degree lowering and finite-coordinate equivalences;

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.FiniteJet
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.Forward
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.JetDivisibility
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.Shift
 
 /-!
@@ -21,6 +22,8 @@ The API has three layers:
   exact degree lowering and finite-coordinate equivalences;
 * `HasseTaylor.Forward` gives explicit finite forward truncations with a canonical `X ^ m`
   remainder quotient;
+* `HasseTaylor.JetDivisibility` identifies zero or equal finite jets with the corresponding
+  shifted-power divisibility statements;
 * `HasseTaylor.Shift` gives Hasse vanishing/divisibility bridges and the moving-point backward
   identity, including the normalized error used by hidden-derivative interpolation.
 

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor.lean
@@ -6,8 +6,8 @@ Authors: Quang Dao
 
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.FiniteJet
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.Forward
-import ArkLib.ToMathlib.Polynomial.HasseTaylor.JetDivisibility
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.Shift
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.JetDivisibility
 
 /-!
 # Characteristic-safe Hasse--Taylor infrastructure
@@ -16,16 +16,16 @@ This module exports ArkLib's reusable univariate Hasse--Taylor API.  It builds o
 `Polynomial.hasseDeriv` and `Polynomial.taylor` without introducing factorial denominators or
 characteristic lower bounds.
 
-The API has four layers:
+The API has four layers, listed in dependency order where one layer builds on another:
 
 * `HasseTaylor.FiniteJet` packages derivative orders `< m` as the linear map `hasseJet` and gives
   exact degree lowering and finite-coordinate equivalences;
 * `HasseTaylor.Forward` gives explicit finite forward truncations with a canonical `X ^ m`
   remainder quotient;
-* `HasseTaylor.JetDivisibility` identifies zero or equal finite jets with the corresponding
-  shifted-power divisibility statements;
-* `HasseTaylor.Shift` gives Hasse vanishing/divisibility bridges and the moving-point backward
-  identity, including the normalized error used by hidden-derivative interpolation.
+* `HasseTaylor.Shift` gives scalar Hasse vanishing/divisibility bridges, the elementary shift
+  quotient, and the moving-point backward identity;
+* `HasseTaylor.JetDivisibility` packages the scalar divisibility bridges as zero- and equal-jet
+  characterizations for downstream finite-coordinate consumers.
 
 Concrete convention and small-characteristic tests live in the sibling `*Canary` modules so this
 umbrella does not import test-only arithmetic dependencies.

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
@@ -193,7 +193,7 @@ theorem hasseJet_taylor (m : ℕ) (r s : R) (p : R[X]) :
   exact hasseCoeffAt_taylor r s i p
 
 /-- Mapping coefficients after a forward shift gives the jet at the mapped translated point. -/
-theorem map_hasseJet_taylor {S : Type*} [CommSemiring S] (f : R →+* S)
+theorem map_hasseJet_taylor {S : Type*} [Semiring S] (f : R →+* S)
     (m : ℕ) (r s : R) (p : R[X]) :
     (fun i ↦ f (hasseJet m s (taylor r p) i)) =
       hasseJet m (f s + f r) (p.map f) := by

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
@@ -90,6 +90,20 @@ theorem hasseJet_castSucc (m : ℕ) (r : R) (p : R[X]) (i : Fin m) :
     hasseJet (m + 1) r p i.castSucc = hasseJet m r p i :=
   rfl
 
+/-- The jet through the natural degree of `p` detects whether `p` is zero.
+
+This finite identity principle works over every semiring: its last coordinate is the leading
+coefficient of `p`. -/
+theorem hasseJet_natDegree_add_one_eq_zero_iff (r : R) (p : R[X]) :
+    hasseJet (p.natDegree + 1) r p = 0 ↔ p = 0 := by
+  constructor
+  · intro h
+    rw [← leadingCoeff_eq_zero]
+    have hi := congrFun h ⟨p.natDegree, Nat.lt_add_one _⟩
+    simpa [hasseJet_apply, hasseDeriv_natDegree_eq_C] using hi
+  · rintro rfl
+    exact LinearMap.map_zero _
+
 /-- Taking the `k`-th Hasse derivative lowers a strict degree bound from `n + k` to `n`.
 
 The additive indexing makes the boundary case explicit and avoids truncated-subtraction side

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
@@ -43,6 +43,11 @@ theorem hasseCoeffAt_apply (r : R) (i : ℕ) (p : R[X]) :
     hasseCoeffAt r i p = (hasseDeriv i p).eval r :=
   rfl
 
+/-- At the origin, Hasse coefficients are ordinary polynomial coefficients. -/
+theorem hasseCoeffAt_zero_eq_coeff (i : ℕ) (p : R[X]) :
+    hasseCoeffAt (0 : R) i p = p.coeff i := by
+  rw [hasseCoeffAt_apply, ← taylor_coeff, taylor_zero]
+
 /-- The first `m` Hasse coefficients of a polynomial at `r`.
 
 Index `i : Fin m` records `D⁽ⁱ⁾ p(r)`, where `D⁽ⁱ⁾` is the Hasse derivative.  Thus

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
@@ -108,6 +108,12 @@ theorem hasseJet_castLE {m n : ℕ} (h : m ≤ n) (r : R) (p : R[X]) (i : Fin m)
     hasseJet n r p (Fin.castLE h i) = hasseJet m r p i :=
   rfl
 
+/-- Restricting an order-`m + n` Hasse jet along the canonical prefix embedding gives the
+order-`m` jet. -/
+theorem hasseJet_castAdd (m n : ℕ) (r : R) (p : R[X]) :
+    (fun i : Fin m ↦ hasseJet (m + n) r p (Fin.castAdd n i)) = hasseJet m r p :=
+  rfl
+
 /-- The first `m` entries of the order-`m+1` Hasse jet are the order-`m` jet. -/
 theorem hasseJet_castSucc (m : ℕ) (r : R) (p : R[X]) (i : Fin m) :
     hasseJet (m + 1) r p i.castSucc = hasseJet m r p i :=

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import Mathlib.RingTheory.Polynomial.DegreeLT
+
+/-!
+# Finite Hasse jets of univariate polynomials
+
+This file packages Mathlib's Hasse derivatives into finite coordinate vectors.  The construction is
+valid over arbitrary semirings and therefore does not silently introduce factorial denominators or
+characteristic assumptions.
+
+The main declarations are:
+
+* `Polynomial.hasseCoeffAt`: the `i`-th Hasse derivative evaluated at a point;
+* `Polynomial.hasseJet`: the first `m` Hasse coefficients at a point, as a linear map;
+* `Polynomial.hasseDerivDegreeLT`: the degree-lowering Hasse derivative on `degreeLT`;
+* `Polynomial.hasseJetEquiv`: over a commutative ring, finite jets give coordinates on
+  polynomials of degree strictly less than `m`.
+-/
+
+namespace Polynomial
+
+noncomputable section
+
+variable {R : Type*}
+
+section Semiring
+
+variable [Semiring R]
+
+/-- The `i`-th Hasse coefficient of `p` at `r`, packaged as a linear functional.
+
+Equivalently, this is coefficient `i` of `p(X + r)`. -/
+def hasseCoeffAt (r : R) (i : ℕ) : R[X] →ₗ[R] R :=
+  (leval r).comp (hasseDeriv i)
+
+@[simp]
+theorem hasseCoeffAt_apply (r : R) (i : ℕ) (p : R[X]) :
+    hasseCoeffAt r i p = (hasseDeriv i p).eval r :=
+  rfl
+
+/-- The first `m` Hasse coefficients of a polynomial at `r`.
+
+Index `i : Fin m` records `D⁽ⁱ⁾ p(r)`, where `D⁽ⁱ⁾` is the Hasse derivative.  Thus
+`m = 0` gives the empty jet and `m = 1` records only evaluation at `r`. -/
+def hasseJet (m : ℕ) (r : R) : R[X] →ₗ[R] (Fin m → R) where
+  toFun p i := hasseCoeffAt r i p
+  map_add' p q := by
+    ext i
+    simp
+  map_smul' c p := by
+    ext i
+    simp
+
+@[simp]
+theorem hasseJet_apply (m : ℕ) (r : R) (p : R[X]) (i : Fin m) :
+    hasseJet m r p i = (hasseDeriv i p).eval r :=
+  rfl
+
+@[simp]
+theorem hasseJet_zero_apply (m : ℕ) (r : R) (p : R[X]) :
+    hasseJet (m + 1) r p 0 = p.eval r := by
+  simp
+
+@[simp]
+theorem hasseJet_zero (r : R) (p : R[X]) : hasseJet 0 r p = 0 :=
+  Subsingleton.elim _ _
+
+@[simp]
+theorem hasseJet_one (r : R) (p : R[X]) : hasseJet 1 r p = fun _ ↦ p.eval r := by
+  ext i
+  simp [Fin.eq_zero i]
+
+/-- Finite Hasse jets are precisely the initial coefficients of the Taylor shift. -/
+theorem hasseJet_eq_taylor_coeff (m : ℕ) (r : R) (p : R[X]) (i : Fin m) :
+    hasseJet m r p i = (taylor r p).coeff i := by
+  rw [hasseJet_apply, taylor_coeff]
+
+/-- Taking the `k`-th Hasse derivative lowers a strict degree bound from `n + k` to `n`.
+
+The additive indexing makes the boundary case explicit and avoids truncated-subtraction side
+conditions. -/
+theorem hasseDeriv_mem_degreeLT_add {n k : ℕ} {p : R[X]}
+    (hp : p ∈ degreeLT R (n + k)) : hasseDeriv k p ∈ degreeLT R n := by
+  rw [mem_degreeLT, degree_lt_iff_coeff_zero] at hp ⊢
+  intro i hi
+  rw [hasseDeriv_coeff, hp (i + k) (Nat.add_le_add_right hi k), mul_zero]
+
+/-- Taking the `k`-th Hasse derivative lowers a strict degree bound `d` to `d - k`.
+
+When `d ≤ k`, the target is `degreeLT R 0`, so this theorem also records that every such
+derivative is zero. -/
+theorem hasseDeriv_mem_degreeLT_sub {d k : ℕ} {p : R[X]} (hp : p ∈ degreeLT R d) :
+    hasseDeriv k p ∈ degreeLT R (d - k) := by
+  rw [mem_degreeLT, degree_lt_iff_coeff_zero] at hp ⊢
+  intro i hi
+  rw [hasseDeriv_coeff, hp (i + k) (by omega), mul_zero]
+
+/-- The `k`-th Hasse derivative as a degree-lowering linear map on strict-degree submodules. -/
+def hasseDerivDegreeLT (d k : ℕ) : degreeLT R d →ₗ[R] degreeLT R (d - k) :=
+  (hasseDeriv k).domRestrict (degreeLT R d) |>.codRestrict
+    (degreeLT R (d - k)) fun p ↦ hasseDeriv_mem_degreeLT_sub p.2
+
+@[simp]
+theorem hasseDerivDegreeLT_apply_coe (d k : ℕ) (p : degreeLT R d) :
+    (hasseDerivDegreeLT d k p : R[X]) = hasseDeriv k p :=
+  rfl
+
+end Semiring
+
+section CommSemiring
+
+variable [CommSemiring R]
+
+/-- The product rule for Hasse coefficients, with no characteristic assumptions. -/
+theorem hasseCoeffAt_mul (r : R) (n : ℕ) (p q : R[X]) :
+    hasseCoeffAt r n (p * q) =
+      ∑ ij ∈ Finset.antidiagonal n,
+        hasseCoeffAt r ij.1 p * hasseCoeffAt r ij.2 q := by
+  simp only [hasseCoeffAt_apply, hasseDeriv_mul, eval_finsetSum, eval_mul]
+
+/-- Shifting a polynomial translates the point at which its Hasse jet is evaluated. -/
+theorem hasseCoeffAt_taylor (r s : R) (i : ℕ) (p : R[X]) :
+    hasseCoeffAt s i (taylor r p) = hasseCoeffAt (s + r) i p := by
+  simp only [hasseCoeffAt_apply]
+  rw [← taylor_coeff, ← taylor_coeff, taylor_taylor]
+
+/-- Componentwise form of `hasseCoeffAt_taylor` for finite jets. -/
+theorem hasseJet_taylor (m : ℕ) (r s : R) (p : R[X]) :
+    hasseJet m s (taylor r p) = hasseJet m (s + r) p := by
+  ext i
+  exact hasseCoeffAt_taylor r s i p
+
+end CommSemiring
+
+section CommRing
+
+variable [CommRing R]
+
+/-- Hasse jets at `r` are linear coordinates on polynomials of degree strictly less than `m`.
+
+This is the usual coefficient equivalence after applying Mathlib's degree-preserving Taylor
+automorphism. -/
+noncomputable def hasseJetEquiv (m : ℕ) (r : R) : degreeLT R m ≃ₗ[R] (Fin m → R) :=
+  (taylorLinearEquiv r m).trans (degreeLTEquiv R m)
+
+@[simp]
+theorem hasseJetEquiv_apply (m : ℕ) (r : R) (p : degreeLT R m) (i : Fin m) :
+    hasseJetEquiv m r p i = hasseJet m r p i := by
+  rw [hasseJet_eq_taylor_coeff]
+  change (taylor r (p : R[X])).coeff i = _
+  rfl
+
+/-- Two degree-`< m` polynomials with the same order-`m` Hasse jet are equal. -/
+theorem hasseJet_injective_on_degreeLT (m : ℕ) (r : R) {p q : degreeLT R m}
+    (h : hasseJet m r p = hasseJet m r q) : p = q := by
+  apply (hasseJetEquiv m r).injective
+  ext i
+  simpa using congrFun h i
+
+/-- Every vector of `m` Hasse coefficients occurs for a unique polynomial of degree `< m`. -/
+theorem existsUnique_degreeLT_hasseJet (m : ℕ) (r : R) (v : Fin m → R) :
+    ∃! p : degreeLT R m, hasseJet m r p = v := by
+  let p := (hasseJetEquiv m r).symm v
+  refine ⟨p, ?_, ?_⟩
+  · ext i
+    simpa using congrFun ((hasseJetEquiv m r).apply_symm_apply v) i
+  · intro q hq
+    exact hasseJet_injective_on_degreeLT m r (hq.trans (by
+      ext i
+      simpa using congrFun ((hasseJetEquiv m r).apply_symm_apply v).symm i))
+
+end CommRing
+
+end
+
+end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
@@ -48,6 +48,18 @@ theorem hasseCoeffAt_zero_eq_coeff (i : ℕ) (p : R[X]) :
     hasseCoeffAt (0 : R) i p = p.coeff i := by
   rw [hasseCoeffAt_apply, ← taylor_coeff, taylor_zero]
 
+/-- Hasse derivatives commute with mapping polynomial coefficients along a ring homomorphism. -/
+@[simp]
+theorem map_hasseDeriv {S : Type*} [Semiring S] (f : R →+* S) (i : ℕ) (p : R[X]) :
+    (hasseDeriv i p).map f = hasseDeriv i (p.map f) := by
+  ext n
+  simp [hasseDeriv_coeff]
+
+/-- Hasse coefficients are natural under coefficient-ring homomorphisms. -/
+theorem map_hasseCoeffAt {S : Type*} [Semiring S] (f : R →+* S) (a : R) (i : ℕ)
+    (p : R[X]) : f (hasseCoeffAt a i p) = hasseCoeffAt (f a) i (p.map f) := by
+  rw [hasseCoeffAt_apply, hasseCoeffAt_apply, ← eval_map_apply, map_hasseDeriv]
+
 /-- The first `m` Hasse coefficients of a polynomial at `r`.
 
 Index `i : Fin m` records `D⁽ⁱ⁾ p(r)`, where `D⁽ⁱ⁾` is the Hasse derivative.  Thus
@@ -65,6 +77,12 @@ def hasseJet (m : ℕ) (r : R) : R[X] →ₗ[R] (Fin m → R) where
 theorem hasseJet_apply (m : ℕ) (r : R) (p : R[X]) (i : Fin m) :
     hasseJet m r p i = (hasseDeriv i p).eval r :=
   rfl
+
+/-- Finite Hasse jets are natural under coefficient-ring homomorphisms. -/
+theorem map_hasseJet {S : Type*} [Semiring S] (f : R →+* S) (m : ℕ) (a : R) (p : R[X]) :
+    (fun i ↦ f (hasseJet m a p i)) = hasseJet m (f a) (p.map f) := by
+  ext i
+  exact map_hasseCoeffAt f a i p
 
 @[simp]
 theorem hasseJet_zero_apply (m : ℕ) (r : R) (p : R[X]) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
@@ -80,6 +80,16 @@ theorem hasseJet_eq_taylor_coeff (m : ℕ) (r : R) (p : R[X]) (i : Fin m) :
     hasseJet m r p i = (taylor r p).coeff i := by
   rw [hasseJet_apply, taylor_coeff]
 
+/-- A longer Hasse jet restricts definitionally to every shorter prefix. -/
+theorem hasseJet_castLE {m n : ℕ} (h : m ≤ n) (r : R) (p : R[X]) (i : Fin m) :
+    hasseJet n r p (Fin.castLE h i) = hasseJet m r p i :=
+  rfl
+
+/-- The first `m` entries of the order-`m+1` Hasse jet are the order-`m` jet. -/
+theorem hasseJet_castSucc (m : ℕ) (r : R) (p : R[X]) (i : Fin m) :
+    hasseJet (m + 1) r p i.castSucc = hasseJet m r p i :=
+  rfl
+
 /-- Taking the `k`-th Hasse derivative lowers a strict degree bound from `n + k` to `n`.
 
 The additive indexing makes the boundary case explicit and avoids truncated-subtraction side
@@ -122,6 +132,16 @@ theorem hasseCoeffAt_mul (r : R) (n : ℕ) (p q : R[X]) :
       ∑ ij ∈ Finset.antidiagonal n,
         hasseCoeffAt r ij.1 p * hasseCoeffAt r ij.2 q := by
   simp only [hasseCoeffAt_apply, hasseDeriv_mul, eval_finsetSum, eval_mul]
+
+/-- Iterating Hasse derivatives introduces the expected binomial coefficient. -/
+theorem hasseCoeffAt_hasseDeriv (r : R) (i k : ℕ) (p : R[X]) :
+    hasseCoeffAt r i (hasseDeriv k p) =
+      (Nat.choose (i + k) i : R) * hasseCoeffAt r (i + k) p := by
+  change (hasseDeriv i (hasseDeriv k p)).eval r = _
+  have h := LinearMap.congr_fun (hasseDeriv_comp (R := R) i k) p
+  rw [LinearMap.comp_apply, LinearMap.smul_apply] at h
+  rw [h]
+  simp
 
 /-- Shifting a polynomial translates the point at which its Hasse jet is evaluated. -/
 theorem hasseCoeffAt_taylor (r s : R) (i : ℕ) (p : R[X]) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
@@ -32,6 +32,8 @@ section Semiring
 
 variable [Semiring R]
 
+/-! ### Finite Hasse coordinates -/
+
 /-- The `i`-th Hasse coefficient of `p` at `r`, packaged as a linear functional.
 
 Equivalently, this is coefficient `i` of `p(X + r)`. -/
@@ -133,6 +135,8 @@ theorem hasseJet_natDegree_add_one_eq_zero_iff (r : R) (p : R[X]) :
   · rintro rfl
     exact LinearMap.map_zero _
 
+/-! ### Degree-lowering Hasse derivatives -/
+
 /-- Taking the `k`-th Hasse derivative lowers a strict degree bound from `n + k` to `n`.
 
 The additive indexing makes the boundary case explicit and avoids truncated-subtraction side
@@ -168,6 +172,8 @@ end Semiring
 section CommSemiring
 
 variable [CommSemiring R]
+
+/-! ### Products, shifts, and affine substitutions -/
 
 /-- The product rule for Hasse coefficients, with no characteristic assumptions. -/
 theorem hasseCoeffAt_mul (r : R) (n : ℕ) (p q : R[X]) :
@@ -231,6 +237,8 @@ end CommSemiring
 section CommRing
 
 variable [CommRing R]
+
+/-! ### Finite-jet coordinates for degree-bounded polynomials -/
 
 /-- Hasse jets at `r` are linear coordinates on polynomials of degree strictly less than `m`.
 

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
@@ -192,6 +192,14 @@ theorem hasseJet_taylor (m : ℕ) (r s : R) (p : R[X]) :
   ext i
   exact hasseCoeffAt_taylor r s i p
 
+/-- Mapping coefficients after a forward shift gives the jet at the mapped translated point. -/
+theorem map_hasseJet_taylor {S : Type*} [CommSemiring S] (f : R →+* S)
+    (m : ℕ) (r s : R) (p : R[X]) :
+    (fun i ↦ f (hasseJet m s (taylor r p) i)) =
+      hasseJet m (f s + f r) (p.map f) := by
+  rw [hasseJet_taylor]
+  simpa using map_hasseJet f m (s + r) p
+
 end CommSemiring
 
 section CommRing

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJet.lean
@@ -200,6 +200,26 @@ theorem map_hasseJet_taylor {S : Type*} [Semiring S] (f : R →+* S)
   rw [hasseJet_taylor]
   simpa using map_hasseJet f m (s + r) p
 
+/-- Under the affine substitution `X ↦ cX + a`, Hasse order `i` scales by `c ^ i` and its
+evaluation point moves from `b` to `c * b + a`. -/
+theorem hasseCoeffAt_taylor_comp_C_mul_X (a b c : R) (i : ℕ) (p : R[X]) :
+    hasseCoeffAt b i ((taylor a p).comp (C c * X)) =
+      hasseCoeffAt (c * b + a) i p * c ^ i := by
+  rw [hasseCoeffAt_apply, ← taylor_coeff]
+  rw [show taylor b ((taylor a p).comp (C c * X)) =
+      (taylor (c * b + a) p).comp (C c * X) by
+    simp only [taylor_apply, comp_assoc, add_comp, mul_comp, C_comp, X_comp]
+    congr 1
+    rw [mul_add, ← C_mul, add_assoc, ← C_add]]
+  rw [comp_C_mul_X_coeff, taylor_coeff, ← hasseCoeffAt_apply]
+
+/-- Componentwise affine-substitution law for finite Hasse jets. -/
+theorem hasseJet_taylor_comp_C_mul_X (m : ℕ) (a b c : R) (p : R[X]) :
+    hasseJet m b ((taylor a p).comp (C c * X)) =
+      fun i ↦ hasseJet m (c * b + a) p i * c ^ (i : ℕ) := by
+  ext i
+  exact hasseCoeffAt_taylor_comp_C_mul_X a b c i p
+
 end CommSemiring
 
 section CommRing

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJetCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJetCanary.lean
@@ -77,4 +77,14 @@ example :
       Fin.reduceFinMk, Matrix.cons_val]
     decide
 
+/-- A prefix-orientation canary: the first two coordinates of the length-three jet are
+`[D⁽⁰⁾, D⁽¹⁾] = [1, 2]`, not the last two coordinates `[2, 1]`. -/
+example :
+    (fun i : Fin 2 ↦ hasseJet 3 (1 : ZMod 5) (X ^ 2) (Fin.castAdd 1 i)) = ![1, 2] := by
+  calc
+    _ = hasseJet 2 (1 : ZMod 5) (X ^ 2) := hasseJet_castAdd 2 1 1 (X ^ 2)
+    _ = ![1, 2] := by
+      funext i
+      fin_cases i <;> norm_num [hasseJet_apply, hasseDeriv_monomial]
+
 end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJetCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJetCanary.lean
@@ -60,4 +60,21 @@ example :
       · rw [hasseJet_apply, X_pow_eq_monomial]
         simp [hasseDeriv_monomial]
 
+/-- An affine-scaling canary: for `p = X²`, offset `1`, scale `2`, and observation point `1`,
+the translated point is `3` and Hasse orders scale by `1, 2, 4`. -/
+example :
+    hasseJet 3 (1 : ZMod 5) ((taylor 1 (X ^ 2)).comp (C 2 * X)) = ![4, 2, 4] := by
+  rw [hasseJet_taylor_comp_C_mul_X]
+  funext i
+  fin_cases i
+  · norm_num [hasseJet_apply, hasseDeriv_monomial]
+    decide
+  · norm_num [hasseJet_apply, hasseDeriv_monomial]
+    decide
+  · rw [hasseJet_apply, X_pow_eq_monomial]
+    simp only [mul_one, hasseDeriv_monomial, tsub_self, Nat.choose_self, Nat.cast_one,
+      monomial_zero_left, map_one, eval_one, one_mul, Nat.succ_eq_add_one, Nat.reduceAdd,
+      Fin.reduceFinMk, Matrix.cons_val]
+    decide
+
 end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJetCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJetCanary.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.FiniteJet
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic.NormNum
+
+/-!
+# Canaries for finite Hasse jets
+
+These examples are intentionally concrete.  In characteristic two the ordinary derivative of
+`X²` vanishes, while its second Hasse derivative is one; this catches accidental replacement of
+Hasse derivatives by iterated ordinary derivatives.
+-/
+
+namespace Polynomial
+
+/-- Iterating the ordinary derivative also loses the order-two coefficient in characteristic two. -/
+example : derivative^[2] (X ^ 2 : (ZMod 2)[X]) = 0 := by
+  have htwo : (2 : ZMod 2) = 0 := ZMod.natCast_self 2
+  simp [Function.iterate_succ_apply', derivative_pow, htwo]
+
+example : hasseJet 3 (0 : ZMod 2) (X ^ 2) = ![0, 0, 1] := by
+  funext i
+  fin_cases i
+  · simp
+  · simp
+  · rw [X_pow_eq_monomial]
+    simp
+
+/-- A point/index canary: the first Hasse coefficient of `X²` at `1` in characteristic three is
+`2`, while the zeroth coefficient is `1`. -/
+example : hasseJet 2 (1 : ZMod 3) (X ^ 2) 1 = 2 := by
+  norm_num [hasseJet_apply, hasseDeriv_monomial]
+
+/-- A shift-sign canary: shifting `X` forward by `2` and taking its jet at `1` gives constant
+coefficient `3`, not `-1`. -/
+example : hasseJet 2 (1 : ZMod 5) (taylor 2 X) = ![3, 1] := by
+  funext i
+  fin_cases i <;> norm_num [hasseJet_apply, taylor_X]
+
+end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJetCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/FiniteJetCanary.lean
@@ -42,4 +42,22 @@ example : hasseJet 2 (1 : ZMod 5) (taylor 2 X) = ![3, 1] := by
   funext i
   fin_cases i <;> norm_num [hasseJet_apply, taylor_X]
 
+/-- A map/shift commutation canary: the integral jet `[1, 2, 1]` of `(X + 1)²` maps to
+`[1, 0, 1]` in characteristic two. -/
+example :
+    (fun i ↦ (Int.castRingHom (ZMod 2))
+      (hasseJet 3 (0 : ℤ) (taylor 1 (X ^ 2)) i)) = ![1, 0, 1] := by
+  calc
+    _ = hasseJet 3 ((Int.castRingHom (ZMod 2)) 0 + (Int.castRingHom (ZMod 2)) 1)
+        ((X ^ 2 : ℤ[X]).map (Int.castRingHom (ZMod 2))) :=
+      map_hasseJet_taylor (Int.castRingHom (ZMod 2)) 3 1 0 (X ^ 2)
+    _ = ![1, 0, 1] := by
+      funext i
+      fin_cases i
+      · norm_num [hasseJet_apply, hasseDeriv_monomial]
+      · have hone : (1 + 1 : ZMod 2) = 0 := by decide
+        simpa [hasseJet_apply, hasseDeriv_monomial] using hone
+      · rw [hasseJet_apply, X_pow_eq_monomial]
+        simp [hasseDeriv_monomial]
+
 end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -57,6 +57,20 @@ theorem forwardTaylorTruncation_mem_degreeLT (m : ℕ) (a : R) (p : R[X]) :
   rw [mem_degreeLT, degree_lt_iff_coeff_zero]
   exact fun i hi ↦ coeff_forwardTaylorTruncation_of_le m a p hi
 
+/-- Once `m` is a strict degree bound for `p`, its finite forward truncation is the full Taylor
+shift.  Stating the hypothesis with `degreeLT` includes the zero polynomial even at `m = 0`. -/
+theorem forwardTaylorTruncation_eq_taylor_of_mem_degreeLT (m : ℕ) (a : R) (p : R[X])
+    (hp : p ∈ degreeLT R m) : forwardTaylorTruncation m a p = taylor a p := by
+  ext i
+  by_cases hi : i < m
+  · exact coeff_forwardTaylorTruncation_of_lt m a p hi
+  · rw [coeff_forwardTaylorTruncation_of_le m a p (not_lt.mp hi)]
+    have hdeg : (taylor a p).degree < (i : WithBot ℕ) := by
+      rw [degree_taylor]
+      exact (mem_degreeLT.mp hp).trans_le
+        (WithBot.coe_le_coe.mpr (not_lt.mp hi))
+    exact (coeff_eq_zero_of_degree_lt hdeg).symm
+
 @[simp]
 theorem forwardTaylorTruncation_zero (a : R) (p : R[X]) :
     forwardTaylorTruncation 0 a p = 0 := by
@@ -139,6 +153,12 @@ theorem forwardTaylorRemainder_zero (a : R) (p : R[X]) :
     forwardTaylorRemainder 0 a p = taylor a p := by
   simp [forwardTaylorRemainder]
 
+/-- A truncation past the degree of `p` has zero forward remainder. -/
+theorem forwardTaylorRemainder_eq_zero_of_mem_degreeLT (m : ℕ) (a : R) (p : R[X])
+    (hp : p ∈ degreeLT R m) : forwardTaylorRemainder m a p = 0 := by
+  rw [forwardTaylorRemainder, forwardTaylorTruncation_eq_taylor_of_mem_degreeLT m a p hp,
+    sub_self]
+
 @[simp]
 theorem forwardTaylorRemainder_one (a : R) (p : R[X]) :
     forwardTaylorRemainder 1 a p = taylor a p - C (p.eval a) := by
@@ -148,6 +168,12 @@ theorem forwardTaylorRemainder_one (a : R) (p : R[X]) :
 theorem forwardTaylorQuotient_zero (a : R) (p : R[X]) :
     forwardTaylorQuotient 0 a p = taylor a p := by
   simp [forwardTaylorQuotient]
+
+/-- A truncation past the degree of `p` also has zero canonical quotient. -/
+theorem forwardTaylorQuotient_eq_zero_of_mem_degreeLT (m : ℕ) (a : R) (p : R[X])
+    (hp : p ∈ degreeLT R m) : forwardTaylorQuotient m a p = 0 := by
+  rw [forwardTaylorQuotient, forwardTaylorRemainder_eq_zero_of_mem_degreeLT m a p hp,
+    zero_divByMonic]
 
 end Ring
 

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -54,11 +54,6 @@ private def forwardTaylorTruncationToPolynomial (m : ℕ) (a : R) : R[X] →ₗ[
     simp only [coeff_smul, coeff_forwardTaylorTruncation]
     split_ifs <;> simp
 
-/-- At the origin, Hasse coefficients are ordinary polynomial coefficients. -/
-theorem hasseCoeffAt_zero_eq_coeff (i : ℕ) (p : R[X]) :
-    hasseCoeffAt (0 : R) i p = p.coeff i := by
-  rw [hasseCoeffAt_apply, ← taylor_coeff, taylor_zero]
-
 /-- Below the truncation order, the finite polynomial agrees coefficientwise with `p(X + a)`. -/
 theorem coeff_forwardTaylorTruncation_of_lt (m : ℕ) (a : R) (p : R[X]) {i : ℕ}
     (hi : i < m) : (forwardTaylorTruncation m a p).coeff i = (taylor a p).coeff i := by
@@ -180,6 +175,17 @@ theorem X_pow_mul_forwardTaylorQuotient (m : ℕ) (a : R) (p : R[X]) :
       (X_pow_dvd_forwardTaylorRemainder m a p)
   simpa [forwardTaylorQuotient, hmod] using
     modByMonic_add_div (forwardTaylorRemainder m a p) (X ^ m)
+
+/-- Coefficient `i` of the canonical quotient is Hasse--Taylor order `i + m` of `p` at `a`. -/
+@[simp]
+theorem coeff_forwardTaylorQuotient (m : ℕ) (a : R) (p : R[X]) (i : ℕ) :
+    (forwardTaylorQuotient m a p).coeff i = hasseCoeffAt a (i + m) p := by
+  have h := congrArg (fun q : R[X] ↦ q.coeff (i + m))
+    (X_pow_mul_forwardTaylorQuotient m a p)
+  rw [coeff_X_pow_mul, forwardTaylorRemainder, coeff_sub,
+    coeff_forwardTaylorTruncation_of_le m a p (Nat.le_add_left m i), sub_zero,
+    taylor_coeff] at h
+  exact h
 
 /-- Finite forward Hasse--Taylor reconstruction with a canonical quotient remainder. -/
 theorem taylor_eq_forwardTaylorTruncation_add_X_pow_mul_quotient

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -163,6 +163,14 @@ variable [Ring R]
 def forwardTaylorRemainder (m : ℕ) (a : R) (p : R[X]) : R[X] :=
   taylor a p - forwardTaylorTruncation m a p
 
+/-- Forward Taylor remainders are natural under coefficient-ring homomorphisms. -/
+theorem map_forwardTaylorRemainder {S : Type*} [Ring S] (f : R →+* S)
+    (m : ℕ) (a : R) (p : R[X]) :
+    (forwardTaylorRemainder m a p).map f =
+      forwardTaylorRemainder m (f a) (p.map f) := by
+  rw [forwardTaylorRemainder, forwardTaylorRemainder, Polynomial.map_sub, map_taylor,
+    map_forwardTaylorTruncation]
+
 /-- Every coefficient of the forward Taylor remainder below `m` vanishes. -/
 theorem coeff_forwardTaylorRemainder_of_lt (m : ℕ) (a : R) (p : R[X]) {i : ℕ}
     (hi : i < m) : (forwardTaylorRemainder m a p).coeff i = 0 := by
@@ -198,6 +206,15 @@ theorem coeff_forwardTaylorQuotient (m : ℕ) (a : R) (p : R[X]) (i : ℕ) :
     coeff_forwardTaylorTruncation_of_le m a p (Nat.le_add_left m i), sub_zero,
     taylor_coeff] at h
   exact h
+
+/-- Canonical forward Taylor quotients are natural under coefficient-ring homomorphisms. -/
+theorem map_forwardTaylorQuotient {S : Type*} [Ring S] (f : R →+* S)
+    (m : ℕ) (a : R) (p : R[X]) :
+    (forwardTaylorQuotient m a p).map f =
+      forwardTaylorQuotient m (f a) (p.map f) := by
+  ext i
+  rw [coeff_map, coeff_forwardTaylorQuotient, coeff_forwardTaylorQuotient]
+  exact map_hasseCoeffAt f a (i + m) p
 
 /-- Finite forward Hasse--Taylor reconstruction with a canonical quotient remainder. -/
 theorem taylor_eq_forwardTaylorTruncation_add_X_pow_mul_quotient

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -247,6 +247,19 @@ theorem coeff_forwardTaylorQuotient (m : ℕ) (a : R) (p : R[X]) (i : ℕ) :
     taylor_coeff] at h
   exact h
 
+/-- The final `n` coordinates of an order-`m + n` jet are the order-`n` jet at zero of the
+order-`m` forward Taylor quotient.  The canonical `Fin.natAdd` embedding selects this tail. -/
+theorem hasseJet_natAdd_eq_forwardTaylorQuotient
+    (m n : ℕ) (a : R) (p : R[X]) :
+    (fun i : Fin n ↦ hasseJet (m + n) a p (Fin.natAdd m i)) =
+      hasseJet n 0 (forwardTaylorQuotient m a p) := by
+  ext i
+  change hasseCoeffAt a (m + (i : ℕ)) p =
+    hasseCoeffAt 0 (i : ℕ) (forwardTaylorQuotient m a p)
+  rw [hasseCoeffAt_zero_eq_coeff, coeff_forwardTaylorQuotient]
+  congr 2
+  omega
+
 /-- Removing the first `m` Taylor coefficients lowers natural degree by at least `m`.
 
 This formulation is zero-aware: it remains meaningful for `p = 0` and when `m` exceeds the

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -89,6 +89,17 @@ theorem forwardTaylorTruncationLinearMap_coordinates (m : ℕ) (a : R) (p : R[X]
   rw [coeff_forwardTaylorTruncation, if_pos i.isLt]
   rfl
 
+/-- The degree-bounded forward truncation map is obtained by decoding Hasse-jet coordinates. -/
+theorem forwardTaylorTruncationLinearMap_eq_degreeLTEquiv_symm_comp_hasseJet
+    (m : ℕ) (a : R) :
+    forwardTaylorTruncationLinearMap m a =
+      (degreeLTEquiv R m).symm.toLinearMap.comp (hasseJet m a) := by
+  apply LinearMap.ext
+  intro p
+  apply (degreeLTEquiv R m).injective
+  rw [forwardTaylorTruncationLinearMap_coordinates]
+  simp
+
 /-- Forward Taylor truncation is natural under coefficient-ring homomorphisms. -/
 theorem map_forwardTaylorTruncation {S : Type*} [Semiring S] (f : R →+* S)
     (m : ℕ) (a : R) (p : R[X]) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.FiniteJet
+
+/-!
+# Finite forward Hasse--Taylor truncations
+
+This file packages the first `m` coefficients of Mathlib's forward Taylor shift `p(X + a)` as an
+explicit polynomial.  Unlike `Polynomial.sum_taylor_eq`, which reconstructs `p` after shifting
+back by `a`, this API stays in the displacement variable `X`.  It is intended for consumers that
+need a finite jet plus a remainder divisible by `X ^ m`.
+
+Construction and coefficient lemmas require only a semiring.  Subtraction, the remainder, and its
+canonical quotient by the monic polynomial `X ^ m` are isolated in the `Ring` section.
+-/
+
+namespace Polynomial
+
+noncomputable section
+
+variable {R : Type*}
+
+section Semiring
+
+variable [Semiring R]
+
+/-- The polynomial consisting of Hasse--Taylor orders strictly below `m` at `a`.
+
+It is expressed in the forward displacement variable: coefficient `i < m` is `D⁽ⁱ⁾ p(a)`. -/
+def forwardTaylorTruncation (m : ℕ) (a : R) (p : R[X]) : R[X] :=
+  ∑ i ∈ Finset.range m, C (hasseCoeffAt a i p) * X ^ i
+
+/-- Coefficients of the finite forward Taylor truncation. -/
+@[simp]
+theorem coeff_forwardTaylorTruncation (m : ℕ) (a : R) (p : R[X]) (i : ℕ) :
+    (forwardTaylorTruncation m a p).coeff i =
+      if i < m then hasseCoeffAt a i p else 0 := by
+  simp [forwardTaylorTruncation, finsetSum_coeff]
+
+/-- Below the truncation order, the finite polynomial agrees coefficientwise with `p(X + a)`. -/
+theorem coeff_forwardTaylorTruncation_of_lt (m : ℕ) (a : R) (p : R[X]) {i : ℕ}
+    (hi : i < m) : (forwardTaylorTruncation m a p).coeff i = (taylor a p).coeff i := by
+  rw [coeff_forwardTaylorTruncation, if_pos hi, hasseCoeffAt_apply, taylor_coeff]
+
+/-- At and above the truncation order, the finite forward Taylor truncation has zero coefficient. -/
+theorem coeff_forwardTaylorTruncation_of_le (m : ℕ) (a : R) (p : R[X]) {i : ℕ}
+    (hi : m ≤ i) : (forwardTaylorTruncation m a p).coeff i = 0 := by
+  rw [coeff_forwardTaylorTruncation, if_neg (not_lt_of_ge hi)]
+
+/-- The forward Taylor truncation has degree strictly less than its truncation order. -/
+theorem forwardTaylorTruncation_mem_degreeLT (m : ℕ) (a : R) (p : R[X]) :
+    forwardTaylorTruncation m a p ∈ degreeLT R m := by
+  rw [mem_degreeLT, degree_lt_iff_coeff_zero]
+  exact fun i hi ↦ coeff_forwardTaylorTruncation_of_le m a p hi
+
+@[simp]
+theorem forwardTaylorTruncation_zero (a : R) (p : R[X]) :
+    forwardTaylorTruncation 0 a p = 0 := by
+  simp [forwardTaylorTruncation]
+
+@[simp]
+theorem forwardTaylorTruncation_one (a : R) (p : R[X]) :
+    forwardTaylorTruncation 1 a p = C (p.eval a) := by
+  simp [forwardTaylorTruncation, hasseCoeffAt_apply]
+
+/-- At the origin, truncating a monomial either keeps the monomial or discards it. -/
+theorem forwardTaylorTruncation_X_pow (m n : ℕ) :
+    forwardTaylorTruncation m (0 : R) (X ^ n) = if n < m then X ^ n else 0 := by
+  ext i
+  have hcoeff : hasseCoeffAt (0 : R) i (X ^ n) = (X ^ n : R[X]).coeff i := by
+    rw [hasseCoeffAt_apply, ← taylor_coeff, taylor_zero]
+  rw [coeff_forwardTaylorTruncation, hcoeff]
+  by_cases hin : i = n
+  · subst i
+    by_cases hn : n < m
+    · rw [if_pos hn, if_pos hn, coeff_X_pow_self]
+    · rw [if_neg hn, if_neg hn, coeff_zero]
+  · by_cases hn : n < m
+    · rw [if_pos hn, coeff_X_pow, if_neg hin]
+      simp
+    · rw [if_neg hn, coeff_zero]
+      simp [hin]
+
+end Semiring
+
+section Ring
+
+variable [Ring R]
+
+/-- The part of the forward Taylor shift left after removing all orders below `m`. -/
+def forwardTaylorRemainder (m : ℕ) (a : R) (p : R[X]) : R[X] :=
+  taylor a p - forwardTaylorTruncation m a p
+
+/-- Every coefficient of the forward Taylor remainder below `m` vanishes. -/
+theorem coeff_forwardTaylorRemainder_of_lt (m : ℕ) (a : R) (p : R[X]) {i : ℕ}
+    (hi : i < m) : (forwardTaylorRemainder m a p).coeff i = 0 := by
+  rw [forwardTaylorRemainder, coeff_sub, coeff_forwardTaylorTruncation_of_lt m a p hi,
+    sub_self]
+
+/-- The forward Taylor remainder is divisible by `X ^ m`. -/
+theorem X_pow_dvd_forwardTaylorRemainder (m : ℕ) (a : R) (p : R[X]) :
+    X ^ m ∣ forwardTaylorRemainder m a p := by
+  rw [X_pow_dvd_iff]
+  exact fun i hi ↦ coeff_forwardTaylorRemainder_of_lt m a p hi
+
+/-- The canonical monic-division quotient of the forward Taylor remainder by `X ^ m`. -/
+def forwardTaylorQuotient (m : ℕ) (a : R) (p : R[X]) : R[X] :=
+  forwardTaylorRemainder m a p /ₘ (X ^ m)
+
+/-- Multiplying the canonical quotient by `X ^ m` recovers the forward Taylor remainder. -/
+theorem X_pow_mul_forwardTaylorQuotient (m : ℕ) (a : R) (p : R[X]) :
+    X ^ m * forwardTaylorQuotient m a p = forwardTaylorRemainder m a p := by
+  have hmod : forwardTaylorRemainder m a p %ₘ (X ^ m) = 0 :=
+    (modByMonic_eq_zero_iff_dvd (monic_X_pow m)).2
+      (X_pow_dvd_forwardTaylorRemainder m a p)
+  simpa [forwardTaylorQuotient, hmod] using
+    modByMonic_add_div (forwardTaylorRemainder m a p) (X ^ m)
+
+/-- Finite forward Hasse--Taylor reconstruction with a canonical quotient remainder. -/
+theorem taylor_eq_forwardTaylorTruncation_add_X_pow_mul_quotient
+    (m : ℕ) (a : R) (p : R[X]) :
+    taylor a p =
+      forwardTaylorTruncation m a p + X ^ m * forwardTaylorQuotient m a p := by
+  rw [X_pow_mul_forwardTaylorQuotient, forwardTaylorRemainder]
+  rw [sub_eq_add_neg]
+  calc
+    taylor a p = 0 + taylor a p := (zero_add _).symm
+    _ = (forwardTaylorTruncation m a p + -forwardTaylorTruncation m a p) + taylor a p := by
+      rw [add_neg_cancel]
+    _ = forwardTaylorTruncation m a p + (taylor a p + -forwardTaylorTruncation m a p) := by
+      ac_rfl
+
+@[simp]
+theorem forwardTaylorRemainder_zero (a : R) (p : R[X]) :
+    forwardTaylorRemainder 0 a p = taylor a p := by
+  simp [forwardTaylorRemainder]
+
+@[simp]
+theorem forwardTaylorRemainder_one (a : R) (p : R[X]) :
+    forwardTaylorRemainder 1 a p = taylor a p - C (p.eval a) := by
+  simp [forwardTaylorRemainder]
+
+@[simp]
+theorem forwardTaylorQuotient_zero (a : R) (p : R[X]) :
+    forwardTaylorQuotient 0 a p = taylor a p := by
+  simp [forwardTaylorQuotient]
+
+end Ring
+
+end
+
+
+end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -89,6 +89,18 @@ theorem forwardTaylorTruncationLinearMap_coordinates (m : ℕ) (a : R) (p : R[X]
   rw [coeff_forwardTaylorTruncation, if_pos i.isLt]
   rfl
 
+/-- Forward Taylor truncation is natural under coefficient-ring homomorphisms. -/
+theorem map_forwardTaylorTruncation {S : Type*} [Semiring S] (f : R →+* S)
+    (m : ℕ) (a : R) (p : R[X]) :
+    (forwardTaylorTruncation m a p).map f =
+      forwardTaylorTruncation m (f a) (p.map f) := by
+  ext i
+  simp only [coeff_map, coeff_forwardTaylorTruncation]
+  by_cases hi : i < m
+  · rw [if_pos hi, if_pos hi]
+    exact map_hasseCoeffAt f a i p
+  · rw [if_neg hi, if_neg hi, map_zero]
+
 /-- Once `m` is a strict degree bound for `p`, its finite forward truncation is the full Taylor
 shift.  Stating the hypothesis with `degreeLT` includes the zero polynomial even at `m = 0`. -/
 theorem forwardTaylorTruncation_eq_taylor_of_mem_degreeLT (m : ℕ) (a : R) (p : R[X])

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -357,6 +357,13 @@ theorem forwardTaylorQuotient_zero (a : R) (p : R[X]) :
     forwardTaylorQuotient 0 a p = taylor a p := by
   simp [forwardTaylorQuotient]
 
+/-- The canonical order-`m` Taylor tail is obtained by dropping the first `m` coefficients of
+the full Taylor shift. -/
+theorem forwardTaylorQuotient_eq_iterate_divX_taylor (m : ℕ) (a : R) (p : R[X]) :
+    forwardTaylorQuotient m a p = divX^[m] (taylor a p) := by
+  simpa only [zero_add, forwardTaylorQuotient_zero] using
+    forwardTaylorQuotient_add_eq_iterate_divX 0 m a p
+
 /-- A truncation past the degree of `p` also has zero canonical quotient. -/
 theorem forwardTaylorQuotient_eq_zero_of_mem_degreeLT (m : ℕ) (a : R) (p : R[X])
     (hp : p ∈ degreeLT R m) : forwardTaylorQuotient m a p = 0 := by

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -155,6 +155,22 @@ theorem forwardTaylorTruncation_zero_comp (m n : ℕ) (a : R) (p : R[X]) :
 
 end Semiring
 
+section CommSemiring
+
+variable [CommSemiring R]
+
+/-- Successive changes of origin add their centers before finite forward truncation. -/
+theorem forwardTaylorTruncation_taylor (m : ℕ) (a b : R) (p : R[X]) :
+    forwardTaylorTruncation m b (taylor a p) =
+      forwardTaylorTruncation m (b + a) p := by
+  ext i
+  simp only [coeff_forwardTaylorTruncation]
+  split_ifs
+  · rw [hasseCoeffAt_taylor]
+  · rfl
+
+end CommSemiring
+
 section Ring
 
 variable [Ring R]
@@ -258,6 +274,25 @@ theorem forwardTaylorQuotient_eq_zero_of_mem_degreeLT (m : ℕ) (a : R) (p : R[X
     zero_divByMonic]
 
 end Ring
+
+section CommRing
+
+variable [CommRing R]
+
+/-- Successive changes of origin add their centers before taking the forward remainder. -/
+theorem forwardTaylorRemainder_taylor (m : ℕ) (a b : R) (p : R[X]) :
+    forwardTaylorRemainder m b (taylor a p) =
+      forwardTaylorRemainder m (b + a) p := by
+  rw [forwardTaylorRemainder, forwardTaylorRemainder, taylor_taylor,
+    forwardTaylorTruncation_taylor]
+
+/-- Successive changes of origin add their centers before taking the canonical tail quotient. -/
+theorem forwardTaylorQuotient_taylor (m : ℕ) (a b : R) (p : R[X]) :
+    forwardTaylorQuotient m b (taylor a p) =
+      forwardTaylorQuotient m (b + a) p := by
+  rw [forwardTaylorQuotient, forwardTaylorQuotient, forwardTaylorRemainder_taylor]
+
+end CommRing
 
 end
 

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -41,6 +41,24 @@ theorem coeff_forwardTaylorTruncation (m : ℕ) (a : R) (p : R[X]) (i : ℕ) :
       if i < m then hasseCoeffAt a i p else 0 := by
   simp [forwardTaylorTruncation, finsetSum_coeff]
 
+/-- Forward Taylor truncation as an ambient-polynomial linear map, before restricting its
+codomain to `degreeLT`. -/
+private def forwardTaylorTruncationToPolynomial (m : ℕ) (a : R) : R[X] →ₗ[R] R[X] where
+  toFun := forwardTaylorTruncation m a
+  map_add' p q := by
+    ext i
+    simp only [coeff_add, coeff_forwardTaylorTruncation]
+    split_ifs <;> simp
+  map_smul' c p := by
+    ext i
+    simp only [coeff_smul, coeff_forwardTaylorTruncation]
+    split_ifs <;> simp
+
+/-- At the origin, Hasse coefficients are ordinary polynomial coefficients. -/
+theorem hasseCoeffAt_zero_eq_coeff (i : ℕ) (p : R[X]) :
+    hasseCoeffAt (0 : R) i p = p.coeff i := by
+  rw [hasseCoeffAt_apply, ← taylor_coeff, taylor_zero]
+
 /-- Below the truncation order, the finite polynomial agrees coefficientwise with `p(X + a)`. -/
 theorem coeff_forwardTaylorTruncation_of_lt (m : ℕ) (a : R) (p : R[X]) {i : ℕ}
     (hi : i < m) : (forwardTaylorTruncation m a p).coeff i = (taylor a p).coeff i := by
@@ -56,6 +74,25 @@ theorem forwardTaylorTruncation_mem_degreeLT (m : ℕ) (a : R) (p : R[X]) :
     forwardTaylorTruncation m a p ∈ degreeLT R m := by
   rw [mem_degreeLT, degree_lt_iff_coeff_zero]
   exact fun i hi ↦ coeff_forwardTaylorTruncation_of_le m a p hi
+
+/-- Forward Taylor truncation as a linear map whose codomain records the strict degree bound. -/
+def forwardTaylorTruncationLinearMap (m : ℕ) (a : R) :
+    R[X] →ₗ[R] degreeLT R m :=
+  (forwardTaylorTruncationToPolynomial m a).codRestrict
+    (degreeLT R m) (forwardTaylorTruncation_mem_degreeLT m a)
+
+@[simp]
+theorem forwardTaylorTruncationLinearMap_apply_coe (m : ℕ) (a : R) (p : R[X]) :
+    (forwardTaylorTruncationLinearMap m a p : R[X]) = forwardTaylorTruncation m a p :=
+  rfl
+
+/-- The coefficient coordinates of the degree-bounded truncation are exactly the Hasse jet. -/
+theorem forwardTaylorTruncationLinearMap_coordinates (m : ℕ) (a : R) (p : R[X]) :
+    degreeLTEquiv R m (forwardTaylorTruncationLinearMap m a p) = hasseJet m a p := by
+  ext i
+  change (forwardTaylorTruncation m a p).coeff i = hasseJet m a p i
+  rw [coeff_forwardTaylorTruncation, if_pos i.isLt]
+  rfl
 
 /-- Once `m` is a strict degree bound for `p`, its finite forward truncation is the full Taylor
 shift.  Stating the hypothesis with `degreeLT` includes the zero polynomial even at `m = 0`. -/
@@ -98,6 +135,16 @@ theorem forwardTaylorTruncation_X_pow (m n : ℕ) :
       simp
     · rw [if_neg hn, coeff_zero]
       simp [hin]
+
+/-- Re-truncating the coefficient polynomial at zero composes the two bounds by `min`. -/
+theorem forwardTaylorTruncation_zero_comp (m n : ℕ) (a : R) (p : R[X]) :
+    forwardTaylorTruncation m 0 (forwardTaylorTruncation n a p) =
+      forwardTaylorTruncation (min m n) a p := by
+  ext i
+  rw [coeff_forwardTaylorTruncation, hasseCoeffAt_zero_eq_coeff,
+    coeff_forwardTaylorTruncation, coeff_forwardTaylorTruncation]
+  simp only [lt_min_iff]
+  split_ifs <;> simp_all
 
 end Semiring
 

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -28,6 +28,8 @@ section Semiring
 
 variable [Semiring R]
 
+/-! ### Finite truncation and degree-bounded coordinates -/
+
 /-- The polynomial consisting of Hasse--Taylor orders strictly below `m` at `a`.
 
 It is expressed in the forward displacement variable: coefficient `i < m` is `D⁽ⁱ⁾ p(a)`. -/
@@ -170,6 +172,8 @@ section CommSemiring
 
 variable [CommSemiring R]
 
+/-! ### Change of center and affine substitution -/
+
 /-- Successive changes of origin add their centers before finite forward truncation. -/
 theorem forwardTaylorTruncation_taylor (m : ℕ) (a b : R) (p : R[X]) :
     forwardTaylorTruncation m b (taylor a p) =
@@ -198,6 +202,8 @@ end CommSemiring
 section Ring
 
 variable [Ring R]
+
+/-! ### Canonical forward remainders and tail quotients -/
 
 /-- The part of the forward Taylor shift left after removing all orders below `m`. -/
 def forwardTaylorRemainder (m : ℕ) (a : R) (p : R[X]) : R[X] :=
@@ -375,6 +381,8 @@ end Ring
 section CommRing
 
 variable [CommRing R]
+
+/-! ### Change of center and affine substitution for remainders -/
 
 /-- Successive changes of origin add their centers before taking the forward remainder. -/
 theorem forwardTaylorRemainder_taylor (m : ℕ) (a b : R) (p : R[X]) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -209,6 +209,15 @@ variable [Ring R]
 def forwardTaylorRemainder (m : ℕ) (a : R) (p : R[X]) : R[X] :=
   taylor a p - forwardTaylorTruncation m a p
 
+/-- The forward Taylor remainder as a linear map in the input polynomial. -/
+def forwardTaylorRemainderLinearMap (m : ℕ) (a : R) : R[X] →ₗ[R] R[X] :=
+  taylor a - forwardTaylorTruncationToPolynomial m a
+
+@[simp]
+theorem forwardTaylorRemainderLinearMap_apply (m : ℕ) (a : R) (p : R[X]) :
+    forwardTaylorRemainderLinearMap m a p = forwardTaylorRemainder m a p :=
+  rfl
+
 /-- Forward Taylor remainders are natural under coefficient-ring homomorphisms. -/
 theorem map_forwardTaylorRemainder {S : Type*} [Ring S] (f : R →+* S)
     (m : ℕ) (a : R) (p : R[X]) :
@@ -252,6 +261,22 @@ theorem coeff_forwardTaylorQuotient (m : ℕ) (a : R) (p : R[X]) (i : ℕ) :
     coeff_forwardTaylorTruncation_of_le m a p (Nat.le_add_left m i), sub_zero,
     taylor_coeff] at h
   exact h
+
+/-- The canonical forward Taylor tail as a linear map in the input polynomial. -/
+def forwardTaylorQuotientLinearMap (m : ℕ) (a : R) : R[X] →ₗ[R] R[X] where
+  toFun := forwardTaylorQuotient m a
+  map_add' p q := by
+    ext i
+    simp only [coeff_add, coeff_forwardTaylorQuotient, LinearMap.map_add]
+  map_smul' c p := by
+    ext i
+    rw [coeff_smul, coeff_forwardTaylorQuotient, coeff_forwardTaylorQuotient]
+    simp
+
+@[simp]
+theorem forwardTaylorQuotientLinearMap_apply (m : ℕ) (a : R) (p : R[X]) :
+    forwardTaylorQuotientLinearMap m a p = forwardTaylorQuotient m a p :=
+  rfl
 
 /-- The final `n` coordinates of an order-`m + n` jet are the order-`n` jet at zero of the
 order-`m` forward Taylor quotient.  The canonical `Fin.natAdd` embedding selects this tail. -/

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -247,6 +247,29 @@ theorem coeff_forwardTaylorQuotient (m : ℕ) (a : R) (p : R[X]) (i : ℕ) :
     taylor_coeff] at h
   exact h
 
+/-- Removing the first `m` Taylor coefficients lowers natural degree by at least `m`.
+
+This formulation is zero-aware: it remains meaningful for `p = 0` and when `m` exceeds the
+degree of `p`. -/
+theorem natDegree_forwardTaylorQuotient_le (m : ℕ) (a : R) (p : R[X]) :
+    (forwardTaylorQuotient m a p).natDegree ≤ p.natDegree - m := by
+  rw [natDegree_le_iff_coeff_eq_zero]
+  intro i hi
+  rw [coeff_forwardTaylorQuotient, hasseCoeffAt_apply,
+    hasseDeriv_eq_zero_of_lt_natDegree p (i + m) (by omega), eval_zero]
+
+/-- A strict degree bound on `p` descends by `m` to its canonical forward Taylor quotient. -/
+theorem forwardTaylorQuotient_mem_degreeLT (m d : ℕ) (a : R) (p : R[X])
+    (hp : p ∈ degreeLT R d) :
+    forwardTaylorQuotient m a p ∈ degreeLT R (d - m) := by
+  rw [mem_degreeLT, degree_lt_iff_coeff_zero] at hp ⊢
+  intro i hi
+  rw [coeff_forwardTaylorQuotient, hasseCoeffAt_apply]
+  have hderiv : hasseDeriv (i + m) p = 0 := by
+    ext j
+    rw [hasseDeriv_coeff, hp (j + (i + m)) (by omega), mul_zero, coeff_zero]
+  rw [hderiv, eval_zero]
+
 /-- Canonical forward Taylor quotients are natural under coefficient-ring homomorphisms. -/
 theorem map_forwardTaylorQuotient {S : Type*} [Ring S] (f : R →+* S)
     (m : ℕ) (a : R) (p : R[X]) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -270,6 +270,36 @@ theorem forwardTaylorQuotient_mem_degreeLT (m d : ℕ) (a : R) (p : R[X])
     rw [hasseDeriv_coeff, hp (j + (i + m)) (by omega), mul_zero, coeff_zero]
   rw [hderiv, eval_zero]
 
+/-- Removing `m + n` Taylor coefficients at once is the same as dropping another `n`
+coefficients from the order-`m` quotient. -/
+theorem forwardTaylorQuotient_add_eq_iterate_divX (m n : ℕ) (a : R) (p : R[X]) :
+    forwardTaylorQuotient (m + n) a p =
+      divX^[n] (forwardTaylorQuotient m a p) := by
+  ext i
+  rw [coeff_forwardTaylorQuotient]
+  have coeff_iterate_divX (f : R[X]) (k j : ℕ) :
+      (divX^[k] f).coeff j = f.coeff (j + k) := by
+    induction k generalizing f j with
+    | zero => simp
+    | succ k ih =>
+      rw [Function.iterate_succ', Function.comp_apply, coeff_divX, ih]
+      congr 1
+      omega
+  rw [coeff_iterate_divX, coeff_forwardTaylorQuotient]
+  congr 2
+  omega
+
+/-- Canonical Taylor quotients form a tail tower: taking an order-`n` quotient at zero from the
+order-`m` quotient is the order-`m + n` quotient of the original polynomial. -/
+theorem forwardTaylorQuotient_zero_comp (m n : ℕ) (a : R) (p : R[X]) :
+    forwardTaylorQuotient n 0 (forwardTaylorQuotient m a p) =
+      forwardTaylorQuotient (m + n) a p := by
+  ext i
+  rw [coeff_forwardTaylorQuotient, hasseCoeffAt_zero_eq_coeff,
+    coeff_forwardTaylorQuotient, coeff_forwardTaylorQuotient]
+  congr 2
+  omega
+
 /-- Canonical forward Taylor quotients are natural under coefficient-ring homomorphisms. -/
 theorem map_forwardTaylorQuotient {S : Type*} [Ring S] (f : R →+* S)
     (m : ℕ) (a : R) (p : R[X]) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Forward.lean
@@ -180,6 +180,19 @@ theorem forwardTaylorTruncation_taylor (m : ℕ) (a b : R) (p : R[X]) :
   · rw [hasseCoeffAt_taylor]
   · rfl
 
+/-- Finite forward truncation commutes with an affine substitution, with the output variable
+scaled by the same factor. -/
+theorem forwardTaylorTruncation_taylor_comp_C_mul_X
+    (m : ℕ) (a b c : R) (p : R[X]) :
+    forwardTaylorTruncation m b ((taylor a p).comp (C c * X)) =
+      (forwardTaylorTruncation m (c * b + a) p).comp (C c * X) := by
+  ext i
+  rw [coeff_forwardTaylorTruncation, comp_C_mul_X_coeff,
+    coeff_forwardTaylorTruncation]
+  by_cases hi : i < m
+  · rw [if_pos hi, if_pos hi, hasseCoeffAt_taylor_comp_C_mul_X]
+  · rw [if_neg hi, if_neg hi, zero_mul]
+
 end CommSemiring
 
 section Ring
@@ -302,6 +315,29 @@ theorem forwardTaylorQuotient_taylor (m : ℕ) (a b : R) (p : R[X]) :
     forwardTaylorQuotient m b (taylor a p) =
       forwardTaylorQuotient m (b + a) p := by
   rw [forwardTaylorQuotient, forwardTaylorQuotient, forwardTaylorRemainder_taylor]
+
+/-- Forward Taylor remainders commute with affine substitution. -/
+theorem forwardTaylorRemainder_taylor_comp_C_mul_X
+    (m : ℕ) (a b c : R) (p : R[X]) :
+    forwardTaylorRemainder m b ((taylor a p).comp (C c * X)) =
+      (forwardTaylorRemainder m (c * b + a) p).comp (C c * X) := by
+  rw [forwardTaylorRemainder, forwardTaylorRemainder, sub_comp,
+    forwardTaylorTruncation_taylor_comp_C_mul_X]
+  congr 1
+  ext i
+  rw [taylor_coeff, comp_C_mul_X_coeff, taylor_coeff]
+  exact hasseCoeffAt_taylor_comp_C_mul_X a b c i p
+
+/-- Under affine substitution, the canonical tail quotient scales by the `m`-th power of the
+linear coefficient, in addition to scaling its output variable. -/
+theorem forwardTaylorQuotient_taylor_comp_C_mul_X
+    (m : ℕ) (a b c : R) (p : R[X]) :
+    forwardTaylorQuotient m b ((taylor a p).comp (C c * X)) =
+      C (c ^ m) * (forwardTaylorQuotient m (c * b + a) p).comp (C c * X) := by
+  ext i
+  rw [coeff_forwardTaylorQuotient, coeff_C_mul, comp_C_mul_X_coeff,
+    coeff_forwardTaylorQuotient, hasseCoeffAt_taylor_comp_C_mul_X, pow_add]
+  ac_rfl
 
 end CommRing
 

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
@@ -106,4 +106,35 @@ example (m : ℕ) : forwardTaylorQuotient m (2 : ℤ) 0 = 0 := by
   simp [forwardTaylorQuotient, forwardTaylorRemainder, forwardTaylorTruncation,
     hasseCoeffAt_apply]
 
+/-- An asymmetric tail-tower canary: dropping one coefficient and then two more gives the
+order-three tail, whose independently computed value is `4 + X` here. -/
+example :
+    forwardTaylorQuotient 2 0
+      (forwardTaylorQuotient 1 (1 : ZMod 5) (X ^ 4)) = C 4 + X := by
+  rw [forwardTaylorQuotient_zero_comp]
+  ext i
+  rw [coeff_forwardTaylorQuotient, X_pow_eq_monomial]
+  by_cases hi : i < 2
+  · interval_cases i
+    · norm_num [hasseCoeffAt_apply, hasseDeriv_monomial, coeff_add, coeff_X]
+    · norm_num [hasseCoeffAt_apply, hasseDeriv_monomial, coeff_add, coeff_X]
+  · have hchoose : Nat.choose 4 (i + 3) = 0 := Nat.choose_eq_zero_of_lt (by omega)
+    have hi0 : i ≠ 0 := by omega
+    have hi1 : 1 ≠ i := by omega
+    simp [hasseCoeffAt_apply, hasseDeriv_monomial, hchoose, coeff_add, coeff_C, coeff_X,
+      hi0, hi1]
+
+/-- The extra tail operation is inert when either added order is zero. -/
+example :
+    forwardTaylorQuotient 0 0
+        (forwardTaylorQuotient 2 (1 : ℤ) (X ^ 4)) =
+      forwardTaylorQuotient (2 + 0) (1 : ℤ) (X ^ 4) := by
+  exact forwardTaylorQuotient_zero_comp 2 0 1 (X ^ 4)
+
+example :
+    forwardTaylorQuotient 2 0
+        (forwardTaylorQuotient 0 (1 : ℤ) (X ^ 4)) =
+      forwardTaylorQuotient (0 + 2) (1 : ℤ) (X ^ 4) := by
+  exact forwardTaylorQuotient_zero_comp 0 2 1 (X ^ 4)
+
 end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
@@ -124,6 +124,38 @@ example :
     simp [hasseCoeffAt_apply, hasseDeriv_monomial, hchoose, coeff_add, coeff_C, coeff_X,
       hi0, hi1]
 
+/-- The packaged remainder linear map retains exactly the positive-degree part of the shift. -/
+example :
+    forwardTaylorRemainderLinearMap 1 (1 : ZMod 5) (X ^ 2) =
+      X ^ 2 + C 2 * X := by
+  rw [forwardTaylorRemainderLinearMap_apply]
+  norm_num [forwardTaylorRemainder, forwardTaylorTruncation, hasseCoeffAt_apply, taylor_apply]
+  rw [C_ofNat]
+  ring
+
+/-- The packaged quotient linear map preserves a nontrivial scalar and the independently
+computed order-three tail. -/
+example :
+    forwardTaylorQuotientLinearMap 3 (1 : ZMod 5) ((2 : ZMod 5) • (X ^ 4)) =
+      C 3 + C 2 * X := by
+  rw [LinearMap.map_smul, forwardTaylorQuotientLinearMap_apply]
+  have htail : forwardTaylorQuotient 3 (1 : ZMod 5) (X ^ 4) = C 4 + X := by
+    ext i
+    rw [coeff_forwardTaylorQuotient, X_pow_eq_monomial]
+    by_cases hi : i < 2
+    · interval_cases i <;>
+        norm_num [hasseCoeffAt_apply, hasseDeriv_monomial, coeff_add, coeff_X]
+    · have hchoose : Nat.choose 4 (i + 3) = 0 := Nat.choose_eq_zero_of_lt (by omega)
+      have hi0 : i ≠ 0 := by omega
+      have hi1 : 1 ≠ i := by omega
+      simp [hasseCoeffAt_apply, hasseDeriv_monomial, hchoose, coeff_add, coeff_C,
+        coeff_X, hi0, hi1]
+  rw [htail, smul_eq_C_mul, mul_add]
+  have hc : C (2 : ZMod 5) * C 4 = C 3 := by
+    rw [← C_mul]
+    congr 1
+  rw [hc]
+
 /-- The extra tail operation is inert when either added order is zero. -/
 example :
     forwardTaylorQuotient 0 0

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
@@ -137,4 +137,19 @@ example :
       forwardTaylorQuotient (0 + 2) (1 : ℤ) (X ^ 4) := by
   exact forwardTaylorQuotient_zero_comp 0 2 1 (X ^ 4)
 
+/-- A tail-embedding canary: after skipping the zeroth coordinate of `[1, 2, 1]`, `Fin.natAdd`
+selects `[2, 1]`, which is the jet at zero of the order-one quotient. -/
+example :
+    (fun i : Fin 2 ↦ hasseJet 3 (1 : ZMod 5) (X ^ 2) (Fin.natAdd 1 i)) =
+        hasseJet 2 0 (forwardTaylorQuotient 1 (1 : ZMod 5) (X ^ 2)) ∧
+      hasseJet 2 0 (forwardTaylorQuotient 1 (1 : ZMod 5) (X ^ 2)) = ![2, 1] := by
+  constructor
+  · exact hasseJet_natAdd_eq_forwardTaylorQuotient 1 2 1 (X ^ 2)
+  · rw [← hasseJet_natAdd_eq_forwardTaylorQuotient]
+    funext i
+    fin_cases i
+    · norm_num [hasseJet_apply, hasseDeriv_monomial]
+    · rw [hasseJet_apply, X_pow_eq_monomial]
+      simp [hasseDeriv_monomial]
+
 end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
@@ -78,4 +78,32 @@ example :
     simp [hasseCoeffAt_apply, hasseDeriv_monomial, hchoose, coeff_add, coeff_one, coeff_X,
       hi0, hi1]
 
+/-- A degree-drop canary: removing orders zero and one from a shifted quartic leaves a quadratic,
+and the general `degreeLT` bound records the same strict bound. -/
+example :
+    (forwardTaylorQuotient 2 (1 : ℤ) (X ^ 4)).natDegree = 2 ∧
+      forwardTaylorQuotient 2 (1 : ℤ) (X ^ 4) ∈ degreeLT ℤ 3 := by
+  have hle : (forwardTaylorQuotient 2 (1 : ℤ) (X ^ 4)).natDegree ≤ 2 := by
+    have h := natDegree_forwardTaylorQuotient_le 2 (1 : ℤ) (X ^ 4)
+    rw [natDegree_X_pow] at h
+    norm_num at h ⊢
+    exact h
+  have hcoeff : (forwardTaylorQuotient 2 (1 : ℤ) (X ^ 4)).coeff 2 ≠ 0 := by
+    rw [coeff_forwardTaylorQuotient, X_pow_eq_monomial]
+    norm_num [hasseCoeffAt_apply, hasseDeriv_monomial]
+  have hdegree : (forwardTaylorQuotient 2 (1 : ℤ) (X ^ 4)).natDegree = 2 :=
+    natDegree_eq_of_le_of_coeff_ne_zero hle hcoeff
+  refine ⟨hdegree, forwardTaylorQuotient_mem_degreeLT 2 5 (1 : ℤ) (X ^ 4) ?_⟩
+  rw [mem_degreeLT, degree_X_pow]
+  exact WithBot.coe_lt_coe.mpr (by omega)
+
+/-- At order zero the quotient is the full shift, so its degree is unchanged. -/
+example : (forwardTaylorQuotient 0 (2 : ℤ) (X ^ 4)).natDegree = 4 := by
+  rw [forwardTaylorQuotient_zero, natDegree_taylor, natDegree_X_pow]
+
+/-- The zero polynomial has zero quotient at every order. -/
+example (m : ℕ) : forwardTaylorQuotient m (2 : ℤ) 0 = 0 := by
+  simp [forwardTaylorQuotient, forwardTaylorRemainder, forwardTaylorTruncation,
+    hasseCoeffAt_apply]
+
 end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
@@ -30,6 +30,16 @@ example : forwardTaylorTruncation 3 (0 : ZMod 2) (X ^ 4) = 0 := by
   rw [forwardTaylorTruncation_X_pow]
   simp
 
+/-- A center-composition canary: two unit shifts cancel in characteristic two before
+order-two truncation. -/
+example :
+    forwardTaylorTruncation 2 (1 : ZMod 2) (taylor 1 (X ^ 2)) = 0 := by
+  rw [forwardTaylorTruncation_taylor]
+  have htwo : (1 + 1 : ZMod 2) = 0 := by decide
+  rw [htwo]
+  rw [forwardTaylorTruncation_X_pow]
+  simp
+
 /-- A high-truncation canary: all three Hasse coefficients retain the shifted quadratic, leaving
 both the remainder and its canonical quotient zero. -/
 example :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.Forward
+import Mathlib.Data.ZMod.Basic
+
+/-!
+# Canaries for finite forward Hasse--Taylor truncation
+
+The characteristic-two example is decisive: shifting `X²` forward by one gives `X² + 1`, so
+the order-two truncation is `1`; the generic remainder theorem then makes the discarded part
+divisible by `X²`.
+-/
+
+namespace Polynomial
+
+example : forwardTaylorTruncation 2 (1 : ZMod 2) (X ^ 2) = 1 := by
+  have htwo : (2 : ZMod 2) = 0 := ZMod.natCast_self 2
+  have htwoPoly : (2 : (ZMod 2)[X]) = 0 := by
+    change C (2 : ZMod 2) = 0
+    rw [htwo, C_0]
+  rw [X_pow_eq_monomial]
+  simp [forwardTaylorTruncation, hasseCoeffAt_apply, hasseDeriv_monomial,
+    Finset.sum_range_succ, htwoPoly]
+
+example : forwardTaylorTruncation 3 (0 : ZMod 2) (X ^ 4) = 0 := by
+  rw [forwardTaylorTruncation_X_pow]
+  simp
+
+end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
@@ -58,4 +58,24 @@ example :
   exact ⟨forwardTaylorRemainder_eq_zero_of_mem_degreeLT 3 1 (X ^ 2) hp,
     forwardTaylorQuotient_eq_zero_of_mem_degreeLT 3 1 (X ^ 2) hp⟩
 
+/-- An affine quotient-factor canary: the `c ^ m = 2²` factor is essential here. -/
+example :
+    forwardTaylorQuotient 2 (1 : ZMod 5)
+      ((taylor 1 (X ^ 3)).comp (C 2 * X)) = 1 + C 3 * X := by
+  rw [forwardTaylorQuotient_taylor_comp_C_mul_X]
+  ext i
+  rw [coeff_C_mul, comp_C_mul_X_coeff, coeff_forwardTaylorQuotient]
+  rw [X_pow_eq_monomial]
+  by_cases hi : i < 2
+  · interval_cases i
+    · norm_num [hasseCoeffAt_apply, hasseDeriv_monomial, coeff_add, coeff_one, coeff_X]
+      decide
+    · norm_num [hasseCoeffAt_apply, hasseDeriv_monomial, coeff_add, coeff_one, coeff_X]
+      decide
+  · have hchoose : Nat.choose 3 (i + 2) = 0 := Nat.choose_eq_zero_of_lt (by omega)
+    have hi0 : i ≠ 0 := by omega
+    have hi1 : 1 ≠ i := by omega
+    simp [hasseCoeffAt_apply, hasseDeriv_monomial, hchoose, coeff_add, coeff_one, coeff_X,
+      hi0, hi1]
+
 end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
@@ -40,6 +40,13 @@ example :
   rw [forwardTaylorTruncation_X_pow]
   simp
 
+/-- An asymmetric center-composition canary: shifting first by `2` and then taking the order-two
+truncation at `1` uses center `1 + 2 = 3`, not the inverse shift. -/
+example :
+    forwardTaylorTruncation 2 (1 : ZMod 5) (taylor 2 X) = C 3 + X := by
+  rw [forwardTaylorTruncation_taylor]
+  norm_num [forwardTaylorTruncation, Finset.sum_range_succ, hasseCoeffAt_apply]
+
 /-- A high-truncation canary: all three Hasse coefficients retain the shifted quadratic, leaving
 both the remainder and its canonical quotient zero. -/
 example :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ForwardCanary.lean
@@ -30,4 +30,15 @@ example : forwardTaylorTruncation 3 (0 : ZMod 2) (X ^ 4) = 0 := by
   rw [forwardTaylorTruncation_X_pow]
   simp
 
+/-- A high-truncation canary: all three Hasse coefficients retain the shifted quadratic, leaving
+both the remainder and its canonical quotient zero. -/
+example :
+    forwardTaylorRemainder 3 (1 : ZMod 2) (X ^ 2) = 0 ∧
+      forwardTaylorQuotient 3 (1 : ZMod 2) (X ^ 2) = 0 := by
+  have hp : (X ^ 2 : (ZMod 2)[X]) ∈ degreeLT (ZMod 2) 3 := by
+    rw [mem_degreeLT, degree_X_pow]
+    exact WithBot.coe_lt_coe.mpr (Nat.lt_succ_self 2)
+  exact ⟨forwardTaylorRemainder_eq_zero_of_mem_degreeLT 3 1 (X ^ 2) hp,
+    forwardTaylorQuotient_eq_zero_of_mem_degreeLT 3 1 (X ^ 2) hp⟩
+
 end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibility.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibility.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.FiniteJet
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.Shift
+
+/-!
+# Finite Hasse jets and polynomial divisibility
+
+This file joins the finite-vector interface `hasseJet` with the scalar Hasse-vanishing and
+divisibility results from `HasseTaylor.Shift`.  It lets downstream constraint maps use equality in
+`Fin m → R` directly, while retaining the characteristic-independent meaning of the coordinates.
+-/
+
+namespace Polynomial
+
+noncomputable section
+
+variable {R : Type*}
+
+section Semiring
+
+variable [Semiring R]
+
+/-- A Taylor shift is divisible by `X ^ m` exactly when its length-`m` Hasse jet is zero. -/
+theorem X_pow_dvd_taylor_iff_hasseJet_eq_zero (p : R[X]) (a : R) (m : ℕ) :
+    X ^ m ∣ taylor a p ↔ hasseJet m a p = 0 := by
+  rw [X_pow_dvd_taylor_iff]
+  constructor
+  · intro h
+    funext i
+    simpa using h i i.isLt
+  · intro h i hi
+    have hi := congrFun h ⟨i, hi⟩
+    simpa using hi
+
+end Semiring
+
+section CommRing
+
+variable [CommRing R]
+
+/-- A root has multiplicity at least `m` exactly when its length-`m` Hasse jet vanishes. -/
+theorem X_sub_C_pow_dvd_iff_hasseJet_eq_zero (p : R[X]) (a : R) (m : ℕ) :
+    (X - C a) ^ m ∣ p ↔ hasseJet m a p = 0 := by
+  rw [X_sub_C_pow_dvd_iff_hasseDeriv_eval_eq_zero]
+  constructor
+  · intro h
+    funext i
+    simpa using h i i.isLt
+  · intro h i hi
+    have hi := congrFun h ⟨i, hi⟩
+    simpa using hi
+
+/-- Two polynomials agree to Hasse order `< m` at `a` exactly when their shifted difference is
+divisible by `X ^ m`. -/
+theorem X_pow_dvd_taylor_sub_iff_hasseJet_eq (p q : R[X]) (a : R) (m : ℕ) :
+    X ^ m ∣ taylor a p - taylor a q ↔ hasseJet m a p = hasseJet m a q := by
+  rw [X_pow_dvd_taylor_sub_iff]
+  constructor
+  · intro h
+    funext i
+    exact h i i.isLt
+  · intro h i hi
+    exact congrFun h ⟨i, hi⟩
+
+/-- For a nonzero polynomial, a zero finite Hasse jet is the corresponding root-multiplicity
+lower bound. -/
+theorem hasseJet_eq_zero_iff_le_rootMultiplicity {p : R[X]} (hp : p ≠ 0)
+    (a : R) (m : ℕ) :
+    hasseJet m a p = 0 ↔ m ≤ p.rootMultiplicity a := by
+  rw [← X_sub_C_pow_dvd_iff_hasseJet_eq_zero]
+  exact (le_rootMultiplicity_iff hp).symm
+
+end CommRing
+
+end
+
+end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibility.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibility.lean
@@ -67,6 +67,19 @@ theorem X_pow_dvd_taylor_sub_iff_hasseJet_eq (p q : R[X]) (a : R) (m : ℕ) :
   · intro h i hi
     exact congrFun h ⟨i, hi⟩
 
+/-- Two polynomials have the same length-`m` Hasse jet at `a` exactly when their difference is
+divisible by the `m`-th power of the corresponding root factor. -/
+theorem X_sub_C_pow_dvd_sub_iff_hasseJet_eq (p q : R[X]) (a : R) (m : ℕ) :
+    (X - C a) ^ m ∣ p - q ↔ hasseJet m a p = hasseJet m a q := by
+  rw [X_sub_C_pow_dvd_iff_hasseDeriv_eval_eq_zero]
+  constructor
+  · intro h
+    ext i
+    simpa only [LinearMap.map_sub, eval_sub, sub_eq_zero, hasseJet_apply] using h i i.isLt
+  · intro h i hi
+    simpa only [LinearMap.map_sub, eval_sub, sub_eq_zero, hasseJet_apply] using
+      congrFun h ⟨i, hi⟩
+
 /-- For a nonzero polynomial, a zero finite Hasse jet is the corresponding root-multiplicity
 lower bound. -/
 theorem hasseJet_eq_zero_iff_le_rootMultiplicity {p : R[X]} (hp : p ≠ 0)

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibility.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibility.lean
@@ -88,6 +88,14 @@ theorem hasseJet_eq_zero_iff_le_rootMultiplicity {p : R[X]} (hp : p ≠ 0)
   rw [← X_sub_C_pow_dvd_iff_hasseJet_eq_zero]
   exact (le_rootMultiplicity_iff hp).symm
 
+/-- Distinct polynomials have the same length-`m` Hasse jet exactly when their difference has
+root multiplicity at least `m`. -/
+theorem hasseJet_eq_iff_le_rootMultiplicity_sub {p q : R[X]} (hpq : p ≠ q)
+    (a : R) (m : ℕ) :
+    hasseJet m a p = hasseJet m a q ↔ m ≤ (p - q).rootMultiplicity a := by
+  rw [← sub_eq_zero, ← LinearMap.map_sub]
+  exact hasseJet_eq_zero_iff_le_rootMultiplicity (sub_ne_zero.mpr hpq) a m
+
 end CommRing
 
 end

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibility.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibility.lean
@@ -41,23 +41,11 @@ theorem X_pow_dvd_taylor_iff_hasseJet_eq_zero (p : R[X]) (a : R) (m : ℕ) :
 
 end Semiring
 
-section CommRing
+section Ring
 
-variable [CommRing R]
+variable [Ring R]
 
-/-! ### Equal jets, root factors, and root multiplicity -/
-
-/-- A root has multiplicity at least `m` exactly when its length-`m` Hasse jet vanishes. -/
-theorem X_sub_C_pow_dvd_iff_hasseJet_eq_zero (p : R[X]) (a : R) (m : ℕ) :
-    (X - C a) ^ m ∣ p ↔ hasseJet m a p = 0 := by
-  rw [X_sub_C_pow_dvd_iff_hasseDeriv_eval_eq_zero]
-  constructor
-  · intro h
-    funext i
-    simpa using h i i.isLt
-  · intro h i hi
-    have hi := congrFun h ⟨i, hi⟩
-    simpa using hi
+/-! ### Equal jets and divisibility in shifted coordinates -/
 
 /-- Two polynomials agree to Hasse order `< m` at `a` exactly when their shifted difference is
 divisible by `X ^ m`. -/
@@ -70,6 +58,26 @@ theorem X_pow_dvd_taylor_sub_iff_hasseJet_eq (p q : R[X]) (a : R) (m : ℕ) :
     exact h i i.isLt
   · intro h i hi
     exact congrFun h ⟨i, hi⟩
+
+end Ring
+
+section CommRing
+
+variable [CommRing R]
+
+/-! ### Root factors and root multiplicity -/
+
+/-- A root has multiplicity at least `m` exactly when its length-`m` Hasse jet vanishes. -/
+theorem X_sub_C_pow_dvd_iff_hasseJet_eq_zero (p : R[X]) (a : R) (m : ℕ) :
+    (X - C a) ^ m ∣ p ↔ hasseJet m a p = 0 := by
+  rw [X_sub_C_pow_dvd_iff_hasseDeriv_eval_eq_zero]
+  constructor
+  · intro h
+    funext i
+    simpa using h i i.isLt
+  · intro h i hi
+    have hi := congrFun h ⟨i, hi⟩
+    simpa using hi
 
 /-- Two polynomials have the same length-`m` Hasse jet at `a` exactly when their difference is
 divisible by the `m`-th power of the corresponding root factor. -/

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibility.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibility.lean
@@ -25,6 +25,8 @@ section Semiring
 
 variable [Semiring R]
 
+/-! ### Zero jets and divisibility in shifted coordinates -/
+
 /-- A Taylor shift is divisible by `X ^ m` exactly when its length-`m` Hasse jet is zero. -/
 theorem X_pow_dvd_taylor_iff_hasseJet_eq_zero (p : R[X]) (a : R) (m : ℕ) :
     X ^ m ∣ taylor a p ↔ hasseJet m a p = 0 := by
@@ -42,6 +44,8 @@ end Semiring
 section CommRing
 
 variable [CommRing R]
+
+/-! ### Equal jets, root factors, and root multiplicity -/
 
 /-- A root has multiplicity at least `m` exactly when its length-`m` Hasse jet vanishes. -/
 theorem X_sub_C_pow_dvd_iff_hasseJet_eq_zero (p : R[X]) (a : R) (m : ℕ) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibilityCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibilityCanary.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.JetDivisibility
+import Mathlib.Data.ZMod.Basic
+
+/-!
+# Canaries for finite Hasse jets and local divisibility
+
+These examples exercise the boundary order and a small-characteristic double-contact case.
+-/
+
+namespace Polynomial
+
+/-- Order zero imposes no coordinates and corresponds to divisibility by one. -/
+example (p q : (ZMod 2)[X]) (a : ZMod 2) :
+    (X - C a) ^ 0 ∣ p - q ↔ hasseJet 0 a p = hasseJet 0 a q :=
+  X_sub_C_pow_dvd_sub_iff_hasseJet_eq p q a 0
+
+/-- In characteristic two, `X²` and zero have equal orders-zero-and-one jets at the origin,
+exactly as witnessed by the double root factor. -/
+example :
+    (X - C (0 : ZMod 2)) ^ 2 ∣ (X ^ 2 - 0) ↔
+      hasseJet 2 (0 : ZMod 2) (X ^ 2) = hasseJet 2 (0 : ZMod 2) 0 :=
+  X_sub_C_pow_dvd_sub_iff_hasseJet_eq (X ^ 2) 0 0 2
+
+end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibilityCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/JetDivisibilityCanary.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.JetDivisibility
 import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic.FinCases
 
 /-!
 # Canaries for finite Hasse jets and local divisibility
@@ -26,5 +27,20 @@ example :
     (X - C (0 : ZMod 2)) ^ 2 ∣ (X ^ 2 - 0) ↔
       hasseJet 2 (0 : ZMod 2) (X ^ 2) = hasseJet 2 (0 : ZMod 2) 0 :=
   X_sub_C_pow_dvd_sub_iff_hasseJet_eq (X ^ 2) 0 0 2
+
+example : (X - C (0 : ZMod 2)) ^ 2 ∣ (X ^ 2 - 0) := by
+  simp
+
+example : hasseJet 2 (0 : ZMod 2) (X ^ 2) = hasseJet 2 (0 : ZMod 2) 0 := by
+  funext i
+  fin_cases i <;> simp [hasseJet_apply]
+
+/-- Extending the jet by one coordinate detects the nonzero second Hasse derivative, even though
+the ordinary derivative of `X²` vanishes in characteristic two. -/
+example : hasseJet 3 (0 : ZMod 2) (X ^ 2) ≠ hasseJet 3 (0 : ZMod 2) 0 := by
+  intro h
+  have h2 := congrFun h (2 : Fin 3)
+  rw [hasseJet_apply, hasseJet_apply, X_pow_eq_monomial] at h2
+  simp at h2
 
 end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -27,6 +27,7 @@ term `j` has Hasse order `j + 1`, sign `(-1)^j`, and derivative evaluated at the
 * `backwardTaylorReconstruction`: finite moving-point backward reconstruction.
 * `X_pow_succ_dvd_backwardTaylorResidual`: divisibility of the unnormalized numerator.
 * `X_pow_dvd_normalizedBackwardTaylorError`: divisibility after removing one factor of `X`.
+* `X_mul_normalizedBackwardTaylorError`: the normalized-error identity itself.
 -/
 
 namespace Polynomial
@@ -36,6 +37,11 @@ noncomputable section
 section Semiring
 
 variable {R : Type*} [Semiring R]
+
+/-- Removing the leading `X` from `X * p` recovers `p`. -/
+theorem divX_X_mul (p : R[X]) : (X * p).divX = p := by
+  ext n
+  simp [coeff_divX, coeff_X_mul]
 
 /-- `X ^ m` divides the Taylor expansion at `a` iff the first `m` Hasse derivatives vanish. -/
 theorem X_pow_dvd_taylor_iff (p : R[X]) (a : R) (m : ℕ) :
@@ -268,18 +274,26 @@ theorem X_pow_dvd_normalizedBackwardTaylorError (a : R) (p : R[X]) (d : ℕ) :
   rw [normalizedBackwardTaylorError, backwardTaylorResidual_eq]
   exact X_pow_dvd_normalizedBackwardHasseResidual d (taylor a p)
 
+/-- Equation (16): multiplying the normalized moving error by `X` recovers its numerator. -/
+theorem X_mul_normalizedBackwardTaylorError (a : R) (p : R[X]) (d : ℕ) :
+    X * normalizedBackwardTaylorError a p d = backwardTaylorResidual a p d := by
+  rw [normalizedBackwardTaylorError, backwardTaylorResidual_eq]
+  exact X_mul_normalizedBackwardHasseResidual d (taylor a p)
+
+theorem coeff_normalizedBackwardTaylorError (a : R) (p : R[X]) (d n : ℕ) :
+    (normalizedBackwardTaylorError a p d).coeff n =
+      (backwardTaylorResidual a p d).coeff (n + 1) := by
+  rw [normalizedBackwardTaylorError, coeff_divX]
+
 /-- Finite moving-point backward reconstruction, with signs `+,-,+,...` from Hasse order one. -/
 theorem backwardTaylorReconstruction (a : R) (p : R[X]) (d : ℕ) :
     taylor a p = C (p.eval a) + movingHasseSum a p d +
       X * normalizedBackwardTaylorError a p d := by
-  have hx : X * normalizedBackwardTaylorError a p d = backwardTaylorResidual a p d := by
-    rw [normalizedBackwardTaylorError, backwardTaylorResidual_eq]
-    exact X_mul_normalizedBackwardHasseResidual d (taylor a p)
   calc
     taylor a p = C (p.eval a) + movingHasseSum a p d + backwardTaylorResidual a p d := by
       simp only [backwardTaylorResidual]
       ring
-    _ = _ := by rw [hx]
+    _ = _ := by rw [X_mul_normalizedBackwardTaylorError]
 
 theorem backwardTaylorReconstruction_of_eval_eq {a y : R} {p : R[X]} (d : ℕ)
     (h : p.eval a = y) :
@@ -293,11 +307,28 @@ theorem normalizedBackwardTaylorError_zero (a : R) (p : R[X]) :
   simp [normalizedBackwardTaylorError, backwardTaylorResidual, movingHasseSum,
     shiftIncrementQuotient, coeff_divX]
 
+/-- The reconstruction determines its normalized error uniquely. -/
+theorem normalizedBackwardTaylorError_unique (a : R) (p : R[X]) (d : ℕ) {e : R[X]}
+    (h : taylor a p = C (p.eval a) + movingHasseSum a p d + X * e) :
+    e = normalizedBackwardTaylorError a p d := by
+  have hres : backwardTaylorResidual a p d = X * e := by
+    rw [backwardTaylorResidual, h]
+    ring
+  rw [← divX_X_mul e, ← hres]
+  rfl
+
 /-- At or above the polynomial degree, the normalized moving error is zero. -/
 theorem normalizedBackwardTaylorError_eq_zero_of_natDegree_le (a : R) (p : R[X]) (d : ℕ)
     (hdeg : p.natDegree ≤ d) : normalizedBackwardTaylorError a p d = 0 := by
   rw [normalizedBackwardTaylorError,
     backwardTaylorResidual_eq_zero_of_natDegree_le a p d hdeg, divX_zero]
+
+/-- At or above the polynomial degree, the finite reconstruction is exact without a remainder. -/
+theorem backwardTaylorReconstruction_of_natDegree_le (a : R) (p : R[X]) (d : ℕ)
+    (hdeg : p.natDegree ≤ d) :
+    taylor a p = C (p.eval a) + movingHasseSum a p d := by
+  simpa only [normalizedBackwardTaylorError_eq_zero_of_natDegree_le a p d hdeg,
+    mul_zero, add_zero] using backwardTaylorReconstruction a p d
 
 end CommRing
 

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -29,6 +29,12 @@ term `j` has Hasse order `j + 1`, sign `(-1)^j`, and derivative evaluated at the
 * `X_pow_succ_dvd_backwardTaylorResidual`: divisibility of the unnormalized numerator.
 * `X_pow_dvd_normalizedBackwardTaylorError`: divisibility after removing one factor of `X`.
 * `X_mul_normalizedBackwardTaylorError`: the normalized-error identity itself.
+
+## References
+
+* J. Brakensiek, Y. Chen, E. Putterman, M. Zhang, and G. Zheng,
+  *Algorithmic List Decoding of Reed--Solomon Codes up to Capacity in the Low-Rate Regime*,
+  [ECCC TR26-164](https://eccc.weizmann.ac.il/report/2026/164/), 2026.
 -/
 
 namespace Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -296,6 +296,18 @@ theorem movingHasseSum_add (a : R) (p q : R[X]) (d : ℕ) :
     movingHasseSum a (p + q) d = movingHasseSum a p d + movingHasseSum a q d := by
   simp only [movingHasseSum, LinearMap.map_add, mul_add, Finset.sum_add_distrib]
 
+/-- The moving-Hasse correction sum respects coefficient scalar multiplication. -/
+theorem movingHasseSum_smul (c a : R) (p : R[X]) (d : ℕ) :
+    movingHasseSum a (c • p) d = c • movingHasseSum a p d := by
+  simp only [movingHasseSum, smul_eq_C_mul]
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [show C c * p = c • p by rw [smul_eq_C_mul]]
+  rw [LinearMap.map_smul, LinearMap.map_smul]
+  simp only [smul_eq_C_mul]
+  ring
+
 @[simp]
 theorem movingHasseSum_zero (a : R) (d : ℕ) : movingHasseSum a 0 d = 0 := by
   simp [movingHasseSum]
@@ -344,9 +356,27 @@ theorem backwardTaylorResidual_add (a : R) (p q : R[X]) (d : ℕ) :
     LinearMap.map_add, eval_add, map_add, movingHasseSum_add]
   ring
 
+/-- The moving-point backward numerator respects coefficient scalar multiplication. -/
+theorem backwardTaylorResidual_smul (c a : R) (p : R[X]) (d : ℕ) :
+    backwardTaylorResidual a (c • p) d = c • backwardTaylorResidual a p d := by
+  rw [backwardTaylorResidual, backwardTaylorResidual]
+  simp only [LinearMap.map_smul, eval_smul, movingHasseSum_smul]
+  simp only [smul_eq_C_mul, smul_eq_mul, map_mul]
+  ring
+
 @[simp]
 theorem backwardTaylorResidual_zero (a : R) (d : ℕ) : backwardTaylorResidual a 0 d = 0 := by
   simp [backwardTaylorResidual]
+
+/-- The moving-point backward numerator as an `R`-linear map in the input polynomial. -/
+def backwardTaylorResidualLinearMap (a : R) (d : ℕ) : R[X] →ₗ[R] R[X] where
+  toFun p := backwardTaylorResidual a p d
+  map_add' p q := backwardTaylorResidual_add a p q d
+  map_smul' c p := backwardTaylorResidual_smul c a p d
+
+@[simp]
+theorem backwardTaylorResidualLinearMap_apply (a : R) (d : ℕ) (p : R[X]) :
+    backwardTaylorResidualLinearMap a d p = backwardTaylorResidual a p d := rfl
 
 /-- The order-one residual recovers the earlier derivative-contact identity exactly. -/
 theorem backwardTaylorResidual_one (a : R) (p : R[X]) :
@@ -450,11 +480,29 @@ theorem normalizedBackwardTaylorError_add (a : R) (p q : R[X]) (d : ℕ) :
   ext n
   simp only [coeff_normalizedBackwardTaylorError, backwardTaylorResidual_add, coeff_add]
 
+/-- The normalized moving-point error respects coefficient scalar multiplication. -/
+theorem normalizedBackwardTaylorError_smul (c a : R) (p : R[X]) (d : ℕ) :
+    normalizedBackwardTaylorError a (c • p) d =
+      c • normalizedBackwardTaylorError a p d := by
+  ext n
+  simp only [coeff_normalizedBackwardTaylorError, backwardTaylorResidual_smul, coeff_smul]
+
 @[simp]
 theorem normalizedBackwardTaylorError_zero_poly (a : R) (d : ℕ) :
     normalizedBackwardTaylorError a 0 d = 0 := by
   ext n
   simp [coeff_normalizedBackwardTaylorError]
+
+/-- The normalized moving-point error as an `R`-linear map in the input polynomial. -/
+def normalizedBackwardTaylorErrorLinearMap (a : R) (d : ℕ) : R[X] →ₗ[R] R[X] where
+  toFun p := normalizedBackwardTaylorError a p d
+  map_add' p q := normalizedBackwardTaylorError_add a p q d
+  map_smul' c p := normalizedBackwardTaylorError_smul c a p d
+
+@[simp]
+theorem normalizedBackwardTaylorErrorLinearMap_apply (a : R) (d : ℕ) (p : R[X]) :
+    normalizedBackwardTaylorErrorLinearMap a d p =
+      normalizedBackwardTaylorError a p d := rfl
 
 /-- Finite moving-point backward reconstruction, with signs `+,-,+,...` from Hasse order one. -/
 theorem backwardTaylorReconstruction (a : R) (p : R[X]) (d : ℕ) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -44,6 +44,8 @@ section Semiring
 
 variable {R : Type*} [Semiring R]
 
+/-! ### Elementary shift quotients -/
+
 /-- Removing the leading `X` from `X * p` recovers `p`. -/
 private theorem divX_X_mul (p : R[X]) : (X * p).divX = p := by
   ext n
@@ -96,6 +98,8 @@ section CommSemiring
 
 variable {R : Type*} [CommSemiring R]
 
+/-! ### Hasse derivatives under shifts -/
+
 /-- Hasse differentiation commutes with shifting the polynomial's input. -/
 theorem hasseDeriv_taylor (p : R[X]) (a : R) (k : ℕ) :
     hasseDeriv k (taylor a p) = taylor a (hasseDeriv k p) := by
@@ -111,6 +115,8 @@ end CommSemiring
 section CommRing
 
 variable {R : Type*} [CommRing R]
+
+/-! ### Scalar Hasse vanishing and root multiplicity -/
 
 private theorem divX_sub (p q : R[X]) : (p - q).divX = p.divX - q.divX := by
   ext n
@@ -136,6 +142,8 @@ theorem hasseDeriv_eval_eq_zero_iff_le_rootMultiplicity {p : R[X]} (hp : p ≠ 0
     (∀ i < m, (hasseDeriv i p).eval a = 0) ↔ m ≤ p.rootMultiplicity a :=
   (X_sub_C_pow_dvd_iff_hasseDeriv_eval_eq_zero p a m).symm.trans
     (le_rootMultiplicity_iff hp).symm
+
+/-! ### Generic backward correction in shifted coordinates -/
 
 private theorem Int.alternating_sum_choose_succ {n : ℕ} (hn : n ≠ 0) :
     (∑ j ∈ Finset.range n, (-1 : ℤ) ^ j * (n.choose (j + 1) : ℤ)) = 1 := by
@@ -270,6 +278,8 @@ theorem X_mul_normalizedBackwardHasseResidual (d : ℕ) (q : R[X]) :
   have hzero := X_pow_dvd_iff.mp (X_pow_succ_dvd_backwardHasseResidual d q) 0 (by omega)
   simpa only [normalizedBackwardHasseResidual, hzero, C_0, add_zero] using
     X_mul_divX_add (backwardHasseResidual d q)
+
+/-! ### Moving-point backward reconstruction -/
 
 /-- Paper-facing correction sum. Derivatives are evaluated at moving point `a + X`. -/
 def movingHasseSum (a : R) (p : R[X]) (d : ℕ) : R[X] :=

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -138,6 +138,26 @@ private theorem divX_sub (p q : R[X]) : (p - q).divX = p.divX - q.divX := by
   ext n
   simp [coeff_divX]
 
+private theorem hasseDeriv_comp_C_mul_X (p : R[X]) (c : R) (k : ℕ) :
+    hasseDeriv k (p.comp (C c * X)) =
+      C (c ^ k) * (hasseDeriv k p).comp (C c * X) := by
+  ext n
+  simp only [hasseDeriv_coeff, coeff_C_mul, comp_C_mul_X_coeff, pow_add]
+  ring
+
+private theorem taylor_comp_C_mul_X (p : R[X]) (a c : R) :
+    taylor a (p.comp (C c * X)) = (taylor (c * a) p).comp (C c * X) := by
+  simp only [taylor_apply, comp_assoc, add_comp, X_comp, C_comp, mul_comp]
+  congr 2
+  rw [map_mul]
+  ring
+
+private theorem divX_comp_C_mul_X (q : R[X]) (c : R) :
+    (q.comp (C c * X)).divX = C c * q.divX.comp (C c * X) := by
+  ext n
+  simp only [coeff_divX, comp_C_mul_X_coeff, coeff_C_mul, pow_succ]
+  ring
+
 /-- Hasse vanishing at `a` is equivalent to divisibility by the corresponding root factor. -/
 theorem X_sub_C_pow_dvd_iff_hasseDeriv_eval_eq_zero (p : R[X]) (a : R) (m : ℕ) :
     (X - C a) ^ m ∣ p ↔ ∀ i < m, (hasseDeriv i p).eval a = 0 := by
@@ -312,6 +332,18 @@ theorem movingHasseSum_taylor (a b : R) (p : R[X]) (d : ℕ) :
   intro j _
   rw [hasseDeriv_taylor, taylor_taylor]
 
+/-- Scaling the input variable scales every moving Hasse order by the corresponding power. -/
+theorem movingHasseSum_comp_C_mul_X (a c : R) (p : R[X]) (d : ℕ) :
+    movingHasseSum a (p.comp (C c * X)) d =
+      (movingHasseSum (c * a) p d).comp (C c * X) := by
+  rw [movingHasseSum, movingHasseSum, sum_comp]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [mul_comp, mul_comp, C_comp, pow_comp, X_comp, hasseDeriv_comp_C_mul_X,
+    taylor_mul, taylor_C, taylor_comp_C_mul_X, mul_pow, C_pow]
+  simp only [map_pow]
+  ring
+
 /-- Adding one truncation order appends exactly the next alternating moving-Hasse term. -/
 theorem movingHasseSum_succ (a : R) (p : R[X]) (d : ℕ) :
     movingHasseSum a p (d + 1) = movingHasseSum a p d +
@@ -374,6 +406,16 @@ theorem backwardTaylorResidual_taylor (a b : R) (p : R[X]) (d : ℕ) :
       backwardTaylorResidual (b + a) p d := by
   rw [backwardTaylorResidual, backwardTaylorResidual, taylor_taylor, taylor_eval,
     movingHasseSum_taylor]
+
+/-- The backward numerator commutes with scaling the input variable. -/
+theorem backwardTaylorResidual_comp_C_mul_X (a c : R) (p : R[X]) (d : ℕ) :
+    backwardTaylorResidual a (p.comp (C c * X)) d =
+      (backwardTaylorResidual (c * a) p d).comp (C c * X) := by
+  rw [backwardTaylorResidual, backwardTaylorResidual, sub_comp, sub_comp,
+    C_comp, taylor_comp_C_mul_X, movingHasseSum_comp_C_mul_X]
+  congr 2
+  rw [eval_comp]
+  simp
 
 /-- Increasing the truncation order subtracts the next moving-Hasse term from the residual. -/
 theorem backwardTaylorResidual_succ (a : R) (p : R[X]) (d : ℕ) :
@@ -471,6 +513,13 @@ theorem normalizedBackwardTaylorError_taylor (a b : R) (p : R[X]) (d : ℕ) :
       normalizedBackwardTaylorError (b + a) p d := by
   rw [normalizedBackwardTaylorError, normalizedBackwardTaylorError,
     backwardTaylorResidual_taylor]
+
+/-- Scaling the input variable contributes one extra factor of `c` after normalization by `X`. -/
+theorem normalizedBackwardTaylorError_comp_C_mul_X (a c : R) (p : R[X]) (d : ℕ) :
+    normalizedBackwardTaylorError a (p.comp (C c * X)) d =
+      C c * (normalizedBackwardTaylorError (c * a) p d).comp (C c * X) := by
+  rw [normalizedBackwardTaylorError, normalizedBackwardTaylorError,
+    backwardTaylorResidual_comp_C_mul_X, divX_comp_C_mul_X]
 
 /-- Increasing the truncation order subtracts the next normalized moving-Hasse term. -/
 theorem normalizedBackwardTaylorError_succ (a : R) (p : R[X]) (d : ℕ) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.FiniteJet
 import Mathlib.Algebra.Polynomial.Div
 import Mathlib.Algebra.Polynomial.Taylor
 import Mathlib.Data.Nat.Choose.Sum
@@ -33,12 +34,6 @@ term `j` has Hasse order `j + 1`, sign `(-1)^j`, and derivative evaluated at the
 namespace Polynomial
 
 noncomputable section
-
-private theorem map_hasseDeriv {R S : Type*} [Semiring R] [Semiring S]
-    (f : R →+* S) (p : R[X]) (k : ℕ) :
-    (hasseDeriv k p).map f = hasseDeriv k (p.map f) := by
-  ext n
-  simp [hasseDeriv_coeff]
 
 private theorem map_divX {R S : Type*} [Semiring R] [Semiring S]
     (f : R →+* S) (p : R[X]) : p.divX.map f = (p.map f).divX := by

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -1,0 +1,307 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import Mathlib.Algebra.Polynomial.Div
+import Mathlib.Algebra.Polynomial.Taylor
+import Mathlib.Data.Nat.Choose.Sum
+
+/-!
+# Hasse--Taylor shifts and backward residuals
+
+Characteristic-independent shift, vanishing, and moving-point backward Hasse identities. The
+elementary shift increment quotient and the paper's truncation-dependent backward error are
+different constructions and are named separately.
+
+The moving-point API formalizes the finite form of the backward identity used as Equation (13)
+and its normalized remainder from Equation (16) in BCPZZ26. For truncation order `d`, correction
+term `j` has Hasse order `j + 1`, sign `(-1)^j`, and derivative evaluated at the moving point
+`a + X`. The numerator is divisible by `X ^ (d + 1)` and its normalized error by `X ^ d`.
+
+## Main declarations
+
+* `X_pow_dvd_taylor_iff`: truncated Hasse vanishing as divisibility.
+* `hasseDeriv_taylor`: Hasse derivatives commute with Taylor shifts.
+* `backwardTaylorReconstruction`: finite moving-point backward reconstruction.
+* `X_pow_succ_dvd_backwardTaylorResidual`: divisibility of the unnormalized numerator.
+* `X_pow_dvd_normalizedBackwardTaylorError`: divisibility after removing one factor of `X`.
+-/
+
+namespace Polynomial
+
+noncomputable section
+
+section Semiring
+
+variable {R : Type*} [Semiring R]
+
+/-- `X ^ m` divides the Taylor expansion at `a` iff the first `m` Hasse derivatives vanish. -/
+theorem X_pow_dvd_taylor_iff (p : R[X]) (a : R) (m : ℕ) :
+    X ^ m ∣ taylor a p ↔ ∀ i < m, (hasseDeriv i p).eval a = 0 := by
+  rw [X_pow_dvd_iff]
+  simp only [taylor_coeff]
+
+/-- The quotient of the shifted increment `p(a + X) - p(a)` by `X`.
+
+This is not the moving-point backward error defined later in this file. -/
+def shiftIncrementQuotient (a : R) (p : R[X]) : R[X] :=
+  (taylor a p).divX
+
+theorem taylor_eq_C_add_X_mul_shiftIncrementQuotient (p : R[X]) (a : R) :
+    taylor a p = C (p.eval a) + X * shiftIncrementQuotient a p := by
+  simpa only [shiftIncrementQuotient, taylor_coeff_zero, add_comm] using
+    (X_mul_divX_add (taylor a p)).symm
+
+theorem taylor_eq_C_add_X_mul_shiftIncrementQuotient_of_eval_eq {p : R[X]} {a y : R}
+    (h : p.eval a = y) :
+    taylor a p = C y + X * shiftIncrementQuotient a p := by
+  simpa only [h] using taylor_eq_C_add_X_mul_shiftIncrementQuotient p a
+
+/-- Coefficient `i` is Hasse derivative `i + 1`; normalization introduces an off-by-one. -/
+theorem coeff_shiftIncrementQuotient (p : R[X]) (a : R) (i : ℕ) :
+    (shiftIncrementQuotient a p).coeff i = (hasseDeriv (i + 1) p).eval a := by
+  rw [shiftIncrementQuotient, coeff_divX, taylor_coeff]
+
+theorem natDegree_shiftIncrementQuotient (p : R[X]) (a : R) :
+    (shiftIncrementQuotient a p).natDegree = p.natDegree - 1 := by
+  rw [shiftIncrementQuotient, natDegree_divX_eq_natDegree_tsub_one, natDegree_taylor]
+
+theorem X_pow_dvd_shiftIncrementQuotient_iff (p : R[X]) (a : R) (m : ℕ) :
+    X ^ m ∣ shiftIncrementQuotient a p ↔
+      ∀ i < m, (hasseDeriv (i + 1) p).eval a = 0 := by
+  rw [X_pow_dvd_iff]
+  simp only [coeff_shiftIncrementQuotient]
+
+end Semiring
+
+section CommSemiring
+
+variable {R : Type*} [CommSemiring R]
+
+/-- Hasse differentiation commutes with shifting the polynomial's input. -/
+theorem hasseDeriv_taylor (p : R[X]) (a : R) (k : ℕ) :
+    hasseDeriv k (taylor a p) = taylor a (hasseDeriv k p) := by
+  ext n
+  rw [hasseDeriv_coeff, taylor_coeff, taylor_coeff]
+  have h := LinearMap.congr_fun (hasseDeriv_comp (R := R) n k) p
+  simp only [LinearMap.comp_apply, LinearMap.smul_apply] at h
+  rw [h, eval_smul, Nat.choose_symm_add]
+  simp [nsmul_eq_mul]
+
+end CommSemiring
+
+section CommRing
+
+variable {R : Type*} [CommRing R]
+
+theorem X_sub_C_pow_dvd_iff_hasseDeriv_eval_eq_zero (p : R[X]) (a : R) (m : ℕ) :
+    (X - C a) ^ m ∣ p ↔ ∀ i < m, (hasseDeriv i p).eval a = 0 := by
+  rw [X_sub_C_pow_dvd_iff]
+  change X ^ m ∣ taylor a p ↔ ∀ i < m, (hasseDeriv i p).eval a = 0
+  exact X_pow_dvd_taylor_iff p a m
+
+theorem X_pow_dvd_taylor_sub_iff (p q : R[X]) (a : R) (m : ℕ) :
+    X ^ m ∣ taylor a p - taylor a q ↔
+      ∀ i < m, (hasseDeriv i p).eval a = (hasseDeriv i q).eval a := by
+  rw [← LinearMap.map_sub, X_pow_dvd_taylor_iff]
+  simp only [LinearMap.map_sub, eval_sub, sub_eq_zero]
+
+theorem hasseDeriv_eval_eq_zero_iff_le_rootMultiplicity {p : R[X]} (hp : p ≠ 0)
+    (a : R) (m : ℕ) :
+    (∀ i < m, (hasseDeriv i p).eval a = 0) ↔ m ≤ p.rootMultiplicity a :=
+  (X_sub_C_pow_dvd_iff_hasseDeriv_eval_eq_zero p a m).symm.trans
+    (le_rootMultiplicity_iff hp).symm
+
+private theorem Int.alternating_sum_choose_succ {n : ℕ} (hn : n ≠ 0) :
+    (∑ j ∈ Finset.range n, (-1 : ℤ) ^ j * (n.choose (j + 1) : ℤ)) = 1 := by
+  have h := Int.alternating_sum_range_choose_of_ne hn
+  rw [Finset.sum_range_succ'] at h
+  simp only [Nat.choose_zero_right, Int.natCast_one, pow_zero, one_mul] at h
+  rw [show (∑ x ∈ Finset.range n, (-1 : ℤ) ^ (x + 1) * ↑(n.choose (x + 1))) =
+      -(∑ x ∈ Finset.range n, (-1 : ℤ) ^ x * ↑(n.choose (x + 1))) by
+    rw [← Finset.sum_neg_distrib]
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [pow_succ]
+    ring] at h
+  omega
+
+private theorem alternating_sum_choose_succ {n : ℕ} (hn : n ≠ 0) :
+    (∑ j ∈ Finset.range n, (-1 : R) ^ j * (n.choose (j + 1) : R)) = 1 := by
+  have h := congrArg (Int.castRingHom R) (Int.alternating_sum_choose_succ hn)
+  simpa using h
+
+/-- First `d` moving-Hasse correction terms for a polynomial in shifted coordinates. -/
+def backwardHasseSum (d : ℕ) (q : R[X]) : R[X] :=
+  ∑ j ∈ Finset.range d,
+    C ((-1 : R) ^ j) * (X ^ (j + 1) * hasseDeriv (j + 1) q)
+
+/-- Through degree `d`, the correction sum reproduces every nonconstant coefficient. -/
+theorem coeff_backwardHasseSum {d n : ℕ} (q : R[X]) (hn : n ≠ 0) (hnd : n ≤ d) :
+    (backwardHasseSum d q).coeff n = q.coeff n := by
+  rw [backwardHasseSum, finsetSum_coeff]
+  rw [← Finset.sum_subset (Finset.range_mono hnd)]
+  · have hterm : ∀ j ∈ Finset.range n,
+        (C ((-1 : R) ^ j) * (X ^ (j + 1) * hasseDeriv (j + 1) q)).coeff n =
+          ((-1 : R) ^ j * (n.choose (j + 1) : R)) * q.coeff n := by
+      intro j hj
+      rw [coeff_C_mul, coeff_X_pow_mul', if_pos]
+      · rw [hasseDeriv_coeff]
+        have hsub : n - (j + 1) + (j + 1) = n := by
+          have := Finset.mem_range.mp hj
+          omega
+        rw [hsub]
+        simp [mul_assoc]
+      · have := Finset.mem_range.mp hj
+        omega
+    rw [Finset.sum_congr rfl hterm, ← Finset.sum_mul,
+      alternating_sum_choose_succ hn, one_mul]
+  · intro j hjd hjn
+    rw [coeff_C_mul, coeff_X_pow_mul', if_neg]
+    · simp
+    · have hjd' := Finset.mem_range.mp hjd
+      have hjn' : ¬j < n := by simpa using hjn
+      omega
+
+/-- Coefficients of the correction sum above the degree of `q` vanish. -/
+theorem coeff_backwardHasseSum_eq_zero_of_natDegree_lt {d n : ℕ} (q : R[X])
+    (hn : q.natDegree < n) : (backwardHasseSum d q).coeff n = 0 := by
+  rw [backwardHasseSum, finsetSum_coeff]
+  apply Finset.sum_eq_zero
+  intro j _
+  rw [coeff_C_mul, coeff_X_pow_mul']
+  split_ifs with h
+  · rw [hasseDeriv_coeff]
+    have heq : n - (j + 1) + (j + 1) = n := Nat.sub_add_cancel h
+    rw [heq, coeff_eq_zero_of_natDegree_lt hn]
+    simp
+  · simp
+
+/-- Numerator remaining after the constant and first `d` moving-Hasse terms are removed. -/
+def backwardHasseResidual (d : ℕ) (q : R[X]) : R[X] :=
+  q - C (q.coeff 0) - backwardHasseSum d q
+
+theorem X_pow_succ_dvd_backwardHasseResidual (d : ℕ) (q : R[X]) :
+    X ^ (d + 1) ∣ backwardHasseResidual d q := by
+  rw [X_pow_dvd_iff]
+  intro n hn
+  by_cases hn0 : n = 0
+  · subst n
+    simp [backwardHasseResidual, backwardHasseSum]
+  · rw [backwardHasseResidual, coeff_sub, coeff_sub, coeff_C, if_neg hn0, sub_zero,
+      coeff_backwardHasseSum q hn0 (by omega), sub_self]
+
+/-- Once `d` reaches the degree of `q`, the finite backward expansion is exact. -/
+theorem backwardHasseResidual_eq_zero_of_natDegree_le (d : ℕ) (q : R[X])
+    (hdeg : q.natDegree ≤ d) : backwardHasseResidual d q = 0 := by
+  ext n
+  by_cases hn : n ≤ d
+  · by_cases hn0 : n = 0
+    · subst n
+      simp [backwardHasseResidual, backwardHasseSum]
+    · rw [backwardHasseResidual, coeff_sub, coeff_sub, coeff_C, if_neg hn0, sub_zero,
+        coeff_backwardHasseSum q hn0 hn, sub_self, coeff_zero]
+  · have hqn : q.natDegree < n := hdeg.trans_lt (Nat.lt_of_not_ge hn)
+    have hn0 : n ≠ 0 := by omega
+    rw [backwardHasseResidual, coeff_sub, coeff_sub, coeff_C, if_neg hn0,
+      coeff_eq_zero_of_natDegree_lt hqn,
+      coeff_backwardHasseSum_eq_zero_of_natDegree_lt q hqn, coeff_zero]
+    simp
+
+/-- Backward residual after removing its guaranteed factor of `X`. -/
+def normalizedBackwardHasseResidual (d : ℕ) (q : R[X]) : R[X] :=
+  (backwardHasseResidual d q).divX
+
+theorem X_pow_dvd_normalizedBackwardHasseResidual (d : ℕ) (q : R[X]) :
+    X ^ d ∣ normalizedBackwardHasseResidual d q := by
+  rw [X_pow_dvd_iff]
+  intro n hn
+  rw [normalizedBackwardHasseResidual, coeff_divX]
+  exact X_pow_dvd_iff.mp (X_pow_succ_dvd_backwardHasseResidual d q) (n + 1) (by omega)
+
+theorem X_mul_normalizedBackwardHasseResidual (d : ℕ) (q : R[X]) :
+    X * normalizedBackwardHasseResidual d q = backwardHasseResidual d q := by
+  have hzero := X_pow_dvd_iff.mp (X_pow_succ_dvd_backwardHasseResidual d q) 0 (by omega)
+  simpa only [normalizedBackwardHasseResidual, hzero, C_0, add_zero] using
+    X_mul_divX_add (backwardHasseResidual d q)
+
+/-- Paper-facing correction sum. Derivatives are evaluated at moving point `a + X`. -/
+def movingHasseSum (a : R) (p : R[X]) (d : ℕ) : R[X] :=
+  ∑ j ∈ Finset.range d,
+    C ((-1 : R) ^ j) * (X ^ (j + 1) * taylor a (hasseDeriv (j + 1) p))
+
+theorem movingHasseSum_eq_backwardHasseSum (a : R) (p : R[X]) (d : ℕ) :
+    movingHasseSum a p d = backwardHasseSum d (taylor a p) := by
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [hasseDeriv_taylor]
+
+def backwardTaylorResidual (a : R) (p : R[X]) (d : ℕ) : R[X] :=
+  taylor a p - C (p.eval a) - movingHasseSum a p d
+
+theorem backwardTaylorResidual_eq (a : R) (p : R[X]) (d : ℕ) :
+    backwardTaylorResidual a p d = backwardHasseResidual d (taylor a p) := by
+  rw [backwardTaylorResidual, backwardHasseResidual, movingHasseSum_eq_backwardHasseSum,
+    taylor_coeff_zero]
+
+/-- The paper-facing numerator has a zero of order at least `d + 1`. -/
+theorem X_pow_succ_dvd_backwardTaylorResidual (a : R) (p : R[X]) (d : ℕ) :
+    X ^ (d + 1) ∣ backwardTaylorResidual a p d := by
+  rw [backwardTaylorResidual_eq]
+  exact X_pow_succ_dvd_backwardHasseResidual d (taylor a p)
+
+/-- At or above the polynomial degree, the moving-point backward expansion has no error. -/
+theorem backwardTaylorResidual_eq_zero_of_natDegree_le (a : R) (p : R[X]) (d : ℕ)
+    (hdeg : p.natDegree ≤ d) : backwardTaylorResidual a p d = 0 := by
+  rw [backwardTaylorResidual_eq]
+  apply backwardHasseResidual_eq_zero_of_natDegree_le
+  simpa only [natDegree_taylor] using hdeg
+
+/-- Canonical normalized moving-point error; unlike the increment quotient, this depends on `d`. -/
+def normalizedBackwardTaylorError (a : R) (p : R[X]) (d : ℕ) : R[X] :=
+  (backwardTaylorResidual a p d).divX
+
+theorem X_pow_dvd_normalizedBackwardTaylorError (a : R) (p : R[X]) (d : ℕ) :
+    X ^ d ∣ normalizedBackwardTaylorError a p d := by
+  rw [normalizedBackwardTaylorError, backwardTaylorResidual_eq]
+  exact X_pow_dvd_normalizedBackwardHasseResidual d (taylor a p)
+
+/-- Finite moving-point backward reconstruction, with signs `+,-,+,...` from Hasse order one. -/
+theorem backwardTaylorReconstruction (a : R) (p : R[X]) (d : ℕ) :
+    taylor a p = C (p.eval a) + movingHasseSum a p d +
+      X * normalizedBackwardTaylorError a p d := by
+  have hx : X * normalizedBackwardTaylorError a p d = backwardTaylorResidual a p d := by
+    rw [normalizedBackwardTaylorError, backwardTaylorResidual_eq]
+    exact X_mul_normalizedBackwardHasseResidual d (taylor a p)
+  calc
+    taylor a p = C (p.eval a) + movingHasseSum a p d + backwardTaylorResidual a p d := by
+      simp only [backwardTaylorResidual]
+      ring
+    _ = _ := by rw [hx]
+
+theorem backwardTaylorReconstruction_of_eval_eq {a y : R} {p : R[X]} (d : ℕ)
+    (h : p.eval a = y) :
+    taylor a p = C y + movingHasseSum a p d + X * normalizedBackwardTaylorError a p d := by
+  simpa only [h] using backwardTaylorReconstruction a p d
+
+/-- At order zero, the moving error specializes to the elementary increment quotient. -/
+theorem normalizedBackwardTaylorError_zero (a : R) (p : R[X]) :
+    normalizedBackwardTaylorError a p 0 = shiftIncrementQuotient a p := by
+  ext n
+  simp [normalizedBackwardTaylorError, backwardTaylorResidual, movingHasseSum,
+    shiftIncrementQuotient, coeff_divX]
+
+/-- At or above the polynomial degree, the normalized moving error is zero. -/
+theorem normalizedBackwardTaylorError_eq_zero_of_natDegree_le (a : R) (p : R[X]) (d : ℕ)
+    (hdeg : p.natDegree ≤ d) : normalizedBackwardTaylorError a p d = 0 := by
+  rw [normalizedBackwardTaylorError,
+    backwardTaylorResidual_eq_zero_of_natDegree_le a p d hdeg, divX_zero]
+
+end CommRing
+
+end
+
+
+end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -17,9 +17,10 @@ elementary shift increment quotient and the paper's truncation-dependent backwar
 different constructions and are named separately.
 
 The moving-point API formalizes the finite form of the backward identity used as Equation (13)
-and its normalized remainder from Equation (16) in BCPZZ26. For truncation order `d`, correction
-term `j` has Hasse order `j + 1`, sign `(-1)^j`, and derivative evaluated at the moving point
-`a + X`. The numerator is divisible by `X ^ (d + 1)` and its normalized error by `X ^ d`.
+and its normalized remainder from Equation (16) of ECCC TR26-164. For truncation order `d`,
+correction term `j` has Hasse order `j + 1`, sign `(-1)^j`, and derivative evaluated at the
+moving point `a + X`. The numerator is divisible by `X ^ (d + 1)` and its normalized error by
+`X ^ d`.
 
 ## Main declarations
 
@@ -576,7 +577,8 @@ theorem coeff_normalizedBackwardTaylorError_eq_zero (a : R) (p : R[X]) (d n : â„
     (hn : n < d) : (normalizedBackwardTaylorError a p d).coeff n = 0 :=
   X_pow_dvd_iff.mp (X_pow_dvd_normalizedBackwardTaylorError a p d) n hn
 
-/-- Equation (16): multiplying the normalized moving error by `X` recovers its numerator. -/
+/-- Cleared-denominator form of Equation (16): multiplying the normalized moving error by `X`
+recovers its numerator. -/
 theorem X_mul_normalizedBackwardTaylorError (a : R) (p : R[X]) (d : â„•) :
     X * normalizedBackwardTaylorError a p d = backwardTaylorResidual a p d := by
   rw [normalizedBackwardTaylorError, backwardTaylorResidual_eq]

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -106,6 +106,10 @@ section CommRing
 
 variable {R : Type*} [CommRing R]
 
+private theorem divX_sub (p q : R[X]) : (p - q).divX = p.divX - q.divX := by
+  ext n
+  simp [coeff_divX]
+
 /-- Hasse vanishing at `a` is equivalent to divisibility by the corresponding root factor. -/
 theorem X_sub_C_pow_dvd_iff_hasseDeriv_eval_eq_zero (p : R[X]) (a : R) (m : ℕ) :
     (X - C a) ^ m ∣ p ↔ ∀ i < m, (hasseDeriv i p).eval a = 0 := by
@@ -347,6 +351,19 @@ theorem backwardTaylorResidual_eq_zero_of_natDegree_le (a : R) (p : R[X]) (d : �
 def normalizedBackwardTaylorError (a : R) (p : R[X]) (d : ℕ) : R[X] :=
   (backwardTaylorResidual a p d).divX
 
+/-- Increasing the truncation order subtracts the next normalized moving-Hasse term. -/
+theorem normalizedBackwardTaylorError_succ (a : R) (p : R[X]) (d : ℕ) :
+    normalizedBackwardTaylorError a p (d + 1) = normalizedBackwardTaylorError a p d -
+      C ((-1 : R) ^ d) * (X ^ d * taylor a (hasseDeriv (d + 1) p)) := by
+  rw [normalizedBackwardTaylorError, normalizedBackwardTaylorError,
+    backwardTaylorResidual_succ, divX_sub]
+  have hterm :
+      C ((-1 : R) ^ d) * (X ^ (d + 1) * taylor a (hasseDeriv (d + 1) p)) =
+        X * (C ((-1 : R) ^ d) * (X ^ d * taylor a (hasseDeriv (d + 1) p))) := by
+    rw [pow_succ]
+    ring
+  rw [hterm, divX_X_mul]
+
 /-- Normalization lowers the residual degree by one. -/
 theorem natDegree_normalizedBackwardTaylorError_le (a : R) (p : R[X]) (d : ℕ) :
     (normalizedBackwardTaylorError a p d).natDegree ≤ p.natDegree - 1 := by
@@ -398,6 +415,12 @@ theorem normalizedBackwardTaylorError_zero (a : R) (p : R[X]) :
   ext n
   simp [normalizedBackwardTaylorError, backwardTaylorResidual, movingHasseSum,
     shiftIncrementQuotient, coeff_divX]
+
+/-- The first update subtracts the shifted ordinary derivative from the increment quotient. -/
+theorem normalizedBackwardTaylorError_one (a : R) (p : R[X]) :
+    normalizedBackwardTaylorError a p 1 =
+      shiftIncrementQuotient a p - taylor a p.derivative := by
+  simpa [normalizedBackwardTaylorError_zero] using normalizedBackwardTaylorError_succ a p 0
 
 /-- The reconstruction determines its normalized error uniquely. -/
 theorem normalizedBackwardTaylorError_unique (a : R) (p : R[X]) (d : ℕ) {e : R[X]}

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -276,6 +276,15 @@ theorem movingHasseSum_succ (a : R) (p : R[X]) (d : ℕ) :
       C ((-1 : R) ^ d) * (X ^ (d + 1) * taylor a (hasseDeriv (d + 1) p)) := by
   rw [movingHasseSum, movingHasseSum, Finset.sum_range_succ]
 
+/-- The moving-Hasse correction sum is additive in the input polynomial. -/
+theorem movingHasseSum_add (a : R) (p q : R[X]) (d : ℕ) :
+    movingHasseSum a (p + q) d = movingHasseSum a p d + movingHasseSum a q d := by
+  simp only [movingHasseSum, LinearMap.map_add, mul_add, Finset.sum_add_distrib]
+
+@[simp]
+theorem movingHasseSum_zero (a : R) (d : ℕ) : movingHasseSum a 0 d = 0 := by
+  simp [movingHasseSum]
+
 /-- Moving derivatives of `p` are ordinary Hasse derivatives of its Taylor shift. -/
 theorem movingHasseSum_eq_backwardHasseSum (a : R) (p : R[X]) (d : ℕ) :
     movingHasseSum a p d = backwardHasseSum d (taylor a p) := by
@@ -304,6 +313,18 @@ theorem backwardTaylorResidual_succ (a : R) (p : R[X]) (d : ℕ) :
       C ((-1 : R) ^ d) * (X ^ (d + 1) * taylor a (hasseDeriv (d + 1) p)) := by
   rw [backwardTaylorResidual, backwardTaylorResidual, movingHasseSum_succ]
   ring
+
+/-- The moving-point backward numerator is additive in the input polynomial. -/
+theorem backwardTaylorResidual_add (a : R) (p q : R[X]) (d : ℕ) :
+    backwardTaylorResidual a (p + q) d =
+      backwardTaylorResidual a p d + backwardTaylorResidual a q d := by
+  rw [backwardTaylorResidual, backwardTaylorResidual, backwardTaylorResidual,
+    LinearMap.map_add, eval_add, map_add, movingHasseSum_add]
+  ring
+
+@[simp]
+theorem backwardTaylorResidual_zero (a : R) (d : ℕ) : backwardTaylorResidual a 0 d = 0 := by
+  simp [backwardTaylorResidual]
 
 /-- The order-one residual recovers the earlier derivative-contact identity exactly. -/
 theorem backwardTaylorResidual_one (a : R) (p : R[X]) :
@@ -392,6 +413,19 @@ theorem coeff_normalizedBackwardTaylorError (a : R) (p : R[X]) (d n : ℕ) :
     (normalizedBackwardTaylorError a p d).coeff n =
       (backwardTaylorResidual a p d).coeff (n + 1) := by
   rw [normalizedBackwardTaylorError, coeff_divX]
+
+/-- The normalized moving-point error is additive in the input polynomial. -/
+theorem normalizedBackwardTaylorError_add (a : R) (p q : R[X]) (d : ℕ) :
+    normalizedBackwardTaylorError a (p + q) d =
+      normalizedBackwardTaylorError a p d + normalizedBackwardTaylorError a q d := by
+  ext n
+  simp only [coeff_normalizedBackwardTaylorError, backwardTaylorResidual_add, coeff_add]
+
+@[simp]
+theorem normalizedBackwardTaylorError_zero_poly (a : R) (d : ℕ) :
+    normalizedBackwardTaylorError a 0 d = 0 := by
+  ext n
+  simp [coeff_normalizedBackwardTaylorError]
 
 /-- Finite moving-point backward reconstruction, with signs `+,-,+,...` from Hasse order one. -/
 theorem backwardTaylorReconstruction (a : R) (p : R[X]) (d : ℕ) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -39,7 +39,7 @@ section Semiring
 variable {R : Type*} [Semiring R]
 
 /-- Removing the leading `X` from `X * p` recovers `p`. -/
-theorem divX_X_mul (p : R[X]) : (X * p).divX = p := by
+private theorem divX_X_mul (p : R[X]) : (X * p).divX = p := by
   ext n
   simp [coeff_divX, coeff_X_mul]
 
@@ -55,11 +55,13 @@ This is not the moving-point backward error defined later in this file. -/
 def shiftIncrementQuotient (a : R) (p : R[X]) : R[X] :=
   (taylor a p).divX
 
+/-- Decompose a Taylor shift into its center value and shifted increment quotient. -/
 theorem taylor_eq_C_add_X_mul_shiftIncrementQuotient (p : R[X]) (a : R) :
     taylor a p = C (p.eval a) + X * shiftIncrementQuotient a p := by
   simpa only [shiftIncrementQuotient, taylor_coeff_zero, add_comm] using
     (X_mul_divX_add (taylor a p)).symm
 
+/-- Decomposition with a caller-supplied center value. -/
 theorem taylor_eq_C_add_X_mul_shiftIncrementQuotient_of_eval_eq {p : R[X]} {a y : R}
     (h : p.eval a = y) :
     taylor a p = C y + X * shiftIncrementQuotient a p := by
@@ -70,10 +72,12 @@ theorem coeff_shiftIncrementQuotient (p : R[X]) (a : R) (i : ℕ) :
     (shiftIncrementQuotient a p).coeff i = (hasseDeriv (i + 1) p).eval a := by
   rw [shiftIncrementQuotient, coeff_divX, taylor_coeff]
 
+/-- The increment quotient has degree one below the original polynomial. -/
 theorem natDegree_shiftIncrementQuotient (p : R[X]) (a : R) :
     (shiftIncrementQuotient a p).natDegree = p.natDegree - 1 := by
   rw [shiftIncrementQuotient, natDegree_divX_eq_natDegree_tsub_one, natDegree_taylor]
 
+/-- Vanishing orders one through `m` are equivalent to `X ^ m` dividing the increment quotient. -/
 theorem X_pow_dvd_shiftIncrementQuotient_iff (p : R[X]) (a : R) (m : ℕ) :
     X ^ m ∣ shiftIncrementQuotient a p ↔
       ∀ i < m, (hasseDeriv (i + 1) p).eval a = 0 := by
@@ -102,18 +106,21 @@ section CommRing
 
 variable {R : Type*} [CommRing R]
 
+/-- Hasse vanishing at `a` is equivalent to divisibility by the corresponding root factor. -/
 theorem X_sub_C_pow_dvd_iff_hasseDeriv_eval_eq_zero (p : R[X]) (a : R) (m : ℕ) :
     (X - C a) ^ m ∣ p ↔ ∀ i < m, (hasseDeriv i p).eval a = 0 := by
   rw [X_sub_C_pow_dvd_iff]
   change X ^ m ∣ taylor a p ↔ ∀ i < m, (hasseDeriv i p).eval a = 0
   exact X_pow_dvd_taylor_iff p a m
 
+/-- Matching length-`m` Hasse jets are equivalent to a shifted congruence modulo `X ^ m`. -/
 theorem X_pow_dvd_taylor_sub_iff (p q : R[X]) (a : R) (m : ℕ) :
     X ^ m ∣ taylor a p - taylor a q ↔
       ∀ i < m, (hasseDeriv i p).eval a = (hasseDeriv i q).eval a := by
   rw [← LinearMap.map_sub, X_pow_dvd_taylor_iff]
   simp only [LinearMap.map_sub, eval_sub, sub_eq_zero]
 
+/-- Hasse vanishing characterizes root multiplicity for a nonzero polynomial. -/
 theorem hasseDeriv_eval_eq_zero_iff_le_rootMultiplicity {p : R[X]} (hp : p ≠ 0)
     (a : R) (m : ℕ) :
     (∀ i < m, (hasseDeriv i p).eval a = 0) ↔ m ≤ p.rootMultiplicity a :=
@@ -189,6 +196,7 @@ theorem coeff_backwardHasseSum_eq_zero_of_natDegree_lt {d n : ℕ} (q : R[X])
 def backwardHasseResidual (d : ℕ) (q : R[X]) : R[X] :=
   q - C (q.coeff 0) - backwardHasseSum d q
 
+/-- The generic backward numerator is divisible by `X ^ (d + 1)`. -/
 theorem X_pow_succ_dvd_backwardHasseResidual (d : ℕ) (q : R[X]) :
     X ^ (d + 1) ∣ backwardHasseResidual d q := by
   rw [X_pow_dvd_iff]
@@ -220,6 +228,7 @@ theorem backwardHasseResidual_eq_zero_of_natDegree_le (d : ℕ) (q : R[X])
 def normalizedBackwardHasseResidual (d : ℕ) (q : R[X]) : R[X] :=
   (backwardHasseResidual d q).divX
 
+/-- Removing one `X` leaves a residual divisible by `X ^ d`. -/
 theorem X_pow_dvd_normalizedBackwardHasseResidual (d : ℕ) (q : R[X]) :
     X ^ d ∣ normalizedBackwardHasseResidual d q := by
   rw [X_pow_dvd_iff]
@@ -227,6 +236,7 @@ theorem X_pow_dvd_normalizedBackwardHasseResidual (d : ℕ) (q : R[X]) :
   rw [normalizedBackwardHasseResidual, coeff_divX]
   exact X_pow_dvd_iff.mp (X_pow_succ_dvd_backwardHasseResidual d q) (n + 1) (by omega)
 
+/-- Multiplication by `X` reconstructs the generic backward numerator. -/
 theorem X_mul_normalizedBackwardHasseResidual (d : ℕ) (q : R[X]) :
     X * normalizedBackwardHasseResidual d q = backwardHasseResidual d q := by
   have hzero := X_pow_dvd_iff.mp (X_pow_succ_dvd_backwardHasseResidual d q) 0 (by omega)
@@ -238,15 +248,37 @@ def movingHasseSum (a : R) (p : R[X]) (d : ℕ) : R[X] :=
   ∑ j ∈ Finset.range d,
     C ((-1 : R) ^ j) * (X ^ (j + 1) * taylor a (hasseDeriv (j + 1) p))
 
+/-- Adding one truncation order appends exactly the next alternating moving-Hasse term. -/
+theorem movingHasseSum_succ (a : R) (p : R[X]) (d : ℕ) :
+    movingHasseSum a p (d + 1) = movingHasseSum a p d +
+      C ((-1 : R) ^ d) * (X ^ (d + 1) * taylor a (hasseDeriv (d + 1) p)) := by
+  rw [movingHasseSum, movingHasseSum, Finset.sum_range_succ]
+
+/-- Moving derivatives of `p` are ordinary Hasse derivatives of its Taylor shift. -/
 theorem movingHasseSum_eq_backwardHasseSum (a : R) (p : R[X]) (d : ℕ) :
     movingHasseSum a p d = backwardHasseSum d (taylor a p) := by
   apply Finset.sum_congr rfl
   intro j _
   rw [hasseDeriv_taylor]
 
+/-- The correction sum reproduces each nonconstant Taylor coefficient through order `d`. -/
+theorem coeff_movingHasseSum {a : R} {p : R[X]} {d n : ℕ} (hn : n ≠ 0) (hnd : n ≤ d) :
+    (movingHasseSum a p d).coeff n = (hasseDeriv n p).eval a := by
+  rw [movingHasseSum_eq_backwardHasseSum,
+    coeff_backwardHasseSum (taylor a p) hn hnd, taylor_coeff]
+
+/-- Numerator left by the finite paper-facing moving-Hasse correction sum. -/
 def backwardTaylorResidual (a : R) (p : R[X]) (d : ℕ) : R[X] :=
   taylor a p - C (p.eval a) - movingHasseSum a p d
 
+/-- Increasing the truncation order subtracts the next moving-Hasse term from the residual. -/
+theorem backwardTaylorResidual_succ (a : R) (p : R[X]) (d : ℕ) :
+    backwardTaylorResidual a p (d + 1) = backwardTaylorResidual a p d -
+      C ((-1 : R) ^ d) * (X ^ (d + 1) * taylor a (hasseDeriv (d + 1) p)) := by
+  rw [backwardTaylorResidual, backwardTaylorResidual, movingHasseSum_succ]
+  ring
+
+/-- The paper-facing residual is the generic residual applied to the shifted polynomial. -/
 theorem backwardTaylorResidual_eq (a : R) (p : R[X]) (d : ℕ) :
     backwardTaylorResidual a p d = backwardHasseResidual d (taylor a p) := by
   rw [backwardTaylorResidual, backwardHasseResidual, movingHasseSum_eq_backwardHasseSum,
@@ -257,6 +289,11 @@ theorem X_pow_succ_dvd_backwardTaylorResidual (a : R) (p : R[X]) (d : ℕ) :
     X ^ (d + 1) ∣ backwardTaylorResidual a p d := by
   rw [backwardTaylorResidual_eq]
   exact X_pow_succ_dvd_backwardHasseResidual d (taylor a p)
+
+/-- Every coefficient below degree `d + 1` of the numerator vanishes. -/
+theorem coeff_backwardTaylorResidual_eq_zero (a : R) (p : R[X]) (d n : ℕ)
+    (hn : n < d + 1) : (backwardTaylorResidual a p d).coeff n = 0 :=
+  X_pow_dvd_iff.mp (X_pow_succ_dvd_backwardTaylorResidual a p d) n hn
 
 /-- At or above the polynomial degree, the moving-point backward expansion has no error. -/
 theorem backwardTaylorResidual_eq_zero_of_natDegree_le (a : R) (p : R[X]) (d : ℕ)
@@ -269,10 +306,16 @@ theorem backwardTaylorResidual_eq_zero_of_natDegree_le (a : R) (p : R[X]) (d : �
 def normalizedBackwardTaylorError (a : R) (p : R[X]) (d : ℕ) : R[X] :=
   (backwardTaylorResidual a p d).divX
 
+/-- The normalized moving-point error is divisible by `X ^ d`. -/
 theorem X_pow_dvd_normalizedBackwardTaylorError (a : R) (p : R[X]) (d : ℕ) :
     X ^ d ∣ normalizedBackwardTaylorError a p d := by
   rw [normalizedBackwardTaylorError, backwardTaylorResidual_eq]
   exact X_pow_dvd_normalizedBackwardHasseResidual d (taylor a p)
+
+/-- Every coefficient below degree `d` of the normalized error vanishes. -/
+theorem coeff_normalizedBackwardTaylorError_eq_zero (a : R) (p : R[X]) (d n : ℕ)
+    (hn : n < d) : (normalizedBackwardTaylorError a p d).coeff n = 0 :=
+  X_pow_dvd_iff.mp (X_pow_dvd_normalizedBackwardTaylorError a p d) n hn
 
 /-- Equation (16): multiplying the normalized moving error by `X` recovers its numerator. -/
 theorem X_mul_normalizedBackwardTaylorError (a : R) (p : R[X]) (d : ℕ) :
@@ -280,6 +323,7 @@ theorem X_mul_normalizedBackwardTaylorError (a : R) (p : R[X]) (d : ℕ) :
   rw [normalizedBackwardTaylorError, backwardTaylorResidual_eq]
   exact X_mul_normalizedBackwardHasseResidual d (taylor a p)
 
+/-- Coefficients of the normalized error are shifted numerator coefficients. -/
 theorem coeff_normalizedBackwardTaylorError (a : R) (p : R[X]) (d n : ℕ) :
     (normalizedBackwardTaylorError a p d).coeff n =
       (backwardTaylorResidual a p d).coeff (n + 1) := by
@@ -295,6 +339,7 @@ theorem backwardTaylorReconstruction (a : R) (p : R[X]) (d : ℕ) :
       ring
     _ = _ := by rw [X_mul_normalizedBackwardTaylorError]
 
+/-- Reconstruction with a caller-supplied center value `y`. -/
 theorem backwardTaylorReconstruction_of_eval_eq {a y : R} {p : R[X]} (d : ℕ)
     (h : p.eval a = y) :
     taylor a p = C y + movingHasseSum a p d + X * normalizedBackwardTaylorError a p d := by

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -34,6 +34,17 @@ namespace Polynomial
 
 noncomputable section
 
+private theorem map_hasseDeriv {R S : Type*} [Semiring R] [Semiring S]
+    (f : R →+* S) (p : R[X]) (k : ℕ) :
+    (hasseDeriv k p).map f = hasseDeriv k (p.map f) := by
+  ext n
+  simp [hasseDeriv_coeff]
+
+private theorem map_divX {R S : Type*} [Semiring R] [Semiring S]
+    (f : R →+* S) (p : R[X]) : p.divX.map f = (p.map f).divX := by
+  ext n
+  simp [coeff_divX]
+
 section Semiring
 
 variable {R : Type*} [Semiring R]
@@ -270,6 +281,15 @@ def movingHasseSum (a : R) (p : R[X]) (d : ℕ) : R[X] :=
   ∑ j ∈ Finset.range d,
     C ((-1 : R) ^ j) * (X ^ (j + 1) * taylor a (hasseDeriv (j + 1) p))
 
+/-- The moving-Hasse correction sum is natural under coefficient-ring homomorphisms. -/
+theorem map_movingHasseSum {S : Type*} [CommRing S] (f : R →+* S)
+    (a : R) (p : R[X]) (d : ℕ) :
+    (movingHasseSum a p d).map f = movingHasseSum (f a) (p.map f) d := by
+  rw [movingHasseSum, movingHasseSum, Polynomial.map_sum f]
+  apply Finset.sum_congr rfl
+  intro j _
+  simp [map_hasseDeriv, map_taylor]
+
 /-- Adding one truncation order appends exactly the next alternating moving-Hasse term. -/
 theorem movingHasseSum_succ (a : R) (p : R[X]) (d : ℕ) :
     movingHasseSum a p (d + 1) = movingHasseSum a p d +
@@ -306,6 +326,13 @@ theorem movingHasseSum_one (a : R) (p : R[X]) :
 /-- Numerator left by the finite paper-facing moving-Hasse correction sum. -/
 def backwardTaylorResidual (a : R) (p : R[X]) (d : ℕ) : R[X] :=
   taylor a p - C (p.eval a) - movingHasseSum a p d
+
+/-- The moving-point backward numerator is natural under coefficient-ring homomorphisms. -/
+theorem map_backwardTaylorResidual {S : Type*} [CommRing S] (f : R →+* S)
+    (a : R) (p : R[X]) (d : ℕ) :
+    (backwardTaylorResidual a p d).map f =
+      backwardTaylorResidual (f a) (p.map f) d := by
+  simp [backwardTaylorResidual, map_taylor, eval_map, map_movingHasseSum]
 
 /-- Increasing the truncation order subtracts the next moving-Hasse term from the residual. -/
 theorem backwardTaylorResidual_succ (a : R) (p : R[X]) (d : ℕ) :
@@ -371,6 +398,13 @@ theorem backwardTaylorResidual_eq_zero_of_natDegree_le (a : R) (p : R[X]) (d : �
 /-- Canonical normalized moving-point error; unlike the increment quotient, this depends on `d`. -/
 def normalizedBackwardTaylorError (a : R) (p : R[X]) (d : ℕ) : R[X] :=
   (backwardTaylorResidual a p d).divX
+
+/-- The normalized moving-point error is natural under coefficient-ring homomorphisms. -/
+theorem map_normalizedBackwardTaylorError {S : Type*} [CommRing S] (f : R →+* S)
+    (a : R) (p : R[X]) (d : ℕ) :
+    (normalizedBackwardTaylorError a p d).map f =
+      normalizedBackwardTaylorError (f a) (p.map f) d := by
+  simp [normalizedBackwardTaylorError, map_divX, map_backwardTaylorResidual]
 
 /-- Increasing the truncation order subtracts the next normalized moving-Hasse term. -/
 theorem normalizedBackwardTaylorError_succ (a : R) (p : R[X]) (d : ℕ) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -112,6 +112,22 @@ theorem hasseDeriv_taylor (p : R[X]) (a : R) (k : ℕ) :
 
 end CommSemiring
 
+section Ring
+
+variable {R : Type*} [Ring R]
+
+/-! ### Shifted-difference congruences -/
+
+/-- Matching Hasse coefficients through order `m - 1` are equivalent to a shifted congruence
+modulo `X ^ m`. -/
+theorem X_pow_dvd_taylor_sub_iff (p q : R[X]) (a : R) (m : ℕ) :
+    X ^ m ∣ taylor a p - taylor a q ↔
+      ∀ i < m, (hasseDeriv i p).eval a = (hasseDeriv i q).eval a := by
+  rw [← LinearMap.map_sub, X_pow_dvd_taylor_iff]
+  simp only [LinearMap.map_sub, eval_sub, sub_eq_zero]
+
+end Ring
+
 section CommRing
 
 variable {R : Type*} [CommRing R]
@@ -128,13 +144,6 @@ theorem X_sub_C_pow_dvd_iff_hasseDeriv_eval_eq_zero (p : R[X]) (a : R) (m : ℕ)
   rw [X_sub_C_pow_dvd_iff]
   change X ^ m ∣ taylor a p ↔ ∀ i < m, (hasseDeriv i p).eval a = 0
   exact X_pow_dvd_taylor_iff p a m
-
-/-- Matching length-`m` Hasse jets are equivalent to a shifted congruence modulo `X ^ m`. -/
-theorem X_pow_dvd_taylor_sub_iff (p q : R[X]) (a : R) (m : ℕ) :
-    X ^ m ∣ taylor a p - taylor a q ↔
-      ∀ i < m, (hasseDeriv i p).eval a = (hasseDeriv i q).eval a := by
-  rw [← LinearMap.map_sub, X_pow_dvd_taylor_iff]
-  simp only [LinearMap.map_sub, eval_sub, sub_eq_zero]
 
 /-- Hasse vanishing characterizes root multiplicity for a nonzero polynomial. -/
 theorem hasseDeriv_eval_eq_zero_iff_le_rootMultiplicity {p : R[X]} (hp : p ≠ 0)

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -344,6 +344,12 @@ theorem movingHasseSum_comp_C_mul_X (a c : R) (p : R[X]) (d : ℕ) :
   simp only [map_pow]
   ring
 
+/-- An affine change of variable sends observation center `b` to `c * b + a`. -/
+theorem movingHasseSum_taylor_comp_C_mul_X (a b c : R) (p : R[X]) (d : ℕ) :
+    movingHasseSum b ((taylor a p).comp (C c * X)) d =
+      (movingHasseSum (c * b + a) p d).comp (C c * X) := by
+  rw [movingHasseSum_comp_C_mul_X, movingHasseSum_taylor]
+
 /-- Adding one truncation order appends exactly the next alternating moving-Hasse term. -/
 theorem movingHasseSum_succ (a : R) (p : R[X]) (d : ℕ) :
     movingHasseSum a p (d + 1) = movingHasseSum a p d +
@@ -416,6 +422,12 @@ theorem backwardTaylorResidual_comp_C_mul_X (a c : R) (p : R[X]) (d : ℕ) :
   congr 2
   rw [eval_comp]
   simp
+
+/-- The backward numerator commutes with an affine change of variable. -/
+theorem backwardTaylorResidual_taylor_comp_C_mul_X (a b c : R) (p : R[X]) (d : ℕ) :
+    backwardTaylorResidual b ((taylor a p).comp (C c * X)) d =
+      (backwardTaylorResidual (c * b + a) p d).comp (C c * X) := by
+  rw [backwardTaylorResidual_comp_C_mul_X, backwardTaylorResidual_taylor]
 
 /-- Increasing the truncation order subtracts the next moving-Hasse term from the residual. -/
 theorem backwardTaylorResidual_succ (a : R) (p : R[X]) (d : ℕ) :
@@ -520,6 +532,13 @@ theorem normalizedBackwardTaylorError_comp_C_mul_X (a c : R) (p : R[X]) (d : ℕ
       C c * (normalizedBackwardTaylorError (c * a) p d).comp (C c * X) := by
   rw [normalizedBackwardTaylorError, normalizedBackwardTaylorError,
     backwardTaylorResidual_comp_C_mul_X, divX_comp_C_mul_X]
+
+/-- The normalized error gains one factor of `c` under an affine change of variable. -/
+theorem normalizedBackwardTaylorError_taylor_comp_C_mul_X
+    (a b c : R) (p : R[X]) (d : ℕ) :
+    normalizedBackwardTaylorError b ((taylor a p).comp (C c * X)) d =
+      C c * (normalizedBackwardTaylorError (c * b + a) p d).comp (C c * X) := by
+  rw [normalizedBackwardTaylorError_comp_C_mul_X, normalizedBackwardTaylorError_taylor]
 
 /-- Increasing the truncation order subtracts the next normalized moving-Hasse term. -/
 theorem normalizedBackwardTaylorError_succ (a : R) (p : R[X]) (d : ℕ) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -192,9 +192,27 @@ theorem coeff_backwardHasseSum_eq_zero_of_natDegree_lt {d n : ℕ} (q : R[X])
     simp
   · simp
 
+/-- The backward correction sum does not increase natural degree. -/
+theorem natDegree_backwardHasseSum_le (d : ℕ) (q : R[X]) :
+    (backwardHasseSum d q).natDegree ≤ q.natDegree := by
+  rw [natDegree_le_iff_coeff_eq_zero]
+  intro n hn
+  exact coeff_backwardHasseSum_eq_zero_of_natDegree_lt q hn
+
 /-- Numerator remaining after the constant and first `d` moving-Hasse terms are removed. -/
 def backwardHasseResidual (d : ℕ) (q : R[X]) : R[X] :=
   q - C (q.coeff 0) - backwardHasseSum d q
+
+/-- The generic backward residual does not increase natural degree. -/
+theorem natDegree_backwardHasseResidual_le (d : ℕ) (q : R[X]) :
+    (backwardHasseResidual d q).natDegree ≤ q.natDegree := by
+  rw [natDegree_le_iff_coeff_eq_zero]
+  intro n hn
+  have hn0 : n ≠ 0 := by omega
+  rw [backwardHasseResidual, coeff_sub, coeff_sub, coeff_C, if_neg hn0,
+    coeff_eq_zero_of_natDegree_lt hn,
+    coeff_backwardHasseSum_eq_zero_of_natDegree_lt q hn]
+  simp
 
 /-- The generic backward numerator is divisible by `X ^ (d + 1)`. -/
 theorem X_pow_succ_dvd_backwardHasseResidual (d : ℕ) (q : R[X]) :
@@ -267,6 +285,11 @@ theorem coeff_movingHasseSum {a : R} {p : R[X]} {d n : ℕ} (hn : n ≠ 0) (hnd 
   rw [movingHasseSum_eq_backwardHasseSum,
     coeff_backwardHasseSum (taylor a p) hn hnd, taylor_coeff]
 
+/-- At order one, the moving-Hasse sum is the shifted ordinary derivative times `X`. -/
+theorem movingHasseSum_one (a : R) (p : R[X]) :
+    movingHasseSum a p 1 = X * taylor a p.derivative := by
+  simp [movingHasseSum]
+
 /-- Numerator left by the finite paper-facing moving-Hasse correction sum. -/
 def backwardTaylorResidual (a : R) (p : R[X]) (d : ℕ) : R[X] :=
   taylor a p - C (p.eval a) - movingHasseSum a p d
@@ -278,17 +301,35 @@ theorem backwardTaylorResidual_succ (a : R) (p : R[X]) (d : ℕ) :
   rw [backwardTaylorResidual, backwardTaylorResidual, movingHasseSum_succ]
   ring
 
+/-- The order-one residual recovers the earlier derivative-contact identity exactly. -/
+theorem backwardTaylorResidual_one (a : R) (p : R[X]) :
+    backwardTaylorResidual a p 1 =
+      taylor a p - C (p.eval a) - X * taylor a p.derivative := by
+  rw [backwardTaylorResidual, movingHasseSum_one]
+
 /-- The paper-facing residual is the generic residual applied to the shifted polynomial. -/
 theorem backwardTaylorResidual_eq (a : R) (p : R[X]) (d : ℕ) :
     backwardTaylorResidual a p d = backwardHasseResidual d (taylor a p) := by
   rw [backwardTaylorResidual, backwardHasseResidual, movingHasseSum_eq_backwardHasseSum,
     taylor_coeff_zero]
 
+/-- The paper-facing backward numerator does not increase the degree of `p`. -/
+theorem natDegree_backwardTaylorResidual_le (a : R) (p : R[X]) (d : ℕ) :
+    (backwardTaylorResidual a p d).natDegree ≤ p.natDegree := by
+  rw [backwardTaylorResidual_eq, ← natDegree_taylor p a]
+  exact natDegree_backwardHasseResidual_le d (taylor a p)
+
 /-- The paper-facing numerator has a zero of order at least `d + 1`. -/
 theorem X_pow_succ_dvd_backwardTaylorResidual (a : R) (p : R[X]) (d : ℕ) :
     X ^ (d + 1) ∣ backwardTaylorResidual a p d := by
   rw [backwardTaylorResidual_eq]
   exact X_pow_succ_dvd_backwardHasseResidual d (taylor a p)
+
+/-- The order-one contact residual is divisible by `X²`. -/
+theorem X_sq_dvd_taylor_sub_C_sub_X_mul_derivative (a : R) (p : R[X]) :
+    X ^ 2 ∣ taylor a p - C (p.eval a) - X * taylor a p.derivative := by
+  simpa only [backwardTaylorResidual_one, Nat.reduceAdd] using
+    X_pow_succ_dvd_backwardTaylorResidual a p 1
 
 /-- Every coefficient below degree `d + 1` of the numerator vanishes. -/
 theorem coeff_backwardTaylorResidual_eq_zero (a : R) (p : R[X]) (d n : ℕ)
@@ -305,6 +346,12 @@ theorem backwardTaylorResidual_eq_zero_of_natDegree_le (a : R) (p : R[X]) (d : �
 /-- Canonical normalized moving-point error; unlike the increment quotient, this depends on `d`. -/
 def normalizedBackwardTaylorError (a : R) (p : R[X]) (d : ℕ) : R[X] :=
   (backwardTaylorResidual a p d).divX
+
+/-- Normalization lowers the residual degree by one. -/
+theorem natDegree_normalizedBackwardTaylorError_le (a : R) (p : R[X]) (d : ℕ) :
+    (normalizedBackwardTaylorError a p d).natDegree ≤ p.natDegree - 1 := by
+  rw [normalizedBackwardTaylorError, natDegree_divX_eq_natDegree_tsub_one]
+  exact Nat.sub_le_sub_right (natDegree_backwardTaylorResidual_le a p d) 1
 
 /-- The normalized moving-point error is divisible by `X ^ d`. -/
 theorem X_pow_dvd_normalizedBackwardTaylorError (a : R) (p : R[X]) (d : ℕ) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -33,7 +33,7 @@ moving point `a + X`. The numerator is divisible by `X ^ (d + 1)` and its normal
 
 ## References
 
-* J. Brakensiek, Y. Chen, E. Putterman, M. Zhang, and G. Zheng,
+* Joshua Brakensiek, Yeyuan Chen, Aaron Putterman, Zihan Zhang, and Kai Zhe Zheng,
   *Algorithmic List Decoding of Reed--Solomon Codes up to Capacity in the Low-Rate Regime*,
   [ECCC TR26-164](https://eccc.weizmann.ac.il/report/2026/164/), 2026.
 -/

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -497,6 +497,18 @@ theorem X_pow_succ_dvd_backwardTaylorResidual (a : R) (p : R[X]) (d : ℕ) :
   rw [backwardTaylorResidual_eq]
   exact X_pow_succ_dvd_backwardHasseResidual d (taylor a p)
 
+/-- Paper-facing congruence from Equation (13), written directly as divisibility by
+`X ^ (d + 1)`. -/
+theorem X_pow_succ_dvd_taylor_sub_C_sub_movingHasseSum (a : R) (p : R[X]) (d : ℕ) :
+    X ^ (d + 1) ∣ taylor a p - C (p.eval a) - movingHasseSum a p d := by
+  exact X_pow_succ_dvd_backwardTaylorResidual a p d
+
+/-- Equation (13) with a caller-supplied center value `y`. -/
+theorem X_pow_succ_dvd_taylor_sub_C_sub_movingHasseSum_of_eval_eq
+    {a y : R} {p : R[X]} (d : ℕ) (h : p.eval a = y) :
+    X ^ (d + 1) ∣ taylor a p - C y - movingHasseSum a p d := by
+  simpa only [h] using X_pow_succ_dvd_taylor_sub_C_sub_movingHasseSum a p d
+
 /-- The order-one contact residual is divisible by `X²`. -/
 theorem X_sq_dvd_taylor_sub_C_sub_X_mul_derivative (a : R) (p : R[X]) :
     X ^ 2 ∣ taylor a p - C (p.eval a) - X * taylor a p.derivative := by

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/Shift.lean
@@ -285,6 +285,14 @@ theorem map_movingHasseSum {S : Type*} [CommRing S] (f : R →+* S)
   intro j _
   simp [map_hasseDeriv, map_taylor]
 
+/-- Successive changes of origin add their centers in the moving-Hasse correction sum. -/
+theorem movingHasseSum_taylor (a b : R) (p : R[X]) (d : ℕ) :
+    movingHasseSum b (taylor a p) d = movingHasseSum (b + a) p d := by
+  rw [movingHasseSum, movingHasseSum]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [hasseDeriv_taylor, taylor_taylor]
+
 /-- Adding one truncation order appends exactly the next alternating moving-Hasse term. -/
 theorem movingHasseSum_succ (a : R) (p : R[X]) (d : ℕ) :
     movingHasseSum a p (d + 1) = movingHasseSum a p d +
@@ -340,6 +348,13 @@ theorem map_backwardTaylorResidual {S : Type*} [CommRing S] (f : R →+* S)
     (backwardTaylorResidual a p d).map f =
       backwardTaylorResidual (f a) (p.map f) d := by
   simp [backwardTaylorResidual, map_taylor, eval_map, map_movingHasseSum]
+
+/-- Successive changes of origin add their centers in the moving-point backward numerator. -/
+theorem backwardTaylorResidual_taylor (a b : R) (p : R[X]) (d : ℕ) :
+    backwardTaylorResidual b (taylor a p) d =
+      backwardTaylorResidual (b + a) p d := by
+  rw [backwardTaylorResidual, backwardTaylorResidual, taylor_taylor, taylor_eval,
+    movingHasseSum_taylor]
 
 /-- Increasing the truncation order subtracts the next moving-Hasse term from the residual. -/
 theorem backwardTaylorResidual_succ (a : R) (p : R[X]) (d : ℕ) :
@@ -430,6 +445,13 @@ theorem map_normalizedBackwardTaylorError {S : Type*} [CommRing S] (f : R →+* 
     (normalizedBackwardTaylorError a p d).map f =
       normalizedBackwardTaylorError (f a) (p.map f) d := by
   simp [normalizedBackwardTaylorError, map_divX, map_backwardTaylorResidual]
+
+/-- Successive changes of origin add their centers in the normalized moving-point error. -/
+theorem normalizedBackwardTaylorError_taylor (a b : R) (p : R[X]) (d : ℕ) :
+    normalizedBackwardTaylorError b (taylor a p) d =
+      normalizedBackwardTaylorError (b + a) p d := by
+  rw [normalizedBackwardTaylorError, normalizedBackwardTaylorError,
+    backwardTaylorResidual_taylor]
 
 /-- Increasing the truncation order subtracts the next normalized moving-Hasse term. -/
 theorem normalizedBackwardTaylorError_succ (a : R) (p : R[X]) (d : ℕ) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
@@ -82,14 +82,41 @@ example :
   · apply normalizedBackwardTaylorError_eq_zero_of_natDegree_le
     norm_num [natDegree_X_pow]
 
-/-- A concrete coefficient reduction checks naturality across genuinely different rings. -/
+/-- A coefficient-sensitive reduction checks naturality across genuinely different rings. Both
+sides are computed independently, rather than discharged by the naturality theorem itself. -/
 example :
-    (normalizedBackwardTaylorError (2 : ℤ) (X ^ 3 + C 7) 2).map
+    (normalizedBackwardTaylorError (0 : ℤ) (C 7 * X ^ 3) 2).map
         (Int.castRingHom (ZMod 5)) =
-      normalizedBackwardTaylorError ((Int.castRingHom (ZMod 5)) 2)
-        ((X ^ 3 + C 7 : ℤ[X]).map (Int.castRingHom (ZMod 5))) 2 := by
-  exact map_normalizedBackwardTaylorError (Int.castRingHom (ZMod 5))
-    (2 : ℤ) (X ^ 3 + C 7) 2
+      normalizedBackwardTaylorError (0 : ZMod 5)
+        ((C 7 * X ^ 3 : ℤ[X]).map (Int.castRingHom (ZMod 5))) 2 := by
+  have hInt : normalizedBackwardTaylorError (0 : ℤ) (C 7 * X ^ 3) 2 =
+      C 7 * X ^ 2 := by
+    have hzero : normalizedBackwardTaylorError (0 : ℤ) (C 7 * X ^ 3) 3 = 0 := by
+      apply normalizedBackwardTaylorError_eq_zero_of_natDegree_le
+      norm_num [natDegree_C_mul_X_pow]
+    have hder : hasseDeriv 3 (C 7 * X ^ 3 : ℤ[X]) = C 7 := by
+      rw [C_mul_X_pow_eq_monomial, hasseDeriv_monomial]
+      norm_num
+    have hrec := normalizedBackwardTaylorError_succ (0 : ℤ) (C 7 * X ^ 3) 2
+    rw [hzero, hder, taylor_zero] at hrec
+    norm_num at hrec ⊢
+    have h := sub_eq_zero.mp hrec.symm
+    simpa [mul_comm] using h
+  have hMod : normalizedBackwardTaylorError (0 : ZMod 5) (C 2 * X ^ 3) 2 =
+      C 2 * X ^ 2 := by
+    have hzero : normalizedBackwardTaylorError (0 : ZMod 5) (C 2 * X ^ 3) 3 = 0 := by
+      apply normalizedBackwardTaylorError_eq_zero_of_natDegree_le
+      rw [natDegree_C_mul_X_pow 3 2 (by decide)]
+    have hder : hasseDeriv 3 (C 2 * X ^ 3 : (ZMod 5)[X]) = C 2 := by
+      rw [C_mul_X_pow_eq_monomial, hasseDeriv_monomial]
+      norm_num
+    have hrec := normalizedBackwardTaylorError_succ (0 : ZMod 5) (C 2 * X ^ 3) 2
+    rw [hzero, hder, taylor_zero] at hrec
+    norm_num at hrec ⊢
+    exact sub_eq_zero.mp hrec.symm
+  rw [hInt]
+  norm_num
+  exact hMod.symm
 
 end
 

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
@@ -48,7 +48,7 @@ private theorem hasseDeriv_two_X_cube :
 
 /-- A genuine order-two example exercises both the positive first-Hasse and negative
 second-Hasse moving terms. -/
-example :
+private theorem X_cube_order_two_oracle :
     movingHasseSum (1 : ℤ) (X ^ 3) 2 = C 3 * X + C 3 * X ^ 2 ∧
       normalizedBackwardTaylorError (1 : ℤ) (X ^ 3) 2 = X ^ 2 := by
   have hm : movingHasseSum (1 : ℤ) (X ^ 3) 2 = C 3 * X + C 3 * X ^ 2 := by
@@ -66,6 +66,13 @@ example :
   · subst n
     simp [coeff_divX, coeff_X_pow]
   · simp [coeff_divX, coeff_X_pow, hn]
+
+/-- A nontrivial scalar checks the packaged linear map and its coefficient action. -/
+example :
+    normalizedBackwardTaylorErrorLinearMap (1 : ℤ) 2
+        ((7 : ℤ) • (X ^ 3 : ℤ[X])) = C 7 * X ^ 2 := by
+  rw [LinearMap.map_smul, normalizedBackwardTaylorErrorLinearMap_apply,
+    X_cube_order_two_oracle.2, smul_eq_C_mul]
 
 /-- Order zero reduces to the ordinary shifted increment quotient. -/
 example (a : ℤ) (p : ℤ[X]) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
@@ -90,6 +90,35 @@ example :
         C 2 * X ^ 2 + X * (C 2 * C 3) := by ring
     _ = C 2 * X ^ 2 + X := by rw [h, mul_one]
 
+/-- Scaling by `2` exercises both powers of `2` and the alternating order-one sign;
+the normalized error carries the additional leading factor from removing `X`. -/
+example :
+    normalizedBackwardTaylorError (0 : ZMod 5)
+        ((X ^ 3).comp (C 2 * X)) 1 = C 4 * X ^ 2 := by
+  rw [normalizedBackwardTaylorError_comp_C_mul_X]
+  simp only [mul_zero]
+  have hbase : normalizedBackwardTaylorError (0 : ZMod 5) (X ^ 3) 1 = C 3 * X ^ 2 := by
+    have hres : backwardTaylorResidual (0 : ZMod 5) (X ^ 3) 1 = C 3 * X ^ 3 := by
+      norm_num [backwardTaylorResidual, movingHasseSum, hasseDeriv_monomial,
+        Finset.sum_range_succ, taylor_zero]
+      have hc : (1 - C 3 : (ZMod 5)[X]) = C 3 := by
+        rw [← C_1, ← map_sub]
+        congr 1
+      calc
+        (X ^ 3 - X * (C 3 * X ^ 2) : (ZMod 5)[X]) =
+            (1 - C 3) * X ^ 3 := by ring
+        _ = C 3 * X ^ 3 := by rw [hc]
+    rw [normalizedBackwardTaylorError, hres]
+    ext n
+    simp [coeff_divX, coeff_X_pow]
+  norm_num [hbase, mul_pow]
+  calc
+    (C 2 * (C 3 * (C 2 ^ 2 * X ^ 2)) : (ZMod 5)[X]) =
+        (C 2 * C 3 * C 2 ^ 2) * X ^ 2 := by ring
+    _ = C (2 * 3 * 2 ^ 2 : ZMod 5) * X ^ 2 := by
+      simp only [map_mul, map_pow]
+    _ = C 4 * X ^ 2 := by congr 2
+
 /-- Order zero reduces to the ordinary shifted increment quotient. -/
 example (a : ℤ) (p : ℤ[X]) :
     normalizedBackwardTaylorError a p 0 = shiftIncrementQuotient a p :=

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao
 -/
 
 import ArkLib.ToMathlib.Polynomial.HasseTaylor.Shift
+import Mathlib.Data.ZMod.Basic
 import Mathlib.Tactic.NormNum
 
 /-! Mutation canaries for Hasse--Taylor shift orientation, characteristic, and signs. -/
@@ -80,6 +81,15 @@ example :
     norm_num [natDegree_X_pow]
   · apply normalizedBackwardTaylorError_eq_zero_of_natDegree_le
     norm_num [natDegree_X_pow]
+
+/-- A concrete coefficient reduction checks naturality across genuinely different rings. -/
+example :
+    (normalizedBackwardTaylorError (2 : ℤ) (X ^ 3 + C 7) 2).map
+        (Int.castRingHom (ZMod 5)) =
+      normalizedBackwardTaylorError ((Int.castRingHom (ZMod 5)) 2)
+        ((X ^ 3 + C 7 : ℤ[X]).map (Int.castRingHom (ZMod 5))) 2 := by
+  exact map_normalizedBackwardTaylorError (Int.castRingHom (ZMod 5))
+    (2 : ℤ) (X ^ 3 + C 7) 2
 
 end
 

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.ToMathlib.Polynomial.HasseTaylor.Shift
+import Mathlib.Tactic.NormNum
+
+/-! Mutation canaries for Hasse--Taylor shift orientation, characteristic, and signs. -/
+
+namespace Polynomial
+
+noncomputable section
+
+/-- Detects wrong sign, fixed-basepoint derivatives, and confusion with the increment quotient. -/
+example : normalizedBackwardTaylorError (1 : ℤ) (X ^ 2) 1 = -X := by
+  have hderiv : hasseDeriv 1 (X ^ 2 : ℤ[X]) = C 2 * X := by
+    rw [X_pow_eq_monomial, hasseDeriv_monomial]
+    norm_num
+    rw [← C_mul_X_pow_eq_monomial]
+    simp
+  have hshift : taylor (1 : ℤ) (hasseDeriv 1 (X ^ 2)) = C 2 * X + C 2 := by
+    rw [hderiv, taylor_mul, taylor_C, taylor_X, mul_add]
+    change C (2 : ℤ) * X + C 2 * C 1 = C 2 * X + C 2
+    rw [← C_mul]
+    norm_num
+  have hres : backwardTaylorResidual (1 : ℤ) (X ^ 2) 1 = -(X ^ 2) := by
+    norm_num [backwardTaylorResidual, movingHasseSum, taylor_apply, hshift]
+    ring
+  rw [normalizedBackwardTaylorError, hres]
+  ext n
+  by_cases hn : n = 1
+  · simp [coeff_divX, coeff_X_pow, coeff_X, hn]
+  · have hn' : 1 ≠ n := Ne.symm hn
+    simp [coeff_divX, coeff_X_pow, coeff_X, hn, hn']
+
+/-- Order zero reduces to the ordinary shifted increment quotient. -/
+example (a : ℤ) (p : ℤ[X]) :
+    normalizedBackwardTaylorError a p 0 = shiftIncrementQuotient a p :=
+  normalizedBackwardTaylorError_zero a p
+
+/-- Once the truncation reaches the polynomial degree, both residuals vanish. -/
+example :
+    backwardTaylorResidual (7 : ℤ) (X ^ 2) 2 = 0 ∧
+      normalizedBackwardTaylorError (7 : ℤ) (X ^ 2) 2 = 0 := by
+  constructor
+  · apply backwardTaylorResidual_eq_zero_of_natDegree_le
+    norm_num [natDegree_X_pow]
+  · apply normalizedBackwardTaylorError_eq_zero_of_natDegree_le
+    norm_num [natDegree_X_pow]
+
+end
+
+end Polynomial

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
@@ -35,6 +35,37 @@ example : normalizedBackwardTaylorError (1 : ℤ) (X ^ 2) 1 = -X := by
   · have hn' : 1 ≠ n := Ne.symm hn
     simp [coeff_divX, coeff_X_pow, coeff_X, hn, hn']
 
+private theorem hasseDeriv_one_X_cube :
+    hasseDeriv 1 (X ^ 3 : ℤ[X]) = monomial 2 3 := by
+  rw [X_pow_eq_monomial, hasseDeriv_monomial]
+  norm_num
+
+private theorem hasseDeriv_two_X_cube :
+    hasseDeriv 2 (X ^ 3 : ℤ[X]) = monomial 1 3 := by
+  rw [X_pow_eq_monomial, hasseDeriv_monomial]
+  norm_num
+
+/-- A genuine order-two example exercises both the positive first-Hasse and negative
+second-Hasse moving terms. -/
+example :
+    movingHasseSum (1 : ℤ) (X ^ 3) 2 = C 3 * X + C 3 * X ^ 2 ∧
+      normalizedBackwardTaylorError (1 : ℤ) (X ^ 3) 2 = X ^ 2 := by
+  have hm : movingHasseSum (1 : ℤ) (X ^ 3) 2 = C 3 * X + C 3 * X ^ 2 := by
+    norm_num [movingHasseSum, Finset.sum_range_succ, hasseDeriv_one_X_cube,
+      hasseDeriv_two_X_cube, taylor_monomial, taylor_C, taylor_apply]
+    ring
+  refine ⟨hm, ?_⟩
+  have hr : backwardTaylorResidual (1 : ℤ) (X ^ 3) 2 = X ^ 3 := by
+    rw [backwardTaylorResidual, hm]
+    norm_num [taylor_apply]
+    ring
+  rw [normalizedBackwardTaylorError, hr]
+  ext n
+  by_cases hn : n = 2
+  · subst n
+    simp [coeff_divX, coeff_X_pow]
+  · simp [coeff_divX, coeff_X_pow, hn]
+
 /-- Order zero reduces to the ordinary shifted increment quotient. -/
 example (a : ℤ) (p : ℤ[X]) :
     normalizedBackwardTaylorError a p 0 = shiftIncrementQuotient a p :=

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
@@ -74,6 +74,22 @@ example :
   rw [LinearMap.map_smul, normalizedBackwardTaylorErrorLinearMap_apply,
     X_cube_order_two_oracle.2, smul_eq_C_mul]
 
+/-- Asymmetric centers detect an inverse shift or a dropped first center in composition. -/
+example :
+    movingHasseSum (1 : ZMod 5) (taylor (2 : ZMod 5) (X ^ 2)) 1 =
+      C 2 * X ^ 2 + X := by
+  rw [movingHasseSum_taylor]
+  have hc : (1 + 2 : ZMod 5) = 3 := by decide
+  rw [hc]
+  norm_num [movingHasseSum, hasseDeriv_monomial, taylor_apply]
+  have h : C (2 : ZMod 5) * C 3 = 1 := by
+    rw [← C_mul]
+    congr 1
+  calc
+    (X * (C 2 * (X + C 3)) : (ZMod 5)[X]) =
+        C 2 * X ^ 2 + X * (C 2 * C 3) := by ring
+    _ = C 2 * X ^ 2 + X := by rw [h, mul_one]
+
 /-- Order zero reduces to the ordinary shifted increment quotient. -/
 example (a : ℤ) (p : ℤ[X]) :
     normalizedBackwardTaylorError a p 0 = shiftIncrementQuotient a p :=

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
@@ -36,10 +36,31 @@ example : normalizedBackwardTaylorError (1 : ℤ) (X ^ 2) 1 = -X := by
   · have hn' : 1 ≠ n := Ne.symm hn
     simp [coeff_divX, coeff_X_pow, coeff_X, hn, hn']
 
-private theorem hasseDeriv_one_X_cube :
-    hasseDeriv 1 (X ^ 3 : ℤ[X]) = monomial 2 3 := by
+private theorem hasseDeriv_one_X_cube {R : Type*} [CommRing R] :
+    hasseDeriv 1 (X ^ 3 : R[X]) = C 3 * X ^ 2 := by
   rw [X_pow_eq_monomial, hasseDeriv_monomial]
   norm_num
+  rw [← C_mul_X_pow_eq_monomial]
+
+private theorem backwardTaylorResidual_X_cube_one {R : Type*} [CommRing R] (a : R) :
+    backwardTaylorResidual a (X ^ 3) 1 =
+      (1 - C 3) * X ^ 3 - C (3 * a) * X ^ 2 := by
+  rw [backwardTaylorResidual, movingHasseSum]
+  norm_num [Finset.sum_range_succ, hasseDeriv_one_X_cube, taylor_apply]
+  rw [C_ofNat]
+  ring
+
+private theorem normalizedBackwardTaylorError_X_cube_one {R : Type*} [CommRing R] (a : R) :
+    normalizedBackwardTaylorError a (X ^ 3) 1 =
+      (1 - C 3) * X ^ 2 - C (3 * a) * X := by
+  rw [normalizedBackwardTaylorError]
+  have hfactor : backwardTaylorResidual a (X ^ 3) 1 =
+      X * ((1 - C 3) * X ^ 2 - C (3 * a) * X) := by
+    rw [backwardTaylorResidual_X_cube_one]
+    ring
+  rw [hfactor]
+  ext n
+  simp [coeff_divX, coeff_X_mul]
 
 private theorem hasseDeriv_two_X_cube :
     hasseDeriv 2 (X ^ 3 : ℤ[X]) = monomial 1 3 := by
@@ -74,13 +95,8 @@ example :
   rw [LinearMap.map_smul, normalizedBackwardTaylorErrorLinearMap_apply,
     X_cube_order_two_oracle.2, smul_eq_C_mul]
 
-/-- Asymmetric centers detect an inverse shift or a dropped first center in composition. -/
-example :
-    movingHasseSum (1 : ZMod 5) (taylor (2 : ZMod 5) (X ^ 2)) 1 =
-      C 2 * X ^ 2 + X := by
-  rw [movingHasseSum_taylor]
-  have hc : (1 + 2 : ZMod 5) = 3 := by decide
-  rw [hc]
+private theorem movingHasseSum_three_X_sq_one :
+    movingHasseSum (3 : ZMod 5) (X ^ 2) 1 = C 2 * X ^ 2 + X := by
   norm_num [movingHasseSum, hasseDeriv_monomial, taylor_apply]
   have h : C (2 : ZMod 5) * C 3 = 1 := by
     rw [← C_mul]
@@ -89,6 +105,31 @@ example :
     (X * (C 2 * (X + C 3)) : (ZMod 5)[X]) =
         C 2 * X ^ 2 + X * (C 2 * C 3) := by ring
     _ = C 2 * X ^ 2 + X := by rw [h, mul_one]
+
+/-- Asymmetric centers detect an inverse shift or a dropped first center in composition. -/
+example :
+    movingHasseSum (1 : ZMod 5) (taylor (2 : ZMod 5) (X ^ 2)) 1 =
+      C 2 * X ^ 2 + X := by
+  rw [movingHasseSum_taylor]
+  have hc : (1 + 2 : ZMod 5) = 3 := by decide
+  rw [hc, movingHasseSum_three_X_sq_one]
+
+/-- A nonzero translation, observation point, and scale detect loss of any affine parameter. -/
+example :
+    movingHasseSum (1 : ZMod 5)
+        ((taylor (1 : ZMod 5) (X ^ 2)).comp (C 2 * X)) 1 =
+      C 3 * X ^ 2 + C 2 * X := by
+  rw [movingHasseSum_taylor_comp_C_mul_X]
+  have hc : (2 * 1 + 1 : ZMod 5) = 3 := by decide
+  rw [hc, movingHasseSum_three_X_sq_one, add_comp, mul_comp, C_comp, pow_comp, X_comp,
+    mul_pow]
+  have h : C (2 : ZMod 5) * C 2 ^ 2 = C 3 := by
+    rw [← map_pow, ← map_mul]
+    congr 1
+  calc
+    (C 2 * (C 2 ^ 2 * X ^ 2) + C 2 * X : (ZMod 5)[X]) =
+        (C 2 * C 2 ^ 2) * X ^ 2 + C 2 * X := by ring
+    _ = C 3 * X ^ 2 + C 2 * X := by rw [h]
 
 /-- Scaling by `2` exercises both powers of `2` and the alternating order-one sign;
 the normalized error carries the additional leading factor from removing `X`. -/
@@ -118,6 +159,23 @@ example :
     _ = C (2 * 3 * 2 ^ 2 : ZMod 5) * X ^ 2 := by
       simp only [map_mul, map_pow]
     _ = C 4 * X ^ 2 := by congr 2
+
+/-- A nonzero center ensures affine scaling uses `c * a`; the linear coefficient also detects the
+extra normalization factor. -/
+example :
+    normalizedBackwardTaylorError (1 : ZMod 5)
+        ((X ^ 3).comp (C 2 * X)) 1 = C 4 * X ^ 2 + X := by
+  rw [normalizedBackwardTaylorError_comp_C_mul_X]
+  simp only [mul_one, normalizedBackwardTaylorError_X_cube_one, sub_comp, mul_comp, C_comp,
+    pow_comp, X_comp, mul_pow]
+  rw [one_comp]
+  norm_num [C_ofNat]
+  ring_nf
+  ext n
+  simp [coeff_add, coeff_sub, coeff_neg, coeff_X_pow, coeff_X]
+  split_ifs <;> norm_num
+  all_goals try omega
+  all_goals decide
 
 /-- Order zero reduces to the ordinary shifted increment quotient. -/
 example (a : ℤ) (p : ℤ[X]) :

--- a/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
+++ b/ArkLib/ToMathlib/Polynomial/HasseTaylor/ShiftCanary.lean
@@ -182,6 +182,12 @@ example (a : ℤ) (p : ℤ[X]) :
     normalizedBackwardTaylorError a p 0 = shiftIncrementQuotient a p :=
   normalizedBackwardTaylorError_zero a p
 
+/-- The direct Equation-(13) API accepts a caller-supplied received value without unfolding the
+residual package. -/
+example {a y : ℤ} {p : ℤ[X]} (h : p.eval a = y) (d : ℕ) :
+    X ^ (d + 1) ∣ taylor a p - C y - movingHasseSum a p d :=
+  X_pow_succ_dvd_taylor_sub_C_sub_movingHasseSum_of_eval_eq d h
+
 /-- Once the truncation reaches the polynomial degree, both residuals vanish. -/
 example :
     backwardTaylorResidual (7 : ℤ) (X ^ 2) 2 = 0 ∧


### PR DESCRIPTION
## Summary

This PR completes the scoped **P2a** package from #854: reusable, characteristic-independent univariate Hasse–Taylor infrastructure for the hidden-derivative Reed–Solomon formalization.

It adds:

- finite Hasse jets and exact degree-lowering maps;
- finite forward Taylor truncations with canonical `X ^ m` remainder quotients;
- linear-map packages for truncations, remainders, quotients, and backward errors;
- equivalences between finite-jet contact, local divisibility, and root-multiplicity bounds;
- the direct moving-point congruence, backward identity, and normalized error underlying equations (13) and (16) of Brakensiek–Chen–Putterman–Zhang–Zheng;
- coefficient-map, change-of-center, affine-substitution, prefix, and tail laws needed by later interpolation and root-solving work.

The API is additive and generic. It does **not** retrofit ArkLib's ordinary-derivative multiplicity-code API, formalize the paper's multivariate local constraints, or prove the decoder theorem in #855.

## Why this layer is needed

Mathlib already provides individual `Polynomial.hasseDeriv` and `Polynomial.taylor` operations. Downstream packages need stable finite-coordinate and remainder interfaces around them:

- local constraints consume the first `m` Hasse coefficients as one linear map;
- interpolation and root solving need exact degree drop and tail control;
- equation (16) needs a canonical polynomial error after removing one factor of the displacement variable;
- affine substitutions must preserve the paper's centers, powers, and normalization factors;
- none of this should rely on factorial inverses, `CharZero`, or a lower bound on the characteristic.

This PR packages those facts once at the generic polynomial layer.

## CI compatibility update (15 September 2026)

The merge of `main` dropped the Hasse–Taylor entries from the generated `ArkLib.lean`. Both the
import job and the source-policy gate failed because those files were outside the umbrella closure.

Commit `dfdedb2ebb88cf88e282e031085f69058fed7989` restores the five production imports and adopts
the current Lean module headers. It also makes `forwardTaylorTruncationToPolynomial` public,
as required by the exposed linear maps that use it, and moves all four unchanged canary files to
`ArkLibTest/ToMathlib/Polynomial/HasseTaylor/`, where `lake test` checks them.

Validation on the updated tree:

- `LAKE_ARTIFACT_CACHE=false LAKE_NO_CACHE=true ./scripts/validate.sh --axioms` passed in full;
- production and acceptance-test warning budgets, source-policy checks, runtime fixtures,
  import integrity, docs integrity, and KB lint passed;
- axiom sweep: 12,591 declarations across 496 modules, 291 existing `sorryAx`-tainted declarations,
  zero nonstandard-axiom taint, and no new axiom/sorry taint;
- source inventory versus current `main`: admissions `172 → 172`, explicit axioms `0 → 0`,
  native trust `0 → 0`; the 37 canary examples are unchanged;
- [GitHub CI for the updated head](https://github.com/Verified-zkEVM/ArkLib/actions/runs/34915512721)
  is running.

The original implementation and review evidence below is pinned to `0c6d0a405d33`; the update above
supersedes its file placement and base-to-head counts.

## Architecture

```text
Mathlib hasseDeriv / taylor
             │
             ▼
         FiniteJet
          ├──────► Forward
          │
          └──────► Shift ──────► JetDivisibility

Each production layer has a corresponding canary under `ArkLibTest/ToMathlib/Polynomial/HasseTaylor/`.
```

The dependency order is `FiniteJet`, then `Forward` and `Shift`, then `JetDivisibility`, followed by the public `HasseTaylor` umbrella.

## Public API by consumer task

### Finite coordinates and degree control

`FiniteJet.lean` provides `hasseCoeffAt`, `hasseJet`, prefix restriction, exact Hasse-derivative maps between `degreeLT` spaces, a finite-jet coordinate equivalence, and product/iteration/Taylor/affine laws.

Under `X ↦ cX + a`, observation point `b` becomes `c * b + a`, and Hasse order `i` gains the expected factor `c ^ i`.

### Forward truncations and canonical tails

`Forward.lean` provides finite Taylor truncations, remainders, canonical quotients, and linear-map packages, including the exact reconstruction

```text
taylor a p
  = forwardTaylorTruncation m a p
      + X ^ m * forwardTaylorQuotient m a p.
```

It also identifies quotient coefficients with Hasse orders `i + m`, proves zero-aware degree bounds, prefix/tail decompositions and tail towers, and supplies coefficient-map, center-composition, and affine-substitution laws. Under affine scaling by `c`, the quotient carries the essential factor `c ^ m`.

### Local contact, divisibility, and multiplicity

`Shift.lean` and `JetDivisibility.lean` show that:

- `X ^ m ∣ taylor a p` iff Hasse orders `< m` vanish;
- over a `Ring`, `X ^ m ∣ taylor a p - taylor a q` iff the corresponding finite jets agree;
- over a commutative ring, these become `(X - C a) ^ m` factor statements;
- for a nonzero polynomial, or two distinct polynomials, they are equivalent to root-multiplicity lower bounds.

The shifted-difference theorem intentionally requires only `Ring`, avoiding a needless commutativity assumption.

### Moving-point backward reconstruction

`Shift.lean` also provides `movingHasseSum`, the direct equation-(13) divisibility theorems, `backwardTaylorResidual`, `normalizedBackwardTaylorError`, their linear maps, and recurrence/coefficient/divisibility/degree/naturality/uniqueness laws. Center-composition and direct affine-substitution theorems cover the correction sum, residual, and normalized error.

For input scaling `X ↦ cX`, the normalized error gains one additional factor `c`, because normalization removes one factor of `X`.

## Exact correspondence with equations (13) and (16)

After assuming `P(α) = y`, equation (13) is

```text
P(α + T)
  ≡ y + Σ_{j=1}^d (-1)^(j+1) T^j P^[j](α + T)
      mod T^(d+1).
```

The zero-indexed Lean definition `movingHasseSum a p d` uses Hasse order `j + 1`, sign `(-1)^j`, and

```text
taylor a (hasseDeriv (j + 1) p),
```

so the derivative is evaluated at the moving point `a + X`, not fixed at `a`.

The theorem `X_pow_succ_dvd_taylor_sub_C_sub_movingHasseSum_of_eval_eq` states equation (13) directly:

```text
X ^ (d + 1) ∣
  taylor a p - C y - movingHasseSum a p d.
```

The reconstruction theorem strengthens this congruence by exposing its canonical quotient:

```text
taylor a p
  = C y
      + movingHasseSum a p d
      + X * normalizedBackwardTaylorError a p d.
```

where

```text
X ^ d ∣ normalizedBackwardTaylorError a p d.
```

Thus the caller-facing divisibility theorem gives the source congruence without requiring downstream users to unfold the residual package.

Equation (16) divides the numerator by `T`. Lean defines the polynomial quotient with `divX` and proves the cleared-denominator identity

```text
X * normalizedBackwardTaylorError a p d
  = backwardTaylorResidual a p d.
```

Reconstruction and uniqueness certify that this is exactly the intended quotient without pretending that the polynomial variable is invertible.

This PR supplies only this univariate algebra. Equations (14)–(15), the multivariate interpolant substitution, and Algorithm 1's later `T^(d+1) E` rescaling remain downstream P4/P5 work.

## Why `shiftIncrementQuotient` is separate

`shiftIncrementQuotient` is the truncation-independent quotient of `p(a + X) - p(a)` by `X`. The normalized backward error depends on `d` and first removes the alternating moving-Hasse terms. They coincide only at `d = 0`.

At `d = 1`,

```text
normalizedBackwardTaylorError a p 1
  = shiftIncrementQuotient a p - taylor a p.derivative.
```

The integer canary `p = X²`, `a = 1`, `d = 1` computes the normalized error as `-X`, rejecting a wrong sign, a fixed-basepoint derivative, or accidental replacement by the increment quotient.

## Characteristic and assumption boundary

No declaration introduces factorial inverses, a characteristic bound, `CharZero`, a field assumption, or an integral-domain assumption.

| Assumption | Main available layer |
|---|---|
| `Semiring` | Hasse coefficients/jets, prefix laws, degree lowering, forward truncation, zero-jet divisibility |
| `CommSemiring` | Product rules, Taylor-center composition, and affine laws for jets and truncations |
| `Ring` | Forward remainders/quotients and shifted-difference jet congruence |
| `CommRing` | Coordinate equivalence, root-factor/multiplicity results, and alternating moving-point identities |

Naturality under ring homomorphisms is explicit for jets, forward tails, moving corrections, residuals, and normalized errors.

## Original change and trust surface at `0c6d0a405d33`

- Base: `22dbd4e836c15a21f68889afa69b7130da04abbb` (`main`)
- Head: `0c6d0a405d334cc26b572f47408cc9176f7de126`
- 45 commits; 10 files; 2,144 insertions; 0 deletions
- 159 production declarations and 37 concrete canary examples across 562 lines
- Normative source: [ECCC TR26-164](https://eccc.weizmann.ac.il/report/2026/164/), especially equations (7), (8), (13), and (16)
- Audited PDF SHA-256: `b749151a7b5961e34760c735cf64067f0c3dea632030f2e69737b6caef7a3e70`

The exact base-to-head diff adds no `sorry`, `admit`, explicit `axiom`, `unsafe`, `native_decide`, production resource-option override, or linter suppression. It changes no existing declaration or runtime behavior. ArkLib's ordinary-derivative multiplicity-code API remains separate.

The four canary modules reject characteristic-two ordinary-derivative substitution, wrong Hasse indices/signs/centers, reversed prefix or tail embeddings, missing affine factors, degree-boundary errors, tail-tower reversal, non-linear map behavior, incorrect moving points, false jet equality at the first nonvanishing order, vacuous naturality, and failure of the direct caller-supplied equation-(13) API to elaborate.

## Validation at `0c6d0a405d334cc26b572f47408cc9176f7de126`

Local final gate:

- `LAKE_ARTIFACT_CACHE=false LAKE_NO_CACHE=true ./scripts/validate.sh --docs --axioms` — **passed all requested checks**;
- full ArkLib build, warning budget, source policy/style/plugin checks, runtime fixtures, import integrity, docs integrity, and documentation build — passed;
- a fresh `doc-gen4` rendering exposes both direct equation-(13) declarations, the corrected source citation, and source links pinned to this exact head;
- repository axiom regression: 11,246 declarations across 440 modules, 312 baseline `sorryAx`-tainted declarations, 0 nonstandard-axiom-tainted declarations, and no new taint;
- `git diff --check` — passed.

Independent exact-head Lean review:

- implementation gate: no P0–P3 findings; the equation-(13) orientation, signs, and `X ^ (d + 1)` exponent are correct; all Hasse–Taylor targets passed; 174 scoped declarations, 0 `sorryAx`, 0 nonstandard axioms;
- consumer/trust gate: representative downstream consumers compiled, including a genuinely noncommutative `Matrix (Fin 2) (Fin 2) ℤ` instance and an exact equation-(13) canary with `p = X³`, center `2`, supplied `y = 8`, and `d = 2`; the latter independently computes the residual numerator as exactly `X³`, and representative declarations depend only on `propext`, `Classical.choice`, and `Quot.sound`;
- source-trust inventory remained admissions `183 → 183`, explicit axioms `0 → 0`, native trust `0 → 0`;
- source-equation gate confirmed the equation-(13)/(16) indexing, signs, moving point, divisibility exponent, and cleared-denominator interpretation against the pinned PDF.

Remote checks at publication time: import, docs-integrity, PR-summary, and the main CI build all passed on the exact final head.

## Scope status

This PR completes the claimed P2a package, not all of P2 and not the central decoder theorem in #855. It deliberately leaves:

- structured multivariate variables and substitutions;
- local hidden-derivative constraints;
- interpolation and multiplicity accumulation;
- the Kopparty differential-equation solver;
- decoder construction and parameter corollaries.

## Reviewer map

Production files are under `ArkLib/ToMathlib/Polynomial/HasseTaylor/`; canaries are under the
matching `ArkLibTest/` path. Suggested order:

1. `FiniteJet.lean` and `FiniteJetCanary.lean` — conventions, finite coordinates, degree lowering, affine naturality, characteristic/indexing canaries.
2. `Forward.lean` and `ForwardCanary.lean` — truncation/remainder/quotient architecture, linear maps, tail laws, degree and affine-factor canaries.
3. `Shift.lean` and `ShiftCanary.lean` — equation-(13)/(16) correspondence, scalar congruence, backward residuals, affine laws, and sign/moving-center canaries.
4. `JetDivisibility.lean` and its canary — finite-vector contact and root-multiplicity bridges.
5. `HasseTaylor.lean` — public dependency narrative; `ArkLib.lean` contains generated registration only.

Refs #854. Builds toward #855.
