### PR TITLE
feat(interaction): accumulated oracle access (AR-3A)

### DIFF
--- a/.github/workflows/interaction.yml
+++ b/.github/workflows/interaction.yml
@@ -1,0 +1,80 @@
+name: Interaction acceptance
+
+on:
+  pull_request:
+    paths:
+      - 'ArkLib/Interaction/**'
+      - 'ArkLibTest/Interaction/**'
+      - 'lakefile.toml'
+      - 'lake-manifest.json'
+      - 'lean-toolchain'
+      - '.github/workflows/interaction.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: interaction-acceptance-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  interaction:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Free disk space for the existing Lean cache
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: false
+          haskell: false
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # Restore only: untrusted PR code must not publish a shared dependency cache.
+      - uses: actions/cache/restore@v6
+        with:
+          path: ./.lake
+          key: ${{ runner.os }}-lean-ci-${{ hashFiles('lake-manifest.json') }}
+          restore-keys: |
+            ${{ runner.os }}-lean-ci-
+
+      - uses: leanprover/lean-action@v1.6.0
+        with:
+          auto-config: false
+          build: false
+          test: false
+          lint: false
+          use-github-cache: false
+          use-mathlib-cache: false
+
+      - name: Fetch dependency cache
+        run: lake exe cache get
+
+      - name: Compile production and acceptance modules
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t modules < <(
+            git ls-files -- 'ArkLib/Interaction/*.lean' 'ArkLibTest/Interaction/*.lean' |
+              LC_ALL=C sort | sed 's/\.lean$//;s,/,.,g'
+          )
+          if (( ${#modules[@]} == 0 )); then
+            echo 'No Interaction modules were discovered.' >&2
+            exit 1
+          fi
+          lake build "${modules[@]}" 2>&1 | tee "$RUNNER_TEMP/interaction-build.log"
+
+      - name: Enforce zero-warning budgets
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/check-warning-log.py "$RUNNER_TEMP/interaction-build.log" \
+            --path-prefix ArkLib/Interaction/ --label 'Interaction warnings (including admissions)'
+          python3 scripts/check-warning-log.py "$RUNNER_TEMP/interaction-build.log" \
+            --path-prefix ArkLibTest/Interaction/ --label 'Interaction acceptance warnings'

--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -277,6 +277,7 @@ import ArkLib.Data.Probability.Combinatorial
 import ArkLib.Data.Probability.Instances
 import ArkLib.Data.Probability.KoalaBear
 import ArkLib.Data.Probability.Notation
+import ArkLib.Interaction.Oracle.Access
 import ArkLib.Interaction.Oracle.Protocol
 import ArkLib.Interaction.Oracle.TypeTree
 import ArkLib.Interaction.Oracle.TypeTree.Decoration

--- a/ArkLib/Interaction/Oracle/Access.lean
+++ b/ArkLib/Interaction/Oracle/Access.lean
@@ -85,7 +85,7 @@ theorem eval_queryPrior {Messages : Type u} (access : PFunctor.{v, u})
     simulateQ (Access.extendImpl access interface prior message)
         (Access.queryPrior access interface q) =
       prior q := by
-  rw [queryPrior, simulateQ_spec_query]
+  rw [queryPrior, simulateQ_spec_query, extendImpl_prior]
 
 @[simp]
 theorem eval_queryLatest {Messages : Type u} (access : PFunctor.{v, u})
@@ -95,7 +95,7 @@ theorem eval_queryLatest {Messages : Type u} (access : PFunctor.{v, u})
     simulateQ (Access.extendImpl access interface prior message)
         (Access.queryLatest access interface q) =
       @OracleInterface.answer _ interface message q := by
-  rw [queryLatest, simulateQ_spec_query]
+  rw [queryLatest, simulateQ_spec_query, extendImpl_latest]
 
 end Access
 

--- a/ArkLib/Interaction/Oracle/Access.lean
+++ b/ArkLib/Interaction/Oracle/Access.lean
@@ -9,17 +9,15 @@ import VCVio.OracleComp.SimSemantics.Append
 /-!
 # Accumulated oracle access
 
-This file is the AR-3A access layer for typed oracle interactions. It records, at every node of an
-`Oracle.TypeTree`, exactly the oracle resources that are queryable before the next message is sent.
+An access signature says which queries are available, not which concrete messages were sent.
+Public values select dependent continuations. An oracle message extends access only after its
+send node. The canonical access at a prefix is computed from the initial signature, the oracle
+decoration, and a real PolyFun cursor; it remains available at terminal leaves.
 
-Public values remain ordinary structural data: they select the dependent continuation and are not
-re-encoded as oracle queries. Oracle access grows only after an oracle-backed prover message. In
-particular, the access stored at an oracle node deliberately excludes that node's message; only the
-continuation receives the extended specification. Future-message access is therefore absent by
-construction.
-
-Execution is intentionally out of scope. AR-3B will package prover/verifier strategies whose node
-computations use the capabilities described here.
+`AccessDecoration.build` is a derived node-local presentation, not an authorization certificate.
+Execution must use the canonical construction rather than trust an arbitrary decoration. A
+structural cursor likewise describes a syntactic prefix, not evidence that a strategy reached it.
+Concrete handlers, reachability, resource identity, and verifier execution are separate concerns.
 -/
 
 universe u v
@@ -28,87 +26,209 @@ open OracleComp OracleSpec
 
 namespace Interaction.Oracle
 
-/-- A packed oracle specification. Packing the query-index type lets the available query space grow
-as earlier prover oracle messages become available. -/
-abbrev AccessSpec := Σ ι : Type v, OracleSpec.{v, u} ι
+/-! Access uses the existing `PFunctor` carrier through `OracleSpec.ofPFunctor` / `toPFunctor`.
+There is no second packed-signature record. Query and response universes remain independent. -/
 
-namespace AccessSpec
+namespace Access
 
-/-- Package an ordinary oracle specification as an access specification. -/
-def ofSpec {ι : Type v} (spec : OracleSpec.{v, u} ι) : AccessSpec.{u, v} :=
-  ⟨ι, spec⟩
+/-- Add a disjoint query slot for a newly sent oracle message. This is signature extension, not a
+claim that two same-signature resources have the same identity. -/
+def extend {Messages : Type u} (access : PFunctor.{v, u})
+    (interface : OracleInterface.{u, v} Messages) : PFunctor.{v, u} :=
+  ((OracleSpec.ofPFunctor access) + @OracleInterface.spec _ interface).toPFunctor
 
-/-- Extend an accumulated access specification with one newly available prover oracle message. -/
-def extend {Messages : Type u} (access : AccessSpec.{u, v})
-    (interface : OracleInterface.{u, v} Messages) : AccessSpec.{u, v} :=
-  ⟨access.1 ⊕ interface.Query, access.2 + @OracleInterface.spec _ interface⟩
-
-/-- Extend a concrete implementation of the prior access with a concrete prover oracle message. -/
-def extendImpl {Messages : Type u} (access : AccessSpec.{u, v})
+/-- Extend a pure handler with the observable behavior of the concrete message just sent. -/
+def extendImpl {Messages : Type u} (access : PFunctor.{v, u})
     (interface : OracleInterface.{u, v} Messages)
-    (prior : QueryImpl access.2 Id) (message : Messages) :
-    QueryImpl (access.extend interface).2 Id :=
+    (prior : QueryImpl (OracleSpec.ofPFunctor access) Id) (message : Messages) :
+    QueryImpl (OracleSpec.ofPFunctor (Access.extend access interface)) Id :=
   prior + fun q => @OracleInterface.answer _ interface message q
 
 @[simp]
-theorem extendImpl_prior {Messages : Type u} (access : AccessSpec.{u, v})
+theorem extendImpl_prior {Messages : Type u} (access : PFunctor.{v, u})
     (interface : OracleInterface.{u, v} Messages)
-    (prior : QueryImpl access.2 Id) (message : Messages) (q : access.1) :
-    access.extendImpl interface prior message (.inl q) = prior q :=
+    (prior : QueryImpl (OracleSpec.ofPFunctor access) Id) (message : Messages) (q : access.A) :
+    Access.extendImpl access interface prior message (.inl q) = prior q :=
   rfl
 
 @[simp]
-theorem extendImpl_latest {Messages : Type u} (access : AccessSpec.{u, v})
+theorem extendImpl_latest {Messages : Type u} (access : PFunctor.{v, u})
     (interface : OracleInterface.{u, v} Messages)
-    (prior : QueryImpl access.2 Id) (message : Messages) (q : interface.Query) :
-    access.extendImpl interface prior message (.inr q) =
+    (prior : QueryImpl (OracleSpec.ofPFunctor access) Id) (message : Messages)
+    (q : interface.Query) :
+    Access.extendImpl access interface prior message (.inr q) =
       @OracleInterface.answer _ interface message q :=
   rfl
 
-end AccessSpec
+/-- Query a prior resource after extension. Explicit routing distinguishes equal signatures. -/
+def queryPrior {Messages : Type u} (access : PFunctor.{v, u})
+    (interface : OracleInterface.{u, v} Messages) :
+    QueryImpl (OracleSpec.ofPFunctor access)
+      (OracleComp (OracleSpec.ofPFunctor (Access.extend access interface))) :=
+  fun q => liftM ((OracleSpec.ofPFunctor (Access.extend access interface)).query (.inl q))
+
+/-- Query the most recently sent message through its interface, without exposing its payload. -/
+def queryLatest {Messages : Type u} (access : PFunctor.{v, u})
+    (interface : OracleInterface.{u, v} Messages) :
+    QueryImpl (@OracleInterface.spec _ interface)
+      (OracleComp (OracleSpec.ofPFunctor (Access.extend access interface))) :=
+  fun q => liftM ((OracleSpec.ofPFunctor (Access.extend access interface)).query (.inr q))
+
+@[simp]
+theorem eval_queryPrior {Messages : Type u} (access : PFunctor.{v, u})
+    (interface : OracleInterface.{u, v} Messages)
+    (prior : QueryImpl (OracleSpec.ofPFunctor access) Id) (message : Messages) (q : access.A) :
+    simulateQ (Access.extendImpl access interface prior message)
+        (Access.queryPrior access interface q) =
+      prior q := by
+  simp [queryPrior, extendImpl]
+
+@[simp]
+theorem eval_queryLatest {Messages : Type u} (access : PFunctor.{v, u})
+    (interface : OracleInterface.{u, v} Messages)
+    (prior : QueryImpl (OracleSpec.ofPFunctor access) Id) (message : Messages)
+    (q : interface.Query) :
+    simulateQ (Access.extendImpl access interface prior message)
+        (Access.queryLatest access interface q) =
+      @OracleInterface.answer _ interface message q := by
+  simp [queryLatest, extendImpl]
+
+end Access
 
 namespace TypeTree
 
 open PFunctor.FreeM.Displayed (Decoration)
 
-/-- Node-local accumulated access. The recursive builder controls where this capability grows. -/
+/-- Signature accumulated along a structural spine, including spines ending at a leaf. The
+signature depends on public choices and interfaces, never on concrete oracle payloads. -/
+def accessAlong :
+    {tree residual : Oracle.TypeTree.{u}} →
+    PFunctor.FreeM.Cursor.Spine tree residual → OracleDecoration.{u, v} tree →
+    PFunctor.{v, u} → PFunctor.{v, u}
+  | _, _, .root _, _, access => access
+  | _, _, .down (a := .public _) move tail, oracles, access =>
+      accessAlong tail (oracles.2 move) access
+  | _, _, .down (a := .oracle _) marker tail, oracles, access =>
+      accessAlong tail (oracles.2 marker) (Access.extend access oracles.1)
+
+/-- Canonical available signature at a syntactic protocol prefix. A terminal cursor still retains
+all earlier slots; a node-only decoration would lose that information at its unit-valued leaf. -/
+def accessAt {tree : Oracle.TypeTree.{u}} (cursor : PFunctor.FreeM.Cursor tree)
+    (oracles : OracleDecoration.{u, v} tree) (initial : PFunctor.{v, u}) :
+    PFunctor.{v, u} :=
+  accessAlong cursor.spine oracles initial
+
+@[simp]
+theorem accessAt_root (tree : Oracle.TypeTree.{u}) (oracles : OracleDecoration.{u, v} tree)
+    (initial : PFunctor.{v, u}) :
+    accessAt (PFunctor.FreeM.Cursor.root tree) oracles initial = initial :=
+  rfl
+
+@[simp]
+theorem accessAt_public {Moves : Type u} {rest : Moves → Oracle.TypeTree.{u}}
+    (move : Moves) (tail : PFunctor.FreeM.Cursor (rest move))
+    (oracles : OracleDecoration.{u, v} (.public Moves rest)) (initial : PFunctor.{v, u}) :
+    accessAt (PFunctor.FreeM.Cursor.down move tail) oracles initial =
+      accessAt tail (oracles.2 move) initial :=
+  rfl
+
+@[simp]
+theorem accessAt_oracle {Messages : Type u} {rest : PUnit.{u + 1} → Oracle.TypeTree.{u}}
+    (marker : PUnit.{u + 1}) (tail : PFunctor.FreeM.Cursor (rest marker))
+    (oracles : OracleDecoration.{u, v} (.oracle Messages rest)) (initial : PFunctor.{v, u}) :
+    accessAt (PFunctor.FreeM.Cursor.down marker tail) oracles initial =
+      accessAt tail (oracles.2 marker) (Access.extend initial oracles.1) :=
+  rfl
+
+/-- Accumulation respects actual spine composition; the suffix uses the restricted interfaces. -/
+theorem accessAlong_comp :
+    {tree middle residual : Oracle.TypeTree.{u}} →
+    (first : PFunctor.FreeM.Cursor.Spine tree middle) →
+    (second : PFunctor.FreeM.Cursor.Spine middle residual) →
+    (oracles : OracleDecoration.{u, v} tree) → (initial : PFunctor.{v, u}) →
+    accessAlong (first.comp second) oracles initial =
+      accessAlong second (OracleDecoration.restrict ⟨middle, first⟩ oracles)
+        (accessAlong first oracles initial)
+  | _, _, _, .root _, _, _, _ => rfl
+  | _, _, _, .down (a := .public _) move tail, second, oracles, initial =>
+      accessAlong_comp tail second (oracles.2 move) initial
+  | _, _, _, .down (a := .oracle _) marker tail, second, oracles, initial =>
+      accessAlong_comp tail second (oracles.2 marker) (Access.extend initial oracles.1)
+
+/-- Continuing a cursor computes exactly the access accumulated by continuing from its residual. -/
+theorem accessAt_comp {tree : Oracle.TypeTree.{u}} (first : PFunctor.FreeM.Cursor tree)
+    (second : PFunctor.FreeM.Cursor first.residual) (oracles : OracleDecoration.{u, v} tree)
+    (initial : PFunctor.{v, u}) :
+    accessAt (first.comp second) oracles initial =
+      accessAt second (OracleDecoration.restrict first oracles) (accessAt first oracles initial) :=
+  accessAlong_comp first.spine second.spine oracles initial
+
+/-- Available signature after a complete structural path, derived from the terminal cursor. -/
+def accessAfter (tree : Oracle.TypeTree.{u}) (oracles : OracleDecoration.{u, v} tree)
+    (initial : PFunctor.{v, u}) (path : BranchPath tree) : PFunctor.{v, u} :=
+  accessAt (PFunctor.FreeM.Cursor.ofPath tree path) oracles initial
+
+@[simp]
+theorem accessAfter_done (oracles : OracleDecoration.{u, v} (.done : Oracle.TypeTree.{u}))
+    (initial : PFunctor.{v, u}) (path : BranchPath .done) :
+    accessAfter .done oracles initial path = initial :=
+  rfl
+
+@[simp]
+theorem accessAfter_public (Moves : Type u) (rest : Moves → Oracle.TypeTree.{u})
+    (oracles : OracleDecoration.{u, v} (.public Moves rest)) (initial : PFunctor.{v, u})
+    (path : BranchPath (.public Moves rest)) :
+    accessAfter (.public Moves rest) oracles initial path =
+      accessAfter (rest path.1) (oracles.2 path.1) initial path.2 :=
+  rfl
+
+@[simp]
+theorem accessAfter_oracle (Messages : Type u) (rest : PUnit.{u + 1} → Oracle.TypeTree.{u})
+    (oracles : OracleDecoration.{u, v} (.oracle Messages rest)) (initial : PFunctor.{v, u})
+    (path : BranchPath (.oracle Messages rest)) :
+    accessAfter (.oracle Messages rest) oracles initial path =
+      accessAfter (rest path.1) (oracles.2 path.1) (Access.extend initial oracles.1) path.2 :=
+  rfl
+
+/-- Equal public branch projections give identical available signatures. This says nothing about
+equality of the concrete handlers: different hidden payloads can give different query answers. -/
+theorem accessAfter_eq_of_toBranchPath_eq {tree : Oracle.TypeTree.{u}}
+    (oracles : OracleDecoration.{u, v} tree) (initial : PFunctor.{v, u})
+    {left right : ExecutionPath tree} (h : left.toBranchPath = right.toBranchPath) :
+    accessAfter tree oracles initial left.toBranchPath =
+      accessAfter tree oracles initial right.toBranchPath :=
+  congrArg (accessAfter tree oracles initial) h
+
+/-- Node-local presentation of accumulated access. The builder owns the growth rule. -/
 @[reducible]
 def AccessContext : Oracle.Position.{u} → Type (max (u + 1) (v + 1)) :=
-  fun _ => AccessSpec.{u, v}
+  fun _ => PFunctor.{v, u}
 
-/-- The accumulated oracle resources available immediately before every node in an oracle tree. -/
+/-- A node-local presentation, not by itself evidence of correctly scoped access. -/
 abbrev AccessDecoration (tree : Oracle.TypeTree.{u}) :=
   Decoration (P := basePFunctor) (α := PUnit.{u + 1}) AccessContext.{u, v} tree
 
 namespace AccessDecoration
 
-/-- Build node-local accumulated access from an initial source specification and the oracle
-interfaces decorating the protocol tree.
-
-A public node keeps the same access while its public value chooses the child. An oracle node also
-stores the old access at the node itself, but appends that node's interface before constructing its
-continuation. -/
+/-- Build the canonical node-local presentation. Public nodes preserve access; oracle nodes expose
+only the old signature at the send and extend it for the continuation. -/
 def build :
-    (tree : Oracle.TypeTree.{u}) →
-    OracleDecoration.{u, v} tree →
-    {ι : Type v} → OracleSpec.{v, u} ι →
-    AccessDecoration.{u, v} tree
+    (tree : Oracle.TypeTree.{u}) → OracleDecoration.{u, v} tree →
+    {ι : Type v} → OracleSpec.{v, u} ι → AccessDecoration.{u, v} tree
   | .done, _, _, _ => ⟨⟩
   | .public _ rest, oracles, _, access =>
-      ⟨AccessSpec.ofSpec access, fun move => build (rest move) (oracles.2 move) access⟩
+      ⟨access.toPFunctor, fun move => build (rest move) (oracles.2 move) access⟩
   | .oracle _ rest, oracles, _, access =>
-      ⟨AccessSpec.ofSpec access, fun marker =>
-        build (rest marker) (oracles.2 marker)
-          (access + @OracleInterface.spec _ oracles.1)⟩
+      ⟨access.toPFunctor, fun marker =>
+        build (rest marker) (oracles.2 marker) (access + @OracleInterface.spec _ oracles.1)⟩
 
-/-- Restrict accumulated access to the residual tree selected by a structural cursor. -/
+/-- Restrict a presentation using PolyFun's canonical displayed restriction. -/
 abbrev restrict {tree : Oracle.TypeTree.{u}} (cursor : PFunctor.FreeM.Cursor tree)
     (access : AccessDecoration.{u, v} tree) : AccessDecoration.{u, v} cursor.residual :=
   Decoration.restrict cursor access
 
 @[simp]
-theorem restrict_root (tree : Oracle.TypeTree.{u})
-    (access : AccessDecoration.{u, v} tree) :
+theorem restrict_root (tree : Oracle.TypeTree.{u}) (access : AccessDecoration.{u, v} tree) :
     restrict (PFunctor.FreeM.Cursor.root tree) access = access :=
   rfl
 
@@ -117,16 +237,38 @@ theorem restrict_down {position : Oracle.Position.{u}}
     {next : position.Branch → Oracle.TypeTree.{u}} (branch : position.Branch)
     (tail : PFunctor.FreeM.Cursor (next branch))
     (access : AccessDecoration.{u, v} (PFunctor.FreeM.liftBind position next)) :
-    restrict (PFunctor.FreeM.Cursor.down branch tail) access =
-      restrict tail (access.2 branch) :=
+    restrict (PFunctor.FreeM.Cursor.down branch tail) access = restrict tail (access.2 branch) :=
   rfl
 
-/-- Cursor composition restricts accumulated access in two stages. -/
+/-- Restriction composes without introducing another cursor representation. -/
 theorem restrict_comp {tree : Oracle.TypeTree.{u}} (first : PFunctor.FreeM.Cursor tree)
-    (second : PFunctor.FreeM.Cursor first.residual)
-    (access : AccessDecoration.{u, v} tree) :
+    (second : PFunctor.FreeM.Cursor first.residual) (access : AccessDecoration.{u, v} tree) :
     restrict (first.comp second) access = restrict second (restrict first access) :=
   Decoration.restrict_comp first second access
+
+/-- Restricting a built presentation equals rebuilding at the residual with the accumulated access.
+This connects the node presentation to the canonical prefix API, rather than merely proving laws
+about arbitrary decorations. -/
+theorem restrict_build_spine :
+    {tree residual : Oracle.TypeTree.{u}} →
+    (spine : PFunctor.FreeM.Cursor.Spine tree residual) →
+    (oracles : OracleDecoration.{u, v} tree) → (initial : PFunctor.{v, u}) →
+    restrict ⟨residual, spine⟩ (build tree oracles (OracleSpec.ofPFunctor initial)) =
+      build residual (OracleDecoration.restrict ⟨residual, spine⟩ oracles)
+        (OracleSpec.ofPFunctor (accessAlong spine oracles initial))
+  | _, _, .root _, _, _ => rfl
+  | _, _, .down (a := .public _) move tail, oracles, initial =>
+      restrict_build_spine tail (oracles.2 move) initial
+  | _, _, .down (a := .oracle _) marker tail, oracles, initial =>
+      restrict_build_spine tail (oracles.2 marker) (Access.extend initial oracles.1)
+
+/-- Cursor-facing canonical restriction/rebuild law. -/
+theorem restrict_build {tree : Oracle.TypeTree.{u}} (cursor : PFunctor.FreeM.Cursor tree)
+    (oracles : OracleDecoration.{u, v} tree) (initial : PFunctor.{v, u}) :
+    restrict cursor (build tree oracles (OracleSpec.ofPFunctor initial)) =
+      build cursor.residual (OracleDecoration.restrict cursor oracles)
+        (OracleSpec.ofPFunctor (accessAt cursor oracles initial)) :=
+  restrict_build_spine cursor.spine oracles initial
 
 end AccessDecoration
 end TypeTree

--- a/ArkLib/Interaction/Oracle/Access.lean
+++ b/ArkLib/Interaction/Oracle/Access.lean
@@ -32,7 +32,9 @@ There is no second packed-signature record. Query and response universes remain 
 namespace Access
 
 /-- Add a disjoint query slot for a newly sent oracle message. This is signature extension, not a
-claim that two same-signature resources have the same identity. -/
+claim that two same-signature resources have the same identity. The signature's query domain must
+reduce at implicit transparency when checking dependent query arguments in interpreter laws. -/
+@[implicit_reducible]
 def extend {Messages : Type u} (access : PFunctor.{v, u})
     (interface : OracleInterface.{u, v} Messages) : PFunctor.{v, u} :=
   ((OracleSpec.ofPFunctor access) + @OracleInterface.spec _ interface).toPFunctor

--- a/ArkLib/Interaction/Oracle/Access.lean
+++ b/ArkLib/Interaction/Oracle/Access.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import ArkLib.Interaction.Oracle.Protocol
+import VCVio.OracleComp.SimSemantics.Append
+
+/-!
+# Accumulated oracle access
+
+This file is the AR-3A access layer for typed oracle interactions. It records, at every node of an
+`Oracle.TypeTree`, exactly the oracle resources that are queryable before the next message is sent.
+
+Public values remain ordinary structural data: they select the dependent continuation and are not
+re-encoded as oracle queries. Oracle access grows only after an oracle-backed prover message. In
+particular, the access stored at an oracle node deliberately excludes that node's message; only the
+continuation receives the extended specification. Future-message access is therefore absent by
+construction.
+
+Execution is intentionally out of scope. AR-3B will package prover/verifier strategies whose node
+computations use the capabilities described here.
+-/
+
+universe u v
+
+open OracleComp OracleSpec
+
+namespace Interaction.Oracle
+
+/-- A packed oracle specification. Packing the query-index type lets the available query space grow
+as earlier prover oracle messages become available. -/
+abbrev AccessSpec := Σ ι : Type v, OracleSpec.{v, u} ι
+
+namespace AccessSpec
+
+/-- Package an ordinary oracle specification as an access specification. -/
+def ofSpec {ι : Type v} (spec : OracleSpec.{v, u} ι) : AccessSpec.{u, v} :=
+  ⟨ι, spec⟩
+
+/-- Extend an accumulated access specification with one newly available prover oracle message. -/
+def extend {Messages : Type u} (access : AccessSpec.{u, v})
+    (interface : OracleInterface.{u, v} Messages) : AccessSpec.{u, v} :=
+  ⟨access.1 ⊕ interface.Query, access.2 + @OracleInterface.spec _ interface⟩
+
+/-- Extend a concrete implementation of the prior access with a concrete prover oracle message. -/
+def extendImpl {Messages : Type u} (access : AccessSpec.{u, v})
+    (interface : OracleInterface.{u, v} Messages)
+    (prior : QueryImpl access.2 Id) (message : Messages) :
+    QueryImpl (access.extend interface).2 Id :=
+  prior + fun q => @OracleInterface.answer _ interface message q
+
+@[simp]
+theorem extendImpl_prior {Messages : Type u} (access : AccessSpec.{u, v})
+    (interface : OracleInterface.{u, v} Messages)
+    (prior : QueryImpl access.2 Id) (message : Messages) (q : access.1) :
+    access.extendImpl interface prior message (.inl q) = prior q :=
+  rfl
+
+@[simp]
+theorem extendImpl_latest {Messages : Type u} (access : AccessSpec.{u, v})
+    (interface : OracleInterface.{u, v} Messages)
+    (prior : QueryImpl access.2 Id) (message : Messages) (q : interface.Query) :
+    access.extendImpl interface prior message (.inr q) =
+      @OracleInterface.answer _ interface message q :=
+  rfl
+
+end AccessSpec
+
+namespace TypeTree
+
+open PFunctor.FreeM.Displayed (Decoration)
+
+/-- Node-local accumulated access. The recursive builder controls where this capability grows. -/
+@[reducible]
+def AccessContext : Oracle.Position.{u} → Type (max (u + 1) (v + 1)) :=
+  fun _ => AccessSpec.{u, v}
+
+/-- The accumulated oracle resources available immediately before every node in an oracle tree. -/
+abbrev AccessDecoration (tree : Oracle.TypeTree.{u}) :=
+  Decoration (P := basePFunctor) (α := PUnit.{u + 1}) AccessContext.{u, v} tree
+
+namespace AccessDecoration
+
+/-- Build node-local accumulated access from an initial source specification and the oracle
+interfaces decorating the protocol tree.
+
+A public node keeps the same access while its public value chooses the child. An oracle node also
+stores the old access at the node itself, but appends that node's interface before constructing its
+continuation. -/
+def build :
+    (tree : Oracle.TypeTree.{u}) →
+    OracleDecoration.{u, v} tree →
+    {ι : Type v} → OracleSpec.{v, u} ι →
+    AccessDecoration.{u, v} tree
+  | .done, _, _, _ => ⟨⟩
+  | .public _ rest, oracles, _, access =>
+      ⟨AccessSpec.ofSpec access, fun move => build (rest move) (oracles.2 move) access⟩
+  | .oracle _ rest, oracles, _, access =>
+      ⟨AccessSpec.ofSpec access, fun marker =>
+        build (rest marker) (oracles.2 marker)
+          (access + @OracleInterface.spec _ oracles.1)⟩
+
+/-- Restrict accumulated access to the residual tree selected by a structural cursor. -/
+abbrev restrict {tree : Oracle.TypeTree.{u}} (cursor : PFunctor.FreeM.Cursor tree)
+    (access : AccessDecoration.{u, v} tree) : AccessDecoration.{u, v} cursor.residual :=
+  Decoration.restrict cursor access
+
+@[simp]
+theorem restrict_root (tree : Oracle.TypeTree.{u})
+    (access : AccessDecoration.{u, v} tree) :
+    restrict (PFunctor.FreeM.Cursor.root tree) access = access :=
+  rfl
+
+@[simp]
+theorem restrict_down {position : Oracle.Position.{u}}
+    {next : position.Branch → Oracle.TypeTree.{u}} (branch : position.Branch)
+    (tail : PFunctor.FreeM.Cursor (next branch))
+    (access : AccessDecoration.{u, v} (PFunctor.FreeM.liftBind position next)) :
+    restrict (PFunctor.FreeM.Cursor.down branch tail) access =
+      restrict tail (access.2 branch) :=
+  rfl
+
+/-- Cursor composition restricts accumulated access in two stages. -/
+theorem restrict_comp {tree : Oracle.TypeTree.{u}} (first : PFunctor.FreeM.Cursor tree)
+    (second : PFunctor.FreeM.Cursor first.residual)
+    (access : AccessDecoration.{u, v} tree) :
+    restrict (first.comp second) access = restrict second (restrict first access) :=
+  Decoration.restrict_comp first second access
+
+end AccessDecoration
+end TypeTree
+end Interaction.Oracle

--- a/ArkLib/Interaction/Oracle/Access.lean
+++ b/ArkLib/Interaction/Oracle/Access.lean
@@ -83,7 +83,7 @@ theorem eval_queryPrior {Messages : Type u} (access : PFunctor.{v, u})
     simulateQ (Access.extendImpl access interface prior message)
         (Access.queryPrior access interface q) =
       prior q := by
-  simp [queryPrior, extendImpl]
+  rw [queryPrior, simulateQ_spec_query]
 
 @[simp]
 theorem eval_queryLatest {Messages : Type u} (access : PFunctor.{v, u})
@@ -93,7 +93,7 @@ theorem eval_queryLatest {Messages : Type u} (access : PFunctor.{v, u})
     simulateQ (Access.extendImpl access interface prior message)
         (Access.queryLatest access interface q) =
       @OracleInterface.answer _ interface message q := by
-  simp [queryLatest, extendImpl]
+  rw [queryLatest, simulateQ_spec_query]
 
 end Access
 

--- a/ArkLib/Interaction/Oracle/Access.lean
+++ b/ArkLib/Interaction/Oracle/Access.lean
@@ -42,7 +42,9 @@ def extendImpl {Messages : Type u} (access : PFunctor.{v, u})
     (interface : OracleInterface.{u, v} Messages)
     (prior : QueryImpl (OracleSpec.ofPFunctor access) Id) (message : Messages) :
     QueryImpl (OracleSpec.ofPFunctor (Access.extend access interface)) Id :=
-  prior + fun q => @OracleInterface.answer _ interface message q
+  QueryImpl.add prior
+    (show QueryImpl (@OracleInterface.spec _ interface) Id from
+      fun q => @OracleInterface.answer _ interface message q)
 
 @[simp]
 theorem extendImpl_prior {Messages : Type u} (access : PFunctor.{v, u})
@@ -106,9 +108,9 @@ def accessAlong :
     PFunctor.FreeM.Cursor.Spine tree residual → OracleDecoration.{u, v} tree →
     PFunctor.{v, u} → PFunctor.{v, u}
   | _, _, .root _, _, access => access
-  | _, _, .down (a := .public _) move tail, oracles, access =>
+  | _, _, .down (a := Oracle.Position.public _) move tail, oracles, access =>
       accessAlong tail (oracles.2 move) access
-  | _, _, .down (a := .oracle _) marker tail, oracles, access =>
+  | _, _, .down (a := Oracle.Position.oracle _) marker tail, oracles, access =>
       accessAlong tail (oracles.2 marker) (Access.extend access oracles.1)
 
 /-- Canonical available signature at a syntactic protocol prefix. A terminal cursor still retains
@@ -150,9 +152,9 @@ theorem accessAlong_comp :
       accessAlong second (OracleDecoration.restrict ⟨middle, first⟩ oracles)
         (accessAlong first oracles initial)
   | _, _, _, .root _, _, _, _ => rfl
-  | _, _, _, .down (a := .public _) move tail, second, oracles, initial =>
+  | _, _, _, .down (a := Oracle.Position.public _) move tail, second, oracles, initial =>
       accessAlong_comp tail second (oracles.2 move) initial
-  | _, _, _, .down (a := .oracle _) marker tail, second, oracles, initial =>
+  | _, _, _, .down (a := Oracle.Position.oracle _) marker tail, second, oracles, initial =>
       accessAlong_comp tail second (oracles.2 marker) (Access.extend initial oracles.1)
 
 /-- Continuing a cursor computes exactly the access accumulated by continuing from its residual. -/
@@ -257,9 +259,9 @@ theorem restrict_build_spine :
       build residual (OracleDecoration.restrict ⟨residual, spine⟩ oracles)
         (OracleSpec.ofPFunctor (accessAlong spine oracles initial))
   | _, _, .root _, _, _ => rfl
-  | _, _, .down (a := .public _) move tail, oracles, initial =>
+  | _, _, .down (a := Oracle.Position.public _) move tail, oracles, initial =>
       restrict_build_spine tail (oracles.2 move) initial
-  | _, _, .down (a := .oracle _) marker tail, oracles, initial =>
+  | _, _, .down (a := Oracle.Position.oracle _) marker tail, oracles, initial =>
       restrict_build_spine tail (oracles.2 marker) (Access.extend initial oracles.1)
 
 /-- Cursor-facing canonical restriction/rebuild law. -/

--- a/ArkLibTest/Interaction/Oracle/TypeTree/AccessExample.lean
+++ b/ArkLibTest/Interaction/Oracle/TypeTree/AccessExample.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import ArkLib.Interaction.Oracle.Access
+
+/-!
+# Accumulated-access acceptance client
+
+This client exercises AR-3A on a public branch selecting two different oracle-message types. It
+checks that public branching does not itself change oracle access, that each oracle message becomes
+queryable only in its continuation, and that the concrete extension implementation routes old and
+new queries to the correct source.
+-/
+
+namespace Interaction.Oracle.TypeTree.AccessExample
+
+open OracleComp OracleSpec
+
+/-- One ambient input resource available throughout the protocol. -/
+def baseSpec : OracleSpec Unit := Unit →ₒ Nat
+
+/-- A concrete implementation used to check passthrough routing. -/
+def baseImpl : QueryImpl baseSpec Id := fun _ => 7
+
+/-- Public future reached after the Boolean oracle branch. -/
+def falseFuture : Oracle.TypeTree :=
+  .public (Fin 2) fun _ => .done
+
+/-- Public future reached after the `Fin 3` oracle branch. -/
+def trueFuture : Oracle.TypeTree :=
+  .public Bool fun _ => .done
+
+/-- A public Boolean selects two different oracle messages. -/
+def accessTree : Oracle.TypeTree :=
+  .public Bool fun
+    | false => .oracle Bool fun _ => falseFuture
+    | true => .oracle (Fin 3) fun _ => trueFuture
+
+/-- Interfaces matching the two branch-dependent oracle nodes. -/
+def accessOracles : accessTree.OracleDecoration :=
+  ⟨PUnit.unit, fun
+    | false => ⟨OracleInterface.instDefault, fun _ => ⟨PUnit.unit, fun _ => ⟨⟩⟩⟩
+    | true => ⟨OracleInterface.instDefault, fun _ => ⟨PUnit.unit, fun _ => ⟨⟩⟩⟩⟩
+
+/-- Accumulated access starting from the ambient input resource. -/
+def access : accessTree.AccessDecoration :=
+  AccessDecoration.build accessTree accessOracles baseSpec
+
+/-- Public branching preserves the current oracle capabilities on either branch. -/
+example : (access.2 false).1.1 = Unit :=
+  rfl
+
+example : (access.2 true).1.1 = Unit :=
+  rfl
+
+/-- Negative canary: at either oracle-send node the only query domain is still the ambient input
+resource. A query of shape `.inr _` for the current prover message is not typeable here. -/
+example : access.1.1 = Unit :=
+  rfl
+
+/-- After the Boolean oracle message is sent, its query slot is appended to the prior access. -/
+example : ((access.2 false).2 PUnit.unit).1.1 = Unit ⊕ Unit :=
+  rfl
+
+/-- The appended Boolean slot has Boolean responses. -/
+example : ((access.2 false).2 PUnit.unit).1.2 (.inr ()) = Bool :=
+  rfl
+
+/-- The other public branch grows by the `Fin 3` oracle interface instead. -/
+example : ((access.2 true).2 PUnit.unit).1.2 (.inr ()) = Fin 3 :=
+  rfl
+
+/-- Extending a concrete implementation preserves routing to the ambient input resource. -/
+example :
+    (AccessSpec.ofSpec baseSpec).extendImpl OracleInterface.instDefault baseImpl true (.inl ()) = 7 :=
+  rfl
+
+/-- The newly appended slot routes to the concrete prover message. -/
+example :
+    (AccessSpec.ofSpec baseSpec).extendImpl OracleInterface.instDefault baseImpl true (.inr ()) = true :=
+  rfl
+
+/-- Cursor selecting the public future after the Boolean oracle message. -/
+def falseFutureCursor : PFunctor.FreeM.Cursor accessTree :=
+  PFunctor.FreeM.Cursor.down false <|
+    PFunctor.FreeM.Cursor.down PUnit.unit (PFunctor.FreeM.Cursor.root falseFuture)
+
+/-- Restriction recovers exactly the access available at the selected future node. -/
+example : (AccessDecoration.restrict falseFutureCursor access).1.1 = Unit ⊕ Unit :=
+  rfl
+
+end Interaction.Oracle.TypeTree.AccessExample

--- a/ArkLibTest/Interaction/Oracle/TypeTree/AccessExample.lean
+++ b/ArkLibTest/Interaction/Oracle/TypeTree/AccessExample.lean
@@ -18,7 +18,7 @@ namespace Interaction.Oracle.TypeTree.AccessExample
 open OracleComp OracleSpec
 
 /-- One input resource available from the start. -/
-def baseSpec : OracleSpec Unit := Unit →ₒ Nat
+abbrev baseSpec : OracleSpec Unit := Unit →ₒ Nat
 
 /-- Input behavior is supplied directly, not assumed to come from an honest representation. -/
 def baseImpl : QueryImpl baseSpec Id := fun _ => 7
@@ -58,9 +58,10 @@ example : ((access.2 true).2 PUnit.unit).1.B (.inr ()) = Fin 3 := rfl
 
 /-- Cursor stopping after the false-branch oracle send. -/
 def afterSend : PFunctor.FreeM.Cursor accessTree :=
-  .down false (.down PUnit.unit (.root (.public (Fin 2) fun _ => .done)))
+  .down false (.down PUnit.unit
+    (.root (Oracle.TypeTree.public (Fin 2) fun _ => Oracle.TypeTree.done)))
 
-example : (accessAt afterSend accessOracles baseSpec.toPFunctor).A = Unit ⊕ Unit := rfl
+example : (accessAt afterSend accessOracles baseSpec.toPFunctor).A = (Unit ⊕ Unit) := rfl
 
 /-- The public future can be selected without any concrete Boolean oracle payload. -/
 example : AccessDecoration.restrict afterSend access =
@@ -88,6 +89,7 @@ example : accessAfter accessTree accessOracles baseSpec.toPFunctor leftPath.toBr
   accessAfter_eq_of_toBranchPath_eq accessOracles baseSpec.toPFunctor rfl
 
 /-- A deliberately non-faithful interface: only the first coordinate is observable. -/
+@[reducible]
 def firstInterface : OracleInterface (Nat × Nat) where
   Query := Unit
   toOC.spec := Unit →ₒ Nat
@@ -102,11 +104,12 @@ def terminalOracles : terminalTree.OracleDecoration :=
 
 /-- Complete cursor; node decorations alone have only unit at this residual. -/
 def terminalCursor : PFunctor.FreeM.Cursor terminalTree :=
-  .down PUnit.unit (.root .done)
+  .down PUnit.unit (.root Oracle.TypeTree.done)
 
-example : (accessAt terminalCursor terminalOracles baseSpec.toPFunctor).A = Unit ⊕ Unit := rfl
+example : (accessAt terminalCursor terminalOracles baseSpec.toPFunctor).A = (Unit ⊕ Unit) := rfl
 
-example : (accessAt terminalCursor terminalOracles baseSpec.toPFunctor).B (.inr ()) = Nat := rfl
+example :
+    (accessAt terminalCursor terminalOracles baseSpec.toPFunctor).B (Sum.inr ()) = Nat := rfl
 
 /-- Two same-signature sources are still explicitly routed to different slots. -/
 def derivedQuery : OracleComp
@@ -116,8 +119,8 @@ def derivedQuery : OracleComp
   return old + fresh
 
 example : simulateQ
-    (Access.extendImpl baseSpec.toPFunctor firstInterface baseImpl (11, 42)) derivedQuery = 18 := by
-  simp [derivedQuery, baseImpl, firstInterface, OracleInterface.answer]
+    (Access.extendImpl baseSpec.toPFunctor firstInterface baseImpl (11, 42)) derivedQuery = 18 :=
+  rfl
 
 /-- Hidden representation data do not leak through the handler. -/
 example (visible hidden₁ hidden₂ : Nat) :

--- a/ArkLibTest/Interaction/Oracle/TypeTree/AccessExample.lean
+++ b/ArkLibTest/Interaction/Oracle/TypeTree/AccessExample.lean
@@ -8,87 +8,146 @@ import ArkLib.Interaction.Oracle.Access
 /-!
 # Accumulated-access acceptance client
 
-This client exercises AR-3A on a public branch selecting two different oracle-message types. It
-checks that public branching does not itself change oracle access, that each oracle message becomes
-queryable only in its continuation, and that the concrete extension implementation routes old and
-new queries to the correct source.
+Public branches select different message types. Rejection tests attempt unavailable queries, with
+positive counterparts after the send. Terminal access, cursor composition, repeated signatures,
+and a non-faithful oracle interface exercise the semantic boundaries, not just tuple projections.
 -/
 
 namespace Interaction.Oracle.TypeTree.AccessExample
 
 open OracleComp OracleSpec
 
-/-- One ambient input resource available throughout the protocol. -/
+/-- One input resource available from the start. -/
 def baseSpec : OracleSpec Unit := Unit →ₒ Nat
 
-/-- A concrete implementation used to check passthrough routing. -/
+/-- Input behavior is supplied directly, not assumed to come from an honest representation. -/
 def baseImpl : QueryImpl baseSpec Id := fun _ => 7
 
-/-- Public future reached after the Boolean oracle branch. -/
-def falseFuture : Oracle.TypeTree :=
-  .public (Fin 2) fun _ => .done
-
-/-- Public future reached after the `Fin 3` oracle branch. -/
-def trueFuture : Oracle.TypeTree :=
-  .public Bool fun _ => .done
-
-/-- A public Boolean selects two different oracle messages. -/
+/-- A public choice changes the next oracle message type. -/
 def accessTree : Oracle.TypeTree :=
   .public Bool fun
-    | false => .oracle Bool fun _ => falseFuture
-    | true => .oracle (Fin 3) fun _ => trueFuture
+    | false => .oracle Bool fun _ => .public (Fin 2) fun _ => .done
+    | true => .oracle (Fin 3) fun _ => .public Bool fun _ => .done
 
-/-- Interfaces matching the two branch-dependent oracle nodes. -/
+/-- Explicit interfaces for the branch-dependent messages. -/
 def accessOracles : accessTree.OracleDecoration :=
   ⟨PUnit.unit, fun
     | false => ⟨OracleInterface.instDefault, fun _ => ⟨PUnit.unit, fun _ => ⟨⟩⟩⟩
     | true => ⟨OracleInterface.instDefault, fun _ => ⟨PUnit.unit, fun _ => ⟨⟩⟩⟩⟩
 
-/-- Accumulated access starting from the ambient input resource. -/
+/-- The derived presentation of access before each node. -/
 def access : accessTree.AccessDecoration :=
   AccessDecoration.build accessTree accessOracles baseSpec
 
-/-- Public branching preserves the current oracle capabilities on either branch. -/
-example : (access.2 false).1.1 = Unit :=
-  rfl
+example : (access.2 false).1.A = Unit := rfl
 
-example : (access.2 true).1.1 = Unit :=
-  rfl
+example : (access.2 true).1.A = Unit := rfl
 
-/-- Negative canary: at either oracle-send node the only query domain is still the ambient input
-resource. A query of shape `.inr _` for the current prover message is not typeable here. -/
-example : access.1.1 = Unit :=
-  rfl
+/-- This actually attempts to type a query for the unsent message. -/
+example : True := by
+  fail_if_success
+    have _ : (access.2 false).1.A := Sum.inr ()
+  trivial
 
-/-- After the Boolean oracle message is sent, its query slot is appended to the prior access. -/
-example : ((access.2 false).2 PUnit.unit).1.1 = Unit ⊕ Unit :=
-  rfl
+/-- The identical query constructor is accepted after the send. -/
+example : ((access.2 false).2 PUnit.unit).1.A := Sum.inr ()
 
-/-- The appended Boolean slot has Boolean responses. -/
-example : ((access.2 false).2 PUnit.unit).1.2 (.inr ()) = Bool :=
-  rfl
+example : ((access.2 false).2 PUnit.unit).1.B (.inr ()) = Bool := rfl
 
-/-- The other public branch grows by the `Fin 3` oracle interface instead. -/
-example : ((access.2 true).2 PUnit.unit).1.2 (.inr ()) = Fin 3 :=
-  rfl
+example : ((access.2 true).2 PUnit.unit).1.B (.inr ()) = Fin 3 := rfl
 
-/-- Extending a concrete implementation preserves routing to the ambient input resource. -/
-example :
-    (AccessSpec.ofSpec baseSpec).extendImpl OracleInterface.instDefault baseImpl true (.inl ()) = 7 :=
-  rfl
+/-- Cursor stopping after the false-branch oracle send. -/
+def afterSend : PFunctor.FreeM.Cursor accessTree :=
+  .down false (.down PUnit.unit (.root (.public (Fin 2) fun _ => .done)))
 
-/-- The newly appended slot routes to the concrete prover message. -/
-example :
-    (AccessSpec.ofSpec baseSpec).extendImpl OracleInterface.instDefault baseImpl true (.inr ()) = true :=
-  rfl
+example : (accessAt afterSend accessOracles baseSpec.toPFunctor).A = Unit ⊕ Unit := rfl
 
-/-- Cursor selecting the public future after the Boolean oracle message. -/
-def falseFutureCursor : PFunctor.FreeM.Cursor accessTree :=
-  PFunctor.FreeM.Cursor.down false <|
-    PFunctor.FreeM.Cursor.down PUnit.unit (PFunctor.FreeM.Cursor.root falseFuture)
+/-- The public future can be selected without any concrete Boolean oracle payload. -/
+example : AccessDecoration.restrict afterSend access =
+    AccessDecoration.build afterSend.residual
+      (OracleDecoration.restrict afterSend accessOracles)
+      (OracleSpec.ofPFunctor (accessAt afterSend accessOracles baseSpec.toPFunctor)) :=
+  AccessDecoration.restrict_build afterSend accessOracles baseSpec.toPFunctor
 
-/-- Restriction recovers exactly the access available at the selected future node. -/
-example : (AccessDecoration.restrict falseFutureCursor access).1.1 = Unit ⊕ Unit :=
-  rfl
+/-- Distinct oracle payloads leave the structural projection unchanged. -/
+def leftPath : ExecutionPath accessTree := ⟨false, false, (0 : Fin 2), PUnit.unit⟩
+
+/-- Same public choices, different concrete oracle payload. -/
+def rightPath : ExecutionPath accessTree := ⟨false, true, (0 : Fin 2), PUnit.unit⟩
+
+example : leftPath ≠ rightPath := by
+  intro h
+  have impossible : false = true := congrArg
+    (fun p : ExecutionPath accessTree => match p with
+      | ⟨false, message, _⟩ => message
+      | ⟨true, _, _⟩ => false) h
+  cases impossible
+
+example : accessAfter accessTree accessOracles baseSpec.toPFunctor leftPath.toBranchPath =
+    accessAfter accessTree accessOracles baseSpec.toPFunctor rightPath.toBranchPath :=
+  accessAfter_eq_of_toBranchPath_eq accessOracles baseSpec.toPFunctor rfl
+
+/-- A deliberately non-faithful interface: only the first coordinate is observable. -/
+def firstInterface : OracleInterface (Nat × Nat) where
+  Query := Unit
+  toOC.spec := Unit →ₒ Nat
+  toOC.impl _ := do return (← read).1
+
+/-- A send immediately followed by a terminal leaf. -/
+def terminalTree : Oracle.TypeTree := .oracle (Nat × Nat) fun _ => .done
+
+/-- Oracle decoration for the terminal-send regression. -/
+def terminalOracles : terminalTree.OracleDecoration :=
+  ⟨firstInterface, fun _ => ⟨⟩⟩
+
+/-- Complete cursor; node decorations alone have only unit at this residual. -/
+def terminalCursor : PFunctor.FreeM.Cursor terminalTree :=
+  .down PUnit.unit (.root .done)
+
+example : (accessAt terminalCursor terminalOracles baseSpec.toPFunctor).A = Unit ⊕ Unit := rfl
+
+example : (accessAt terminalCursor terminalOracles baseSpec.toPFunctor).B (.inr ()) = Nat := rfl
+
+/-- Two same-signature sources are still explicitly routed to different slots. -/
+def derivedQuery : OracleComp
+    (OracleSpec.ofPFunctor (Access.extend baseSpec.toPFunctor firstInterface)) Nat := do
+  let old ← Access.queryPrior baseSpec.toPFunctor firstInterface ()
+  let fresh ← Access.queryLatest baseSpec.toPFunctor firstInterface ()
+  return old + fresh
+
+example : simulateQ
+    (Access.extendImpl baseSpec.toPFunctor firstInterface baseImpl (11, 42)) derivedQuery = 18 := by
+  simp [derivedQuery, baseImpl, firstInterface, OracleInterface.answer]
+
+/-- Hidden representation data do not leak through the handler. -/
+example (visible hidden₁ hidden₂ : Nat) :
+    Access.extendImpl baseSpec.toPFunctor firstInterface baseImpl (visible, hidden₁) =
+      Access.extendImpl baseSpec.toPFunctor firstInterface baseImpl (visible, hidden₂) := by
+  funext q
+  cases q <;> rfl
+
+/-- A second oracle is not available after only the first send. -/
+example : True := by
+  fail_if_success
+    have _ : OracleComp
+        (OracleSpec.ofPFunctor (Access.extend baseSpec.toPFunctor firstInterface)) Nat :=
+      Access.queryLatest (Access.extend baseSpec.toPFunctor firstInterface) firstInterface ()
+  trivial
+
+/-- The same second-slot query is well typed after the second extension. -/
+example : OracleComp
+    (OracleSpec.ofPFunctor
+      (Access.extend (Access.extend baseSpec.toPFunctor firstInterface) firstInterface)) Nat :=
+  Access.queryLatest (Access.extend baseSpec.toPFunctor firstInterface) firstInterface ()
+
+/-- Message/response universe above the query universe. -/
+example (Messages : Type 1) (interface : OracleInterface.{1, 0} Messages)
+    (initial : PFunctor.{0, 1}) : PFunctor.{0, 1} :=
+  Access.extend initial interface
+
+/-- Query universe above the message/response universe. -/
+example (Messages : Type) (interface : OracleInterface.{0, 1} Messages)
+    (initial : PFunctor.{1, 0}) : PFunctor.{1, 0} :=
+  Access.extend initial interface
 
 end Interaction.Oracle.TypeTree.AccessExample

--- a/ArkLibTest/Interaction/Oracle/TypeTree/AccessExample.lean
+++ b/ArkLibTest/Interaction/Oracle/TypeTree/AccessExample.lean
@@ -114,8 +114,8 @@ example :
 /-- Two same-signature sources are still explicitly routed to different slots. -/
 def derivedQuery : OracleComp
     (OracleSpec.ofPFunctor (Access.extend baseSpec.toPFunctor firstInterface)) Nat := do
-  let old ← Access.queryPrior baseSpec.toPFunctor firstInterface ()
-  let fresh ← Access.queryLatest baseSpec.toPFunctor firstInterface ()
+  let old : Nat ← Access.queryPrior baseSpec.toPFunctor firstInterface ()
+  let fresh : Nat ← Access.queryLatest baseSpec.toPFunctor firstInterface ()
   return old + fresh
 
 example : simulateQ

--- a/docs/design/01c-access-execution-contract.md
+++ b/docs/design/01c-access-execution-contract.md
@@ -1,0 +1,104 @@
+# AR-3A / AR-3B semantic acceptance contract
+
+This refines the corresponding slices in [the landing plan](01a-foundation-pr-plan.md).
+The [naming contract](01b-type-tree-rename-cutover.md) and
+[core claim design](02-oracle-reduction-core.md) remain in force. These are acceptance
+requirements, not a statement that validation has already passed.
+
+## AR-3A: signatures are not executions
+
+Use the existing `PFunctor` carrier through `OracleSpec.toPFunctor` and
+`OracleSpec.ofPFunctor`; do not introduce another packed-signature record solely to change
+terminology. Preserve independent query and response universes where the upstream API does.
+
+`TypeTree.accessAt` computes the available signature from an initial signature, an oracle
+decoration, and a real `FreeM.Cursor`. It includes terminal cursors: a send followed by `done`
+still leaves an oracle that the terminal verifier can query. A node decoration alone has a
+unit-valued leaf and cannot serve as the only access API.
+
+`AccessDecoration.build` is a derived presentation. Arbitrary values of `AccessDecoration`
+are not certificates that their queries are authorized. The restriction/rebuild theorem must
+connect that presentation to `accessAt`; generic restriction laws for arbitrary decorations
+are not sufficient.
+
+A cursor proves a syntactic occurrence, not reachability under a strategy. Run-derived resource
+availability belongs to execution and the later full-prefix/artifact work. AR-3A must not infer
+that every cursor is realizable, that every oracle payload type is inhabited, or that a
+structural prefix supplies concrete messages.
+
+Public values choose continuations. Hidden oracle payloads do not. Equal branch projections
+therefore give equal available signatures, but do not imply equal handlers or equal verifier
+results. A query can distinguish payloads when the declared interface permits it. Conversely,
+a non-faithful interface must not silently become a projection to its underlying representation.
+
+Signature extension uses disjoint query slots. Equal query/response types do not make two
+resources identical. Stable identity, sharing, aliasing, and ideal guarantees remain AR-4B;
+AR-3A's sum tags are routing, not a replacement resource schema.
+
+### Required AR-3A tests
+
+- A public branch selects distinct oracle message types and their matching interfaces.
+- A test actually attempts an unavailable query and fails; the same query is accepted after
+  the send. A comment beside a type equality is not a negative canary.
+- A terminal cursor retains the last sent message's query slot.
+- A derived query uses both an initial resource and a new same-signature message, with correct
+  answers under the explicit handler.
+- Distinct hidden representation data with equal interface behavior yield the same handler.
+- Cursor composition and restriction/rebuilding use PolyFun's actual cursor operations.
+- Non-default, independently chosen query and response universes elaborate.
+
+## AR-3B: authoring visibility and runtime visibility differ
+
+The prover may choose and remember concrete message values. The verifier authoring API must
+not receive those values at oracle nodes. Merely erasing payloads from the output path does
+not repair a verifier that already inspected them while running.
+
+Use PolyFun's local syntax and strategy substrate. The execution adapter may receive a
+concrete oracle payload to extend its handler, but must pass only the declared queries to the
+verifier continuation. Public messages, including query-dependent challenges, remain genuine
+structural branches. The verifier's terminal output family is branch-indexed, not indexed by
+hidden representation data.
+
+Input oracle behavior is supplied as an arbitrary pure `QueryImpl`, not restricted to an
+honest object. Prover messages are values of their declared message types, including any ideal
+slot refinements. Neither quantifier should be silently changed to simplify an interpreter.
+
+### Terminal effects and the schedule
+
+A terminal verifier computation must be able to query the final accumulated signature. Do not
+model the terminal statement as a function of the environment alone, and do not invent a dummy
+public round just to run a terminal query.
+
+The first strategy slice may place verifier query effects at verifier-owned public nodes and
+at terminal leaves. Its single-run semantics must delegate to the supported PolyFun runner,
+then execute the terminal action exactly once. This is not yet a general program with local
+binds at arbitrary inter-message points. If Sumcheck or a later client needs that richer
+programmatic surface, introduce it as an explicit extension with an order-preserving execution
+law; do not silently move its effects into raw strategy construction.
+
+A single-run erasure law must hold at the `OracleComp` level before an ambient handler is
+chosen. Test a stateful ambient handler so that reordered or duplicated queries are observable.
+Do not invoke `LawfulCommMonad` to hide a schedule mismatch. General sequential security,
+state restoration, world traces, terminal faults, and run-derived claim closing remain in
+their named later slices.
+
+### Required AR-3B tests
+
+- Run a mixed public/oracle tree with a query-dependent public challenge.
+- Preserve a nontrivial private prover output without giving it to verifier construction.
+- Query both the initial handler and sent messages, including after a final oracle send.
+- Reject a verifier continuation that tries to bind an opaque payload directly.
+- Use a non-faithful oracle interface, rather than only the default whole-object interface.
+- Check the exact ambient-query order and multiplicity using a stateful interpreter.
+- Exhibit the erasure equation for the actual exported executor, not a separate toy runner.
+
+## PR and validation boundary
+
+AR-3A is additive to current `main`. AR-3B is a separate dependent PR; neither changes legacy
+`OracleReduction`, dependency pins, source-policy exceptions, or the axiom baseline. Examples
+belong in `ArkLibTest`, not the production umbrella. Regenerate the umbrella mechanically.
+
+Each PR must report the exact validated head and distinguish static inspection, successful
+Lean compilation, acceptance tests, and the full validation/axiom gate. An open draft or a
+started CI job is not evidence that a formalization is complete. The records remain provisional
+until the Sumcheck and legacy-correspondence checkpoints exercise them.

--- a/docs/design/01c-access-execution-contract.md
+++ b/docs/design/01c-access-execution-contract.md
@@ -63,18 +63,28 @@ Input oracle behavior is supplied as an arbitrary pure `QueryImpl`, not restrict
 honest object. Prover messages are values of their declared message types, including any ideal
 slot refinements. Neither quantifier should be silently changed to simplify an interpreter.
 
-### Terminal effects and the schedule
+### Receive phases, terminal effects, and the schedule
 
-A terminal verifier computation must be able to query the final accumulated signature. Do not
-model the terminal statement as a function of the environment alone, and do not invent a dummy
-public round just to run a terminal query.
+AR-3A records access before a move. AR-3B distinguishes that boundary from the verifier's
+post-receive computation. At an oracle send, the adapter first receives the concrete message,
+then extends the handler, then runs the verifier's query computation. The verifier computation
+has the extended query signature but no concrete-message argument. This allows immediate
+oracle checks without either leaking the payload or postponing all checks to a later round.
 
-The first strategy slice may place verifier query effects at verifier-owned public nodes and
-at terminal leaves. Its single-run semantics must delegate to the supported PolyFun runner,
-then execute the terminal action exactly once. This is not yet a general program with local
-binds at arbitrary inter-message points. If Sumcheck or a later client needs that richer
-programmatic surface, introduce it as an explicit extension with an order-preserving execution
-law; do not silently move its effects into raw strategy construction.
+The single-run schedule follows PolyFun's ordinary paired runner:
+
+- at a public prover-owned node, verifier effects run after receiving the public value and
+  use the unchanged source signature;
+- at an oracle prover-owned node, verifier effects run after receipt and use the extended
+  source signature, without seeing the concrete payload;
+- at a verifier-owned public node, verifier effects run before emitting the chosen move;
+- at a terminal leaf, the accumulated source signature remains available and the terminal
+  action runs exactly once after the paired runner returns it.
+
+Do not invent a dummy public round to run a terminal query, and do not model the terminal
+statement as a function of the environment alone. Monadic continuation construction must not
+silently move effects across any of the boundaries above. A richer authoring language with
+arbitrary local binds would require its own order-preserving execution law.
 
 A single-run erasure law must hold at the `OracleComp` level before an ambient handler is
 chosen. Test a stateful ambient handler so that reordered or duplicated queries are observable.
@@ -82,11 +92,18 @@ Do not invoke `LawfulCommMonad` to hide a schedule mismatch. General sequential 
 state restoration, world traces, terminal faults, and run-derived claim closing remain in
 their named later slices.
 
+A projected public path and verifier result is not the full verifier observation history.
+In particular, it omits the order and answers of local oracle queries. Name that projection
+`publicResult`, not a complete verifier view or a trace artifact. Behavioral opacity means
+that equal interface answers give equal verifier continuations; it does not mean that all
+messages with the same structural branch must produce the same answers.
+
 ### Required AR-3B tests
 
 - Run a mixed public/oracle tree with a query-dependent public challenge.
 - Preserve a nontrivial private prover output without giving it to verifier construction.
 - Query both the initial handler and sent messages, including after a final oracle send.
+- Exercise effects immediately after both public and oracle receives.
 - Reject a verifier continuation that tries to bind an opaque payload directly.
 - Use a non-faithful oracle interface, rather than only the default whole-object interface.
 - Check the exact ambient-query order and multiplicity using a stateful interpreter.
@@ -97,6 +114,11 @@ their named later slices.
 AR-3A is additive to current `main`. AR-3B is a separate dependent PR; neither changes legacy
 `OracleReduction`, dependency pins, source-policy exceptions, or the axiom baseline. Examples
 belong in `ArkLibTest`, not the production umbrella. Regenerate the umbrella mechanically.
+
+The focused Interaction acceptance workflow compiles production and test modules on stacked
+feature-base PRs with the existing source-policy plugin and zero-warning budgets. It restores
+but does not publish the shared build cache and uses a read-only token. It supplements the
+full main-target validation/axiom gate; it does not replace it.
 
 Each PR must report the exact validated head and distinguish static inspection, successful
 Lean compilation, acceptance tests, and the full validation/axiom gate. An open draft or a

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -28,13 +28,16 @@ The other pages have narrower jobs:
 | [`01-foundations.md`](01-foundations.md) | Library ownership and the current cross-library contract | normative |
 | [`01a-foundation-pr-plan.md`](01a-foundation-pr-plan.md) | Live dependency gaps and ArkLib PR slices | operational |
 | [`01b-type-tree-rename-cutover.md`](01b-type-tree-rename-cutover.md) | Landed generic and ArkLib oracle names | normative |
+| [`01c-access-execution-contract.md`](01c-access-execution-contract.md) | Canonical prefix access, payload opacity, and receive/send/terminal effect boundaries | normative |
 | [`02-oracle-reduction-core.md`](02-oracle-reduction-core.md) | Claims, virtual oracles, closing, and composition | normative |
 | [`03-adversarial-oracle-execution.md`](03-adversarial-oracle-execution.md) | Worlds, traces, games, state restoration, extractors, and budgets | normative core, fluid periphery |
 | [`04-oracle-elimination-compiler.md`](04-oracle-elimination-compiler.md) | Compiler passes, backend capabilities, and guarantee transport | normative interfaces, fluid internals |
 | [`05-roadmap.md`](05-roadmap.md) | Implementation phases, gates, and parallel upstream work | operational |
 
 Read them in that order for a full architecture review. To start implementation, read `00`, the
-relevant ArkLib slice in `01a`, and then the owning normative page.
+relevant ArkLib slice in `01a`, and then the owning normative page. AR-3A and AR-3B additionally
+follow `01c`: access signatures are derived at real cursors including terminal leaves, and oracle
+payload opacity must hold in verifier authoring, not merely in a projected final result.
 
 ## Status vocabulary
 

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -43,6 +43,13 @@ Run `lake test` to build them; `./scripts/validate.sh` runs this target by defau
 test warnings, including admissions. Stage new tests so source linting and the trust inventory
 include them. Production modules must not import tests.
 
+Typed Interaction PRs also have a focused hosted check, including when stacked on a feature
+branch. It compiles all tracked `ArkLib/Interaction/` and `ArkLibTest/Interaction/` modules with
+the existing build-time source-policy plugin and rejects every warning in those modules,
+including admissions. This is early feedback, not a replacement for `lake test` or the full
+validation/axiom gate before merging to `main`. The semantic acceptance requirements live in
+[`../design/01c-access-execution-contract.md`](../design/01c-access-execution-contract.md).
+
 ### Lean source-policy checks
 
 ```bash
@@ -215,6 +222,11 @@ python3 -m pip install leanblueprint
   Pages/OIDC permission. It uploads timing artifacts consumed by the trusted
   [`../../.github/workflows/build-timing-report.yml`](../../.github/workflows/build-timing-report.yml)
   workflow, which computes the baseline comparison and posts the PR report.
+- [`../../.github/workflows/interaction.yml`](../../.github/workflows/interaction.yml)
+  provides focused compilation and zero-warning checks for typed Interaction production and
+  acceptance modules. It also runs on feature-base stacked PRs. Its read-only job restores,
+  but never saves, the shared `.lake` cache and does not retain checkout credentials. Passing
+  this check does not waive the full validation/axiom gate for the eventual `main` target.
 - [`../../.github/workflows/check-imports.yml`](../../.github/workflows/check-imports.yml)
   checks that `ArkLib.lean` matches the tracked source tree.
 - [`../../.github/workflows/docs-integrity.yml`](../../.github/workflows/docs-integrity.yml)


### PR DESCRIPTION
## Summary

Complete the AR-3A accumulated-access slice after #851, #852, and #853. Supersedes the initial unvalidated fork draft quangvdao/ArkLib#1. AR-3B is the separate dependent PR #862.

Base: `a527b514e029ecf9da40d66b5531a0707c686edc`. Implementation head: `6781ff233f845af7032ee221891c0fef79c1cac9`.

## Semantic center

Available queries are computed from the initial signature, the oracle-interface decoration, and a real PolyFun cursor. This is signature-level scoping, not resource identity or execution reachability.

- Reuse the existing `PFunctor` signature carrier through `OracleSpec.ofPFunctor` / `toPFunctor`; remove the initial draft's duplicate packed `AccessSpec`.
- `Access.extend` adds one disjoint query slot. `extendImpl`, `queryPrior`, and `queryLatest` provide concrete routing and proved interpretation equations.
- `TypeTree.accessAt` is defined for every structural cursor, including a terminal cursor after the final oracle send. No resource disappears merely because the residual tree is `done`.
- `accessAlong_comp` / `accessAt_comp` identify accumulation along actual cursor composition with accumulation from the restricted suffix interfaces.
- `accessAfter` derives terminal access from `Cursor.ofPath`; equal branch projections imply the same available signature, not equal handlers or query answers.
- `AccessDecoration.build` is only a derived node-local presentation. `restrict_build` proves that restricting it is rebuilding from the canonical accumulated access. An arbitrary decoration is not trusted as an authorization certificate.

The signature extension is marked `implicit_reducible` because dependent query-domain checking needs to see the upstream sum; it introduces no new semantics or linter suppression.

## Acceptance client

`ArkLibTest/Interaction/Oracle/TypeTree/AccessExample.lean` exercises:

1. a public Boolean selecting distinct Boolean / `Fin 3` oracle-message types;
2. actual rejected attempts to use an unsent query, paired with successful post-send constructions;
3. restriction/rebuilding at a real cursor;
4. terminal access immediately after an oracle send;
5. an initial source and new oracle with identical query/response types, routed to distinct slots;
6. a derived query returning `7 + 11 = 18` under its handler;
7. a non-faithful pair interface that exposes only the first coordinate, with handler invariance under changes to the hidden coordinate;
8. independently selected non-default query and response universes.

## Design repair and validation infrastructure

`docs/design/01c-access-execution-contract.md` refines AR-3A/AR-3B's acceptance boundary. It distinguishes signatures from handlers, syntactic cursors from reachable executions, pre-move access from post-receive query effects, and a public-result projection from a complete query-observation trace. The design index links it.

A focused `Interaction acceptance` workflow compiles the production and test modules even on feature-base stacked PRs, with the existing source-policy plugin and zero-warning budgets. It has a read-only token, does not retain checkout credentials, and restores but never publishes the shared cache. The wiki documents it. It supplements—not replaces—the full validation/axiom gate. The generated production umbrella is updated and passes the existing import check.

## Validation at `6781ff23`

Passed:

- [Interaction acceptance](https://github.com/Verified-zkEVM/ArkLib/actions/runs/34091556087): all Interaction production modules and acceptance clients compile; both zero-warning budgets pass, including admissions.
- [Check Imports](https://github.com/Verified-zkEVM/ArkLib/actions/runs/34091556108).
- [Docs Integrity](https://github.com/Verified-zkEVM/ArkLib/actions/runs/34091556039).

The [full repository CI](https://github.com/Verified-zkEVM/ArkLib/actions/runs/34091556078) is still running as of this update. The full validation wrapper and library-wide axiom gate are not yet reported as passed. Validation was performed through hosted CI, not a local Lean installation.

## Non-goals and reviewer map

No legacy `OracleReduction` changes, dependency bumps, resource schemas, claims, probability semantics, security statements, or unrestricted stateful composition are included. Stable identity and aliasing remain AR-4B; reachability and run-derived closing remain later execution/claim slices.

Review `Access.lean`, its acceptance client, then the semantic contract and focused workflow. #862 targets a mirror of this head so its diff contains only AR-3B.