### PR TITLE
feat(mvpoly): add weighted support and substitution bounds

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -255,6 +255,7 @@ import ArkLib.Data.MvPolynomial.NestedEvaluationTree
 import ArkLib.Data.MvPolynomial.RestrictDegree
 import ArkLib.Data.MvPolynomial.RestrictDegreeVar
 import ArkLib.Data.MvPolynomial.SchwartzZippelCounting
+import ArkLib.Data.MvPolynomial.WeightedDegree
 import ArkLib.Data.Polynomial.Bivariate
 import ArkLib.Data.Polynomial.ClassicalWronskian
 import ArkLib.Data.Polynomial.FoldedWronskian

--- a/ArkLib/Data/MvPolynomial/EvenAndOdd.lean
+++ b/ArkLib/Data/MvPolynomial/EvenAndOdd.lean
@@ -4,13 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: František Silváši, Ilia Vlasov, Aristotle (Harmonic)
 -/
 
-import Mathlib.Algebra.MvPolynomial.Monad
 import Mathlib.Tactic.IntervalCases
 import Mathlib.Algebra.CharP.Basic
 import Mathlib.Algebra.BigOperators.Group.Finset.Piecewise
 
 import CompPoly.Data.MvPolynomial.Notation
 import ArkLib.Data.MvPolynomial.LinearMvExtension
+import ArkLib.Data.MvPolynomial.WeightedDegree
 
 /-!
 # ArkLib.Data.MvPolynomial.EvenAndOdd
@@ -267,79 +267,45 @@ private lemma substNoX0_eq_self_of_odd
       (substNoX0_eq_self_of_substPlus p.val)
       (substNoX0_eq_self_of_substMinus p.val))
 
--- For the case m 0 ≠ 0: the product contains a zero factor
-private lemma aeval_shift_monomial_zero_case {n : ℕ} [NeZero n]
-  (m : Fin n →₀ ℕ) (c : R) (hm : ∀ i, m i ≤ 1) (h0 : m 0 ≠ 0) :
-  (monomial m c).aeval (fun i : Fin n ↦ if h : i = (0 : Fin n)
-    then (0 : MvPolynomial (Fin (n - 1)) R)
-    else X ⟨i.val - 1, by omega⟩) = 0 := by
-  change bind₁ _ (monomial m c) = 0
-  rw [bind₁_monomial]
-  have h01 : m 0 = 1 := Nat.le_antisymm (hm 0) (Nat.pos_of_ne_zero h0)
-  have h0s : (0 : Fin n) ∈ m.support := by simp [Finsupp.mem_support_iff, h0]
-  apply mul_eq_zero_of_right
-  apply Finset.prod_eq_zero h0s
-  simp [h01]
-
-/-
-For the case m 0 = 0: the result is a shifted monomial
--/
-private lemma aeval_shift_monomial_nonzero_case
-  (m : Fin n →₀ ℕ) (c : R) (hm : ∀ i, m i ≤ 1) (h0 : m 0 = 0) :
-  (monomial m c).aeval (fun i : Fin n ↦ if h : i = (0 : Fin n)
-      then (0 : MvPolynomial (Fin (n - 1)) R)
-      else X ⟨i.val - 1, by omega⟩) ∈ restrictDegree (Fin (n - 1)) R 1 := by
-  rw [MvPolynomial.mem_restrictDegree]
-  intro s hs i
-  contrapose! hs
-  simp_all only [aeval_eq_bind₁, monomial_eq, Finsupp.prod_pow, map_mul, algHom_C, algebraMap_eq,
-    map_prod, map_pow, bind₁_X_right, dite_pow, pow_zero, mem_support_iff, coeff_C_mul, ne_eq,
-    mul_eq_zero, not_or, not_and, not_not]
-  have h_coeff :
-    coeff s (∏ x : Fin n,
-      if h : x = 0
-      then 1
-      else (MvPolynomial.X ⟨↑x - 1, by omega⟩ : MvPolynomial (Fin (n - 1)) R) ^ m x) = 0 := by
-    have h_coeff :
-      ∀ (t : Fin n → ℕ),
-        (∏ x : Fin n,
-          if h : x = 0
-          then 1
-          else (MvPolynomial.X ⟨↑x - 1, by omega⟩ : MvPolynomial (Fin (n - 1)) R) ^ t x) =
-            MvPolynomial.monomial
-              (∑ x : Fin n, if h : x = 0 then 0 else
-                Finsupp.single ⟨↑x - 1, by omega⟩ (t x)) 1 := by
-      intro t
-      induction (Finset.univ : Finset (Fin n)) using Finset.induction
-        <;> aesop
-              (add simp [Finset.prod_insert, MvPolynomial.monomial_mul,
-                          MvPolynomial.X_pow_eq_monomial])
-    simp_all only [coeff_monomial, ite_eq_right_iff, one_ne_zero, imp_false, ne_eq]
-    intro h
-    replace h := congr_arg (fun f ↦ f i) h
-    simp_all only [sum_apply']
-    rw
-      [Finset.sum_eq_single ⟨i + 1, by grind⟩] at h
-      <;> aesop (add safe (by grind))
-  exact fun _ => h_coeff
+lemma aeval_shift_mem_restrictDegree
+    (q : MvPolynomial (Fin n) R) (hq : q ∈ restrictDegree (Fin n) R 1) :
+  q.aeval (fun i ↦ if h : i = (0 : Fin n) then (0 : MvPolynomial (Fin (n - 1)) R)
+    else X ⟨i.val - 1, by omega⟩) ∈ restrictDegree (Fin (n - 1)) R 1 := by
+  rw [mem_restrictDegree_iff_forall_mem_restrictWeightedDegree_piSingle]
+  intro i
+  let source : Fin n := ⟨i.val + 1, by omega⟩
+  let w : Fin n → ℕ := Pi.single source 1
+  apply aeval_mem_restrictWeightedDegree (w := w) (v := Pi.single i 1)
+  · intro j
+    by_cases hj0 : j = 0
+    · rw [dif_pos hj0]
+      exact (restrictWeightedDegree (R := R) (Pi.single i 1) (w j)).zero_mem
+    · rw [dif_neg hj0]
+      apply X_mem_restrictWeightedDegree
+      by_cases hjs : j = source
+      · subst j
+        simp [w, source]
+      · have hne : (⟨j.val - 1, by omega⟩ : Fin (n - 1)) ≠ i := by
+          intro h
+          apply hjs
+          apply Fin.ext
+          have hjpos : 0 < j.val := Nat.pos_of_ne_zero fun h => hj0 (Fin.ext h)
+          have hv := congrArg Fin.val h
+          change j.val - 1 = i.val at hv
+          change j.val = i.val + 1
+          omega
+        simp [w, hjs, hne]
+  · change q ∈ restrictWeightedDegree (Pi.single source 1) 1
+    exact (mem_restrictDegree_iff_forall_mem_restrictWeightedDegree_piSingle q 1).mp hq source
 
 lemma aeval_shift_monomial_mem {n : ℕ} [NeZero n]
     (m : Fin n →₀ ℕ) (c : R) (hm : ∀ i, m i ≤ 1) :
     (monomial m c).aeval (fun i : Fin n ↦ if h : i = (0 : Fin n)
       then (0 : MvPolynomial (Fin (n - 1)) R)
       else X ⟨i.val - 1, by omega⟩) ∈ restrictDegree (Fin (n - 1)) R 1 := by
-  by_cases h0 : m 0 = 0
-  · exact aeval_shift_monomial_nonzero_case m c hm h0
-  · rw [aeval_shift_monomial_zero_case m c hm h0]; exact zero_mem _
-
-lemma aeval_shift_mem_restrictDegree
-    (q : MvPolynomial (Fin n) R) (hq : q ∈ restrictDegree (Fin n) R 1) :
-  q.aeval (fun i ↦ if h : i = (0 : Fin n) then (0 : MvPolynomial (Fin (n - 1)) R)
-    else X ⟨i.val - 1, by omega⟩) ∈ restrictDegree (Fin (n - 1)) R 1 := by
-  rw [MvPolynomial.as_sum q, map_sum]
-  apply Submodule.sum_mem
-  intro m hm
-  exact aeval_shift_monomial_mem m (q.coeff m) (fun i => (mem_restrictDegree _ q 1).mp hq m hm i)
+  apply aeval_shift_mem_restrictDegree
+  rw [restrictDegree, monomial_mem_restrictSupport]
+  exact Or.inl hm
 
 noncomputable def even_pred (p : R⦃≤ 1⦄[X (Fin n)]) : R⦃≤ 1⦄[X (Fin (n - 1))] :=
   ⟨(even p).1.aeval

--- a/ArkLib/Data/MvPolynomial/WeightedDegree.lean
+++ b/ArkLib/Data/MvPolynomial/WeightedDegree.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 
+import Mathlib.Algebra.MvPolynomial.Monad
 import Mathlib.RingTheory.MvPolynomial.WeightedHomogeneous
 
 /-!
@@ -19,6 +20,8 @@ under multiplication, while a positive fixed bound is not in general.
 -/
 
 noncomputable section
+
+open scoped BigOperators
 
 open Finsupp Module
 
@@ -94,6 +97,124 @@ theorem pow_mem_restrictWeightedDegree {w : σ → ℕ} {d : ℕ} {p : MvPolynom
   | succ n ih =>
       rw [pow_succ, Nat.succ_mul]
       exact mul_mem_restrictWeightedDegree ih hp
+
+/-! ### Weighted-degree bounds under substitution -/
+
+/-- Weighted total degree is subadditive under multiplication. -/
+theorem weightedTotalDegree_mul_le (w : σ → ℕ) (p q : MvPolynomial σ R) :
+    weightedTotalDegree w (p * q) ≤ weightedTotalDegree w p + weightedTotalDegree w q :=
+  AddMonoidAlgebra.supDegree_mul_le (map_add (weight w))
+
+/-- A constant has weighted total degree zero, including the zero constant. -/
+@[simp]
+theorem weightedTotalDegree_C (w : σ → ℕ) (r : R) :
+    weightedTotalDegree w (C r : MvPolynomial σ R) = 0 := by
+  classical
+  rw [weightedTotalDegree, support_C]
+  split_ifs <;> simp
+
+/-- Taking the `n`th power multiplies the weighted-total-degree upper bound by `n`. -/
+theorem weightedTotalDegree_pow_le (w : σ → ℕ) (p : MvPolynomial σ R) (n : ℕ) :
+    weightedTotalDegree w (p ^ n) ≤ n * weightedTotalDegree w p := by
+  induction n with
+  | zero =>
+      rw [pow_zero, ← C_1, weightedTotalDegree_C, zero_mul]
+  | succ n ih =>
+      rw [pow_succ]
+      calc
+        weightedTotalDegree w (p ^ n * p) ≤
+            weightedTotalDegree w (p ^ n) + weightedTotalDegree w p :=
+          weightedTotalDegree_mul_le _ _ _
+        _ ≤ n * weightedTotalDegree w p + weightedTotalDegree w p :=
+          Nat.add_le_add_right ih _
+        _ = (n + 1) * weightedTotalDegree w p := by rw [add_mul, one_mul]
+
+private theorem weightedTotalDegree_bind₁_monomial_le {τ : Type*} (v : τ → ℕ)
+    (f : σ → MvPolynomial τ R) (m : σ →₀ ℕ) (r : R) :
+    weightedTotalDegree v (bind₁ f (monomial m r)) ≤
+      weight (fun i => weightedTotalDegree v (f i)) m := by
+  rw [bind₁_monomial]
+  calc
+    weightedTotalDegree v (C r * ∏ i ∈ m.support, f i ^ m i) ≤
+        weightedTotalDegree v (C r) +
+          weightedTotalDegree v (∏ i ∈ m.support, f i ^ m i) :=
+      weightedTotalDegree_mul_le _ _ _
+    _ ≤ 0 + ∑ i ∈ m.support, weightedTotalDegree v (f i ^ m i) := by
+      apply Nat.add_le_add
+      · exact (weightedTotalDegree_C v r).le
+      · exact AddMonoidAlgebra.supDegree_prod_le (R := R) (A := τ →₀ ℕ) (B := ℕ)
+          (D := weight v) (map_zero (weight v))
+          (fun a b => map_add (weight v) a b)
+    _ ≤ ∑ i ∈ m.support, m i * weightedTotalDegree v (f i) := by
+      simp only [zero_add]
+      exact Finset.sum_le_sum fun i _ => weightedTotalDegree_pow_le v (f i) (m i)
+    _ = weight (fun i => weightedTotalDegree v (f i)) m := by
+      simp only [weight_apply, Finsupp.sum, smul_eq_mul]
+
+/-- Substitution cannot exceed the outer polynomial's weighted degree when each source variable is
+assigned the weighted total degree of its substituted polynomial. This induced-weight form has no
+positivity or nonzero hypotheses and includes zero polynomials and zero substitutions. -/
+theorem weightedTotalDegree_bind₁_le {τ : Type*} (v : τ → ℕ)
+    (f : σ → MvPolynomial τ R) (p : MvPolynomial σ R) :
+    weightedTotalDegree v (bind₁ f p) ≤
+      weightedTotalDegree (fun i => weightedTotalDegree v (f i)) p := by
+  conv_lhs => rw [p.as_sum, map_sum]
+  calc
+    weightedTotalDegree v (∑ m ∈ p.support, bind₁ f (monomial m (coeff m p))) ≤
+        p.support.sup fun m => weightedTotalDegree v (bind₁ f (monomial m (coeff m p))) :=
+      AddMonoidAlgebra.supDegree_sum_le
+    _ ≤ p.support.sup fun m => weight (fun i => weightedTotalDegree v (f i)) m :=
+      Finset.sup_mono_fun fun m _ =>
+        weightedTotalDegree_bind₁_monomial_le v f m (coeff m p)
+    _ = weightedTotalDegree (fun i => weightedTotalDegree v (f i)) p := rfl
+
+/-- Prescribed-weight substitution bound: if the image of source variable `i` has target weighted
+degree at most `w i`, substitution does not increase the outer `w`-weighted total degree. -/
+theorem weightedTotalDegree_bind₁_le_of_le {τ : Type*} (w : σ → ℕ) (v : τ → ℕ)
+    (f : σ → MvPolynomial τ R) (p : MvPolynomial σ R)
+    (hf : ∀ i, weightedTotalDegree v (f i) ≤ w i) :
+    weightedTotalDegree v (bind₁ f p) ≤ weightedTotalDegree w p := by
+  refine (weightedTotalDegree_bind₁_le v f p).trans ?_
+  unfold weightedTotalDegree
+  exact Finset.sup_mono_fun fun m _ => Finsupp.sum_le_sum fun i _ =>
+    Nat.mul_le_mul_left (m i) (hf i)
+
+/-- The induced-weight substitution bound through the standard `MvPolynomial.aeval` spelling. -/
+theorem weightedTotalDegree_aeval_le {τ : Type*} (v : τ → ℕ)
+    (f : σ → MvPolynomial τ R) (p : MvPolynomial σ R) :
+    weightedTotalDegree v (aeval f p) ≤
+      weightedTotalDegree (fun i => weightedTotalDegree v (f i)) p := by
+  rw [aeval_eq_bind₁]
+  exact weightedTotalDegree_bind₁_le v f p
+
+/-- The prescribed-weight substitution bound through the standard `MvPolynomial.aeval`
+spelling. -/
+theorem weightedTotalDegree_aeval_le_of_le {τ : Type*} (w : σ → ℕ) (v : τ → ℕ)
+    (f : σ → MvPolynomial τ R) (p : MvPolynomial σ R)
+    (hf : ∀ i, weightedTotalDegree v (f i) ≤ w i) :
+    weightedTotalDegree v (aeval f p) ≤ weightedTotalDegree w p := by
+  rw [aeval_eq_bind₁]
+  exact weightedTotalDegree_bind₁_le_of_le w v f p hf
+
+/-- The prescribed-weight substitution bound, phrased as preservation of bounded-support
+submodules. -/
+theorem bind₁_mem_restrictWeightedDegree {τ : Type*} {w : σ → ℕ} {v : τ → ℕ} {d : ℕ}
+    {f : σ → MvPolynomial τ R} {p : MvPolynomial σ R}
+    (hf : ∀ i, f i ∈ restrictWeightedDegree (R := R) v (w i))
+    (hp : p ∈ restrictWeightedDegree (R := R) w d) :
+    bind₁ f p ∈ restrictWeightedDegree (R := R) v d := by
+  rw [mem_restrictWeightedDegree_iff_weightedTotalDegree_le] at hp ⊢
+  exact (weightedTotalDegree_bind₁_le_of_le w v f p fun i =>
+    mem_restrictWeightedDegree_iff_weightedTotalDegree_le.mp (hf i)).trans hp
+
+/-- The same substitution bound through the standard `MvPolynomial.aeval` spelling. -/
+theorem aeval_mem_restrictWeightedDegree {τ : Type*} {w : σ → ℕ} {v : τ → ℕ} {d : ℕ}
+    {f : σ → MvPolynomial τ R} {p : MvPolynomial σ R}
+    (hf : ∀ i, f i ∈ restrictWeightedDegree (R := R) v (w i))
+    (hp : p ∈ restrictWeightedDegree (R := R) w d) :
+    aeval f p ∈ restrictWeightedDegree (R := R) v d := by
+  rw [aeval_eq_bind₁]
+  exact bind₁_mem_restrictWeightedDegree hf hp
 
 /-- A zero-weight variable, and every power of it, belongs to the weight-zero piece.  No
 positivity hypothesis belongs in the generic bounded-degree API. -/

--- a/ArkLib/Data/MvPolynomial/WeightedDegree.lean
+++ b/ArkLib/Data/MvPolynomial/WeightedDegree.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 
 import Mathlib.Algebra.MvPolynomial.Monad
 import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
+import Mathlib.RingTheory.MvPolynomial.Homogeneous
 import Mathlib.RingTheory.MvPolynomial.WeightedHomogeneous
 
 /-!
@@ -51,6 +52,15 @@ theorem mem_restrictWeightedDegree_iff_weightedTotalDegree_le {w : σ → ℕ} {
 theorem restrictWeightedDegree_mono (w : σ → ℕ) {d e : ℕ} (hde : d ≤ e) :
     restrictWeightedDegree (R := R) w d ≤ restrictWeightedDegree (R := R) w e := by
   exact restrictSupport_mono R fun _ hm => Nat.le_trans hm hde
+
+/-- Assigning weight one to every variable recovers mathlib's total-degree submodule. -/
+@[simp]
+theorem restrictWeightedDegree_one (d : ℕ) :
+    restrictWeightedDegree (R := R) (fun _ : σ => 1) d = restrictTotalDegree σ R d := by
+  ext p
+  rw [mem_restrictWeightedDegree_iff_weightedTotalDegree_le, mem_restrictTotalDegree]
+  change weightedTotalDegree (1 : σ → ℕ) p ≤ d ↔ p.totalDegree ≤ d
+  rw [weightedTotalDegree_one]
 
 /-- A monomial is bounded exactly when its exponent has bounded weight, unless its coefficient
 vanishes. -/

--- a/ArkLib/Data/MvPolynomial/WeightedDegree.lean
+++ b/ArkLib/Data/MvPolynomial/WeightedDegree.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import Mathlib.RingTheory.MvPolynomial.WeightedHomogeneous
+
+/-!
+# Weighted-degree bounds for multivariate polynomials
+
+This file packages the polynomials whose monomial weights are bounded by a natural number as an
+`R`-submodule.  Unlike `weightedTotalDegree`, the support formulation records the intended
+zero-polynomial convention directly: the zero polynomial belongs to every bound, including bound
+zero.
+
+The bound is additive under multiplication.  Consequently, the weight-zero piece is also closed
+under multiplication, while a positive fixed bound is not in general.
+-/
+
+noncomputable section
+
+open Finsupp Module
+
+namespace MvPolynomial
+
+variable {σ R : Type*} [CommSemiring R]
+
+/-- The `R`-submodule of multivariate polynomials all of whose monomials have `w`-weight at most
+`d`. -/
+def restrictWeightedDegree (w : σ → ℕ) (d : ℕ) : Submodule R (MvPolynomial σ R) :=
+  restrictSupport R {m | m.weight w ≤ d}
+
+/-- Membership in `restrictWeightedDegree` is exactly the pointwise weight bound on support. -/
+theorem mem_restrictWeightedDegree {w : σ → ℕ} {d : ℕ} {p : MvPolynomial σ R} :
+    p ∈ restrictWeightedDegree (R := R) w d ↔ ∀ m ∈ p.support, m.weight w ≤ d := by
+  rfl
+
+/-- The support formulation agrees with mathlib's `weightedTotalDegree`.  In particular, it gives
+the zero polynomial weighted total degree zero, hence membership at bound zero. -/
+theorem mem_restrictWeightedDegree_iff_weightedTotalDegree_le {w : σ → ℕ} {d : ℕ}
+    {p : MvPolynomial σ R} :
+    p ∈ restrictWeightedDegree (R := R) w d ↔ p.weightedTotalDegree w ≤ d := by
+  rw [mem_restrictWeightedDegree, weightedTotalDegree, Finset.sup_le_iff]
+
+/-- Increasing the degree bound enlarges the bounded submodule. -/
+theorem restrictWeightedDegree_mono (w : σ → ℕ) {d e : ℕ} (hde : d ≤ e) :
+    restrictWeightedDegree (R := R) w d ≤ restrictWeightedDegree (R := R) w e := by
+  exact restrictSupport_mono R fun _ hm => Nat.le_trans hm hde
+
+/-- A monomial is bounded exactly when its exponent has bounded weight, unless its coefficient
+vanishes. -/
+@[simp]
+theorem monomial_mem_restrictWeightedDegree (w : σ → ℕ) (d : ℕ) (m : σ →₀ ℕ) (r : R) :
+    monomial m r ∈ restrictWeightedDegree (R := R) w d ↔ m.weight w ≤ d ∨ r = 0 := by
+  simpa only [restrictWeightedDegree, Set.mem_ofPred_eq] using
+    (monomial_mem_restrictSupport (R := R) (s := {m | m.weight w ≤ d}) (m := m) (r := r))
+
+/-- Constant polynomials have weighted degree at most every natural-number bound. -/
+@[simp]
+theorem C_mem_restrictWeightedDegree (w : σ → ℕ) (d : ℕ) (r : R) :
+    C r ∈ restrictWeightedDegree (R := R) w d := by
+  change monomial (0 : σ →₀ ℕ) r ∈ restrictWeightedDegree (R := R) w d
+  exact (monomial_mem_restrictWeightedDegree w d 0 r).mpr (Or.inl (by simp))
+
+/-- The variable `X i` lies in every bound at least its assigned weight. -/
+theorem X_mem_restrictWeightedDegree (w : σ → ℕ) (d : ℕ) (i : σ) (hi : w i ≤ d) :
+    X i ∈ restrictWeightedDegree (R := R) w d := by
+  rw [X, monomial_mem_restrictWeightedDegree]
+  simp [weight_single, hi]
+
+/-- Weighted-degree bounds add under multiplication. -/
+theorem mul_mem_restrictWeightedDegree {w : σ → ℕ} {d e : ℕ} {p q : MvPolynomial σ R}
+    (hp : p ∈ restrictWeightedDegree (R := R) w d)
+    (hq : q ∈ restrictWeightedDegree (R := R) w e) :
+    p * q ∈ restrictWeightedDegree (R := R) w (d + e) := by
+  classical
+  rw [mem_restrictWeightedDegree] at hp hq ⊢
+  intro m hm
+  rw [mem_support_iff, coeff_mul] at hm
+  obtain ⟨⟨a, b⟩, hab, hcoeff⟩ := Finset.exists_ne_zero_of_sum_ne_zero hm
+  have ha : a ∈ p.support := mem_support_iff.mpr (left_ne_zero_of_mul hcoeff)
+  have hb : b ∈ q.support := mem_support_iff.mpr (right_ne_zero_of_mul hcoeff)
+  rw [← Finset.mem_antidiagonal.mp hab, map_add]
+  exact Nat.add_le_add (hp a ha) (hq b hb)
+
+/-- The `n`th power of a polynomial of weighted degree at most `d` has weighted degree at most
+`n * d`. -/
+theorem pow_mem_restrictWeightedDegree {w : σ → ℕ} {d : ℕ} {p : MvPolynomial σ R}
+    (hp : p ∈ restrictWeightedDegree (R := R) w d) (n : ℕ) :
+    p ^ n ∈ restrictWeightedDegree (R := R) w (n * d) := by
+  induction n with
+  | zero => simpa using C_mem_restrictWeightedDegree (R := R) w 0 (1 : R)
+  | succ n ih =>
+      rw [pow_succ, Nat.succ_mul]
+      exact mul_mem_restrictWeightedDegree ih hp
+
+/-- A zero-weight variable, and every power of it, belongs to the weight-zero piece.  No
+positivity hypothesis belongs in the generic bounded-degree API. -/
+theorem X_pow_mem_restrictWeightedDegree_zero {w : σ → ℕ} {i : σ} (hi : w i = 0) (n : ℕ) :
+    X i ^ n ∈ restrictWeightedDegree (R := R) w 0 := by
+  simpa using pow_mem_restrictWeightedDegree
+    (X_mem_restrictWeightedDegree (R := R) w 0 i (by simp [hi])) n
+
+/-- If every variable has positive weight, an exponent of weight zero is the zero exponent. -/
+theorem eq_zero_of_mem_restrictWeightedDegree_zero {w : σ → ℕ} (hw : ∀ i, w i ≠ 0)
+    {p : MvPolynomial σ R} (hp : p ∈ restrictWeightedDegree (R := R) w 0)
+    {m : σ →₀ ℕ} (hm : m ∈ p.support) :
+    m = 0 := by
+  let hnt : Finsupp.NonTorsionWeight ℕ w := Finsupp.nonTorsionWeight_of ℕ w hw
+  apply (@Finsupp.weight_eq_zero_iff_eq_zero σ ℕ _ _ _ _ w hnt).mp
+  exact Nat.eq_zero_of_le_zero ((mem_restrictWeightedDegree.mp hp) m hm)
+
+/-- With positive weights, the weight-zero piece consists only of constants. -/
+theorem eq_C_coeff_zero_of_mem_restrictWeightedDegree_zero {w : σ → ℕ} (hw : ∀ i, w i ≠ 0)
+    {p : MvPolynomial σ R} (hp : p ∈ restrictWeightedDegree (R := R) w 0) :
+    p = C (coeff 0 p) := by
+  ext m
+  by_cases hm : m = 0
+  · subst m
+    simp
+  · have hm_support : m ∉ p.support :=
+      fun hmem => hm (eq_zero_of_mem_restrictWeightedDegree_zero hw hp hmem)
+    rw [notMem_support_iff.mp hm_support]
+    exact (coeff_C_of_ne_zero (R := R) hm (coeff 0 p)).symm
+
+/-- The weight-zero bounded piece is a subalgebra.  This is the fixed-bound multiplication closure
+that remains valid without incorrectly claiming the same for a positive bound. -/
+def weightedDegreeZeroSubalgebra (w : σ → ℕ) : Subalgebra R (MvPolynomial σ R) where
+  carrier := restrictWeightedDegree (R := R) w 0
+  add_mem' := (restrictWeightedDegree (R := R) w 0).add_mem
+  mul_mem' hp hq := by simpa using mul_mem_restrictWeightedDegree hp hq
+  algebraMap_mem' r := by
+    rw [algebraMap_eq]
+    exact C_mem_restrictWeightedDegree w 0 r
+
+@[simp]
+theorem mem_weightedDegreeZeroSubalgebra {w : σ → ℕ} {p : MvPolynomial σ R} :
+    p ∈ weightedDegreeZeroSubalgebra (R := R) w ↔
+      p ∈ restrictWeightedDegree (R := R) w 0 :=
+  Iff.rfl
+
+/-- The monomial basis restricted to exponents of weight at most `d`. -/
+def basisRestrictWeightedDegree (w : σ → ℕ) (d : ℕ) :
+    Basis {m : σ →₀ ℕ // m.weight w ≤ d} R (restrictWeightedDegree (R := R) w d) :=
+  basisRestrictSupport R {m | m.weight w ≤ d}
+
+/-- With finitely many variables and positive weights, the bounded weighted-degree submodule is
+finitely generated. -/
+theorem restrictWeightedDegree_fg [Finite σ] (w : σ → ℕ) (hw : ∀ i, w i ≠ 0) (d : ℕ) :
+    (restrictWeightedDegree (R := R) w d).FG := by
+  rw [← Module.Finite.iff_fg]
+  let finiteExponents : Finite {m : σ →₀ ℕ // m.weight w ≤ d} :=
+    (Finsupp.finite_of_nat_weight_le w hw d).to_subtype
+  exact @Module.Finite.of_basis R (restrictWeightedDegree (R := R) w d)
+    {m : σ →₀ ℕ // m.weight w ≤ d} _ _ _ finiteExponents
+    (basisRestrictWeightedDegree (R := R) w d)
+
+/-! ### A nonuniform-weight mutation canary -/
+
+/-- For weights `(1, 2)`, both `X₀²` and `X₁` meet bound two, while `X₁²` does not.  This rejects
+implementations that accidentally replace the supplied weights by uniform total degree. -/
+theorem nonuniformWeight_canary :
+    let w : Fin 2 → ℕ := ![1, 2]
+    (X 0 ^ 2 + X 1 : MvPolynomial (Fin 2) ℤ) ∈ restrictWeightedDegree w 2 ∧
+      (X 1 ^ 2 : MvPolynomial (Fin 2) ℤ) ∉ restrictWeightedDegree w 2 := by
+  dsimp
+  constructor
+  · apply (restrictWeightedDegree (R := ℤ) ![1, 2] 2).add_mem
+    · simpa using pow_mem_restrictWeightedDegree
+        (X_mem_restrictWeightedDegree (R := ℤ) ![1, 2] 1 0 (by decide)) 2
+    · exact X_mem_restrictWeightedDegree ![1, 2] 2 1 (by decide)
+  · rw [X_pow_eq_monomial, monomial_mem_restrictWeightedDegree]
+    norm_num [weight_single]
+
+end MvPolynomial

--- a/ArkLib/Data/MvPolynomial/WeightedDegree.lean
+++ b/ArkLib/Data/MvPolynomial/WeightedDegree.lean
@@ -5,9 +5,8 @@ Authors: Quang Dao
 -/
 
 import Mathlib.Algebra.MvPolynomial.Monad
-import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
+import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import Mathlib.RingTheory.MvPolynomial.Homogeneous
-import Mathlib.RingTheory.MvPolynomial.WeightedHomogeneous
 
 /-!
 # Weighted-degree bounds for multivariate polynomials
@@ -19,6 +18,16 @@ zero.
 
 The bound is additive under multiplication.  Consequently, the weight-zero piece is also closed
 under multiplication, while a positive fixed bound is not in general.
+
+## Main declarations
+
+* `restrictWeightedDegree`: the bounded-support submodule.
+* `weightedTotalDegree_bind₁_le` and `weightedTotalDegree_aeval_le`: substitution bounds with
+  induced source weights.
+* `bind₁_mem_restrictWeightedDegree`: preservation under prescribed-weight substitution.
+* `basisRestrictWeightedDegree` and `restrictWeightedDegreeCoeff`: its monomial basis and
+  coefficient projections.
+* `finrank_restrictWeightedDegree`: the finite positive-weight dimension formula.
 -/
 
 noncomputable section
@@ -61,6 +70,23 @@ theorem restrictWeightedDegree_one (d : ℕ) :
   rw [mem_restrictWeightedDegree_iff_weightedTotalDegree_le, mem_restrictTotalDegree]
   change weightedTotalDegree (1 : σ → ℕ) p ≤ d ↔ p.totalDegree ≤ d
   rw [weightedTotalDegree_one]
+
+/-- Bounding the degree in every individual variable is equivalent to imposing all singleton
+weighted-degree bounds. -/
+theorem mem_restrictDegree_iff_forall_mem_restrictWeightedDegree_piSingle
+    [DecidableEq σ] (p : MvPolynomial σ R) (d : ℕ) :
+    p ∈ restrictDegree σ R d ↔
+      ∀ i, p ∈ restrictWeightedDegree (R := R) (Pi.single i 1) d := by
+  classical
+  rw [mem_restrictDegree]
+  constructor
+  · intro hp i
+    rw [mem_restrictWeightedDegree]
+    intro m hm
+    simpa [Finsupp.weight_single_one_apply] using hp m hm i
+  · intro hp m hm i
+    have hi := (mem_restrictWeightedDegree.mp (hp i)) m hm
+    simpa [Finsupp.weight_single_one_apply] using hi
 
 /-- A monomial is bounded exactly when its exponent has bounded weight, unless its coefficient
 vanishes. -/
@@ -352,8 +378,14 @@ theorem finrank_restrictWeightedDegree {K : Type*} [Field K] [Finite σ]
       Set.ncard {m : σ →₀ ℕ | m.weight w ≤ d} := by
   let _ : Finite {m : σ →₀ ℕ // m.weight w ≤ d} :=
     (weightedDegreeSupport_finite w hw d).to_subtype
-  exact (Module.finrank_eq_nat_card_basis
-    (basisRestrictWeightedDegree (R := K) w d)).trans (Nat.card_coe_set_eq _)
+  let b := basisRestrictWeightedDegree (R := K) w d
+  let _ : FiniteDimensional K (restrictWeightedDegree (R := K) w d) :=
+    b.finiteDimensional_of_finite
+  have h := congrArg Cardinal.toNat (Module.finrank_eq_card_basis' b)
+  have hcard : Module.finrank K (restrictWeightedDegree (R := K) w d) =
+      Nat.card {m : σ →₀ ℕ // m.weight w ≤ d} := by
+    simpa [Nat.card] using h
+  exact hcard.trans (Nat.card_coe_set_eq _)
 
 /-! ### A nonuniform-weight mutation canary -/
 

--- a/ArkLib/Data/MvPolynomial/WeightedDegree.lean
+++ b/ArkLib/Data/MvPolynomial/WeightedDegree.lean
@@ -266,6 +266,28 @@ def basisRestrictWeightedDegree (w : σ → ℕ) (d : ℕ) :
     Basis {m : σ →₀ ℕ // m.weight w ≤ d} R (restrictWeightedDegree (R := R) w d) :=
   basisRestrictSupport R {m | m.weight w ≤ d}
 
+/-- Coefficient projection from a bounded weighted-degree submodule at an allowed monomial. -/
+def restrictWeightedDegreeCoeff (w : σ → ℕ) (d : ℕ)
+    (m : {m : σ →₀ ℕ // m.weight w ≤ d}) :
+    restrictWeightedDegree (R := R) w d →ₗ[R] R :=
+  lcoeff R m ∘ₗ Submodule.subtype _
+
+@[simp]
+theorem restrictWeightedDegreeCoeff_apply (w : σ → ℕ) (d : ℕ)
+    (m : {m : σ →₀ ℕ // m.weight w ≤ d})
+    (p : restrictWeightedDegree (R := R) w d) :
+    restrictWeightedDegreeCoeff (R := R) w d m p =
+      coeff m (p : MvPolynomial σ R) :=
+  rfl
+
+/-- Coefficients outside the weighted-degree bound vanish. -/
+theorem coeff_eq_zero_of_mem_restrictWeightedDegree {w : σ → ℕ} {d : ℕ}
+    {p : MvPolynomial σ R} (hp : p ∈ restrictWeightedDegree (R := R) w d)
+    {m : σ →₀ ℕ} (hm : d < m.weight w) :
+    coeff m p = 0 := by
+  rw [← notMem_support_iff]
+  exact fun hmem => Nat.not_le_of_gt hm ((mem_restrictWeightedDegree.mp hp) m hmem)
+
 /-- With finitely many variables and positive weights, the bounded weighted-degree submodule is
 finitely generated. -/
 theorem restrictWeightedDegree_fg [Finite σ] (w : σ → ℕ) (hw : ∀ i, w i ≠ 0) (d : ℕ) :

--- a/ArkLib/Data/MvPolynomial/WeightedDegree.lean
+++ b/ArkLib/Data/MvPolynomial/WeightedDegree.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao
 -/
 
 import Mathlib.Algebra.MvPolynomial.Monad
+import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 import Mathlib.RingTheory.MvPolynomial.WeightedHomogeneous
 
 /-!
@@ -113,6 +114,13 @@ theorem weightedTotalDegree_C (w : σ → ℕ) (r : R) :
   rw [weightedTotalDegree, support_C]
   split_ifs <;> simp
 
+/-- The weighted total degree of a nonzero monomial is the weight of its exponent. -/
+theorem weightedTotalDegree_monomial (w : σ → ℕ) (m : σ →₀ ℕ) (r : R) (hr : r ≠ 0) :
+    weightedTotalDegree w (monomial m r) = weight w m := by
+  classical
+  rw [weightedTotalDegree, support_monomial, if_neg hr]
+  simp
+
 /-- Taking the `n`th power multiplies the weighted-total-degree upper bound by `n`. -/
 theorem weightedTotalDegree_pow_le (w : σ → ℕ) (p : MvPolynomial σ R) (n : ℕ) :
     weightedTotalDegree w (p ^ n) ≤ n * weightedTotalDegree w p := by
@@ -216,6 +224,18 @@ theorem aeval_mem_restrictWeightedDegree {τ : Type*} {w : σ → ℕ} {v : τ �
   rw [aeval_eq_bind₁]
   exact bind₁_mem_restrictWeightedDegree hf hp
 
+/-- Bounded substitutions compose: applying a `w`-to-`v` substitution followed by a
+`v`-to-`u` substitution preserves the original bound. -/
+theorem bind₁_comp_mem_restrictWeightedDegree {τ υ : Type*}
+    {w : σ → ℕ} {v : τ → ℕ} {u : υ → ℕ} {d : ℕ}
+    {f : σ → MvPolynomial τ R} {g : τ → MvPolynomial υ R} {p : MvPolynomial σ R}
+    (hf : ∀ i, f i ∈ restrictWeightedDegree (R := R) v (w i))
+    (hg : ∀ j, g j ∈ restrictWeightedDegree (R := R) u (v j))
+    (hp : p ∈ restrictWeightedDegree (R := R) w d) :
+    bind₁ (fun i => bind₁ g (f i)) p ∈ restrictWeightedDegree (R := R) u d := by
+  rw [← bind₁_bind₁]
+  exact bind₁_mem_restrictWeightedDegree hg (bind₁_mem_restrictWeightedDegree hf hp)
+
 /-- A zero-weight variable, and every power of it, belongs to the weight-zero piece.  No
 positivity hypothesis belongs in the generic bounded-degree API. -/
 theorem X_pow_mem_restrictWeightedDegree_zero {w : σ → ℕ} {i : σ} (hi : w i = 0) (n : ℕ) :
@@ -266,6 +286,15 @@ def basisRestrictWeightedDegree (w : σ → ℕ) (d : ℕ) :
     Basis {m : σ →₀ ℕ // m.weight w ≤ d} R (restrictWeightedDegree (R := R) w d) :=
   basisRestrictSupport R {m | m.weight w ≤ d}
 
+/-- Coordinates in the restricted monomial basis are the ordinary polynomial coefficients. -/
+@[simp]
+theorem basisRestrictWeightedDegree_repr_apply (w : σ → ℕ) (d : ℕ)
+    (p : restrictWeightedDegree (R := R) w d)
+    (m : {m : σ →₀ ℕ // m.weight w ≤ d}) :
+    (basisRestrictWeightedDegree (R := R) w d).repr p m =
+      coeff m (p : MvPolynomial σ R) :=
+  rfl
+
 /-- Coefficient projection from a bounded weighted-degree submodule at an allowed monomial. -/
 def restrictWeightedDegreeCoeff (w : σ → ℕ) (d : ℕ)
     (m : {m : σ →₀ ℕ // m.weight w ≤ d}) :
@@ -288,6 +317,12 @@ theorem coeff_eq_zero_of_mem_restrictWeightedDegree {w : σ → ℕ} {d : ℕ}
   rw [← notMem_support_iff]
   exact fun hmem => Nat.not_le_of_gt hm ((mem_restrictWeightedDegree.mp hp) m hmem)
 
+/-- With finitely many variables and positive weights, there are finitely many exponent vectors
+of weight at most `d`. -/
+theorem weightedDegreeSupport_finite [Finite σ] (w : σ → ℕ) (hw : ∀ i, w i ≠ 0) (d : ℕ) :
+    Set.Finite {m : σ →₀ ℕ | m.weight w ≤ d} :=
+  Finsupp.finite_of_nat_weight_le w hw d
+
 /-- With finitely many variables and positive weights, the bounded weighted-degree submodule is
 finitely generated. -/
 theorem restrictWeightedDegree_fg [Finite σ] (w : σ → ℕ) (hw : ∀ i, w i ≠ 0) (d : ℕ) :
@@ -298,6 +333,17 @@ theorem restrictWeightedDegree_fg [Finite σ] (w : σ → ℕ) (hw : ∀ i, w i 
   exact @Module.Finite.of_basis R (restrictWeightedDegree (R := R) w d)
     {m : σ →₀ ℕ // m.weight w ≤ d} _ _ _ finiteExponents
     (basisRestrictWeightedDegree (R := R) w d)
+
+/-- Over a field, the dimension of a bounded weighted-degree submodule is the number of allowed
+monomials. -/
+theorem finrank_restrictWeightedDegree {K : Type*} [Field K] [Finite σ]
+    (w : σ → ℕ) (hw : ∀ i, w i ≠ 0) (d : ℕ) :
+    Module.finrank K (restrictWeightedDegree (R := K) w d) =
+      Set.ncard {m : σ →₀ ℕ | m.weight w ≤ d} := by
+  let _ : Finite {m : σ →₀ ℕ // m.weight w ≤ d} :=
+    (weightedDegreeSupport_finite w hw d).to_subtype
+  exact (Module.finrank_eq_nat_card_basis
+    (basisRestrictWeightedDegree (R := K) w d)).trans (Nat.card_coe_set_eq _)
 
 /-! ### A nonuniform-weight mutation canary -/
 
@@ -315,5 +361,27 @@ theorem nonuniformWeight_canary :
     · exact X_mem_restrictWeightedDegree ![1, 2] 2 1 (by decide)
   · rw [X_pow_eq_monomial, monomial_mem_restrictWeightedDegree]
     norm_num [weight_single]
+
+/-- A genuine nonuniform substitution canary. Target weights are `(2, 5)`; replacing the first
+variable by its cube and the second by its square sends `X₀ * X₁` to exact weighted degree
+`3 * 2 + 2 * 5 = 16`, so the neighboring bound `15` is rejected. This catches swapped weights,
+identity substitution, dropped exponents, and off-by-one bounds. -/
+theorem nonuniformSubstitution_canary :
+    let v : Bool → ℕ := fun b => bif b then 5 else 2
+    let f : Bool → MvPolynomial Bool ℕ := fun b =>
+      bif b then X true ^ 2 else X false ^ 3
+    let p : MvPolynomial Bool ℕ := X false * X true
+    weightedTotalDegree v (bind₁ f p) = 16 ∧
+      ¬weightedTotalDegree v (bind₁ f p) ≤ 15 := by
+  dsimp only
+  have hbind :
+      bind₁ (fun b : Bool => bif b then X true ^ 2 else X false ^ 3)
+          (X false * X true : MvPolynomial Bool ℕ) =
+        monomial (Finsupp.single false 3 + Finsupp.single true 2) 1 := by
+    simp [X_pow_eq_monomial]
+  constructor <;>
+    rw [hbind, weightedTotalDegree_monomial _ _ _ one_ne_zero, map_add,
+      weight_single, weight_single] <;>
+    norm_num
 
 end MvPolynomial


### PR DESCRIPTION
Refs #907. This refreshes the weighted-support port on current `main` and keeps the existing `EvenAndOdd` API while replacing its monomial case split with the general substitution bound.

## What changed

- Adds `MvPolynomial.restrictWeightedDegree`, its exact bridge to Mathlib's `weightedTotalDegree`, and additive bounds for products and powers.
- Adds induced and prescribed weighted-degree bounds for `bind₁` and `aeval`, including bounded substitution composition.
- Adds the restricted monomial basis, coefficient projections, positive-weight finiteness, finite generation, and the exact finrank formula.
- Connects uniform and singleton weights to `restrictTotalDegree` and `restrictDegree`.
- Uses the weighted substitution API in `EvenAndOdd.aeval_shift_mem_restrictDegree`; both existing public theorem types remain unchanged.
- Moves the nonuniform behavior canaries from production into `ArkLibTest`.

The mathematical source is pinned at `a5aa2677fee4e3a79d6bb05136631cce4a08587d`. This refresh deliberately keeps the source theorem statements while adapting module declarations and using the generic Mathlib multiplication bound where appropriate.

## Validation

Head `89cc91a342cad8769ea235e8df1ee4751cb94fd3` is based on the merged Lean 4.34 `main` commit `fa14552d40e793f2ea26e65c440306aae0c08a26`:

- `LAKE_ARTIFACT_CACHE=false LAKE_NO_CACHE=true ./scripts/validate.sh --axioms` passed, including the production modules, compile-time client, runtime checks, generated imports, documentation integrity, and the repository-wide axiom regression sweep;
- the sweep checked 12,662 declarations across 505 modules, with 291 baseline `sorry`-tainted declarations and no non-standard-axiom-tainted declarations;
- the exact dependency pins are Mathlib `5ed2965256430c3649e86755f9576b54eca72435` and CompPoly `7e3683ba72f61c1f3c2deda85953ce26392f0771`;
- `git diff --check` and the added-line trust scan passed.

The Lean 4.34 refresh changes only compatibility syntax in the reviewed source delta: polynomial-first coefficient calls and the current conditional-rewrite names. No theorem hypothesis, conclusion, or generality changed. No new admission, axiom, unsafe declaration, native trust, or suppression is introduced.

## Reviewer map

1. `WeightedDegree.lean`: support submodule and scalar-degree equivalence.
2. Substitution bounds and composition.
3. Basis, coefficient, finiteness, and finrank results.
4. `EvenAndOdd.lean`: the ordinary production consumer.
5. `ArkLibTest`: nonuniform acceptance and rejection canaries.
