### PR TITLE
feat(coding-theory): expose same-set MCA exceptional-set bridges

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -172,6 +172,7 @@ import ArkLib.Data.CodingTheory.ProximityGap.LineDecoding
 import ArkLib.Data.CodingTheory.ProximityGap.Separation
 import ArkLib.Data.CodingTheory.ProximityGenerator.AffineGenerator
 import ArkLib.Data.CodingTheory.ProximityGenerator.Basic
+import ArkLib.Data.CodingTheory.ProximityGenerator.ExceptionalSet
 import ArkLib.Data.CodingTheory.ProximityGenerator.MCAGenerator
 import ArkLib.Data.CodingTheory.ProximityGenerator.PolynomialGenerator
 import ArkLib.Data.CodingTheory.ProximityGenerator.TensorGenerator

--- a/ArkLib/Data/CodingTheory/ProximityGenerator/Basic.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGenerator/Basic.lean
@@ -43,6 +43,8 @@ The correspondence to [BCGM25]'s numbered statements is in
 * [Guruswami, V., Rudra, A., Sudan M., *Essential Coding Theory*, online copy][GRS25]
 * [Bordage, S., Chiesa, A., Guan, Z., Manzur, I., *All Polynomial Generators Preserve Distance
     with Mutual Correlated Agreement*][BCGM25]
+* [Ben-Sasson, E., Carmon, D., Haböck, U., Kopparty, S., Saraf, S.,
+    *On Proximity Gaps for Reed--Solomon Codes*][BCHKS25], Theorem 4.6.
 -/
 
 section
@@ -118,6 +120,35 @@ def IsMCA {S : Type} [Nonempty S] [Fintype S] {A : Type} [AddCommMonoid A] [Modu
   ∃ (T : Finset ι), (T.card : ℝ) ≥ (Fintype.card ι) * (1 - δ) ∧
   projectedWord v T ∈ projectedCodeSubmod MC T ∧
   ∃ j : ℓ, projectedWord (U j) T ∉ projectedCodeSubmod MC T
+
+/-- Outside the MCA error event, every sufficiently large agreement set of the generated word
+admits codeword extensions of all input words on that same set. The extensions may depend on
+the agreement set. This is the simultaneous-extension formulation used in [BCHKS25, Theorem 4.6]. -/
+theorem not_isMCA_iff_forall_exists_codewords
+    {S : Type} [Nonempty S] [Fintype S] {A : Type} [AddCommMonoid A] [Module F A]
+    (G : Generator S ℓ F) (MC : ModuleCode ι F A) (x : S) (U : ℓ → ι → A) (δ : ℝ) :
+    ¬ IsMCA G MC x U δ ↔
+      ∀ T : Finset ι, (T.card : ℝ) ≥ Fintype.card ι * (1 - δ) →
+        projectedWord (fun i => ∑ j, G x j • U j i) T ∈ projectedCodeSubmod MC T →
+        ∃ p : ℓ → MC, ∀ j i, i ∈ T → (p j).val i = U j i := by
+  classical
+  constructor
+  · intro h T hT hv
+    have hU : ∀ j, projectedWord (U j) T ∈ projectedCodeSubmod MC T := by
+      intro j
+      by_contra hj
+      exact h ⟨T, hT, hv, j, hj⟩
+    choose p hp heq using fun j => (mem_projectedCodeSubmod_iff MC T _).mp (hU j)
+    refine ⟨fun j => ⟨p j, hp j⟩, ?_⟩
+    intro j i hi
+    exact (congrFun (heq j) ⟨i, hi⟩).symm
+  · intro h ⟨T, hT, hv, j, hj⟩
+    obtain ⟨p, hp⟩ := h T hT hv
+    apply hj
+    apply (mem_projectedCodeSubmod_iff MC T _).mpr
+    refine ⟨p j, (p j).property, ?_⟩
+    funext i
+    exact (hp j i i.property).symm
 
 omit [Fintype ι] in
 /-- Over the alphabet `A := F`, the linear combination in `IsMCA` is the matrix-vector
@@ -304,6 +335,24 @@ abbrev AffineSpaceGenerator (F : Type) [Field F] (ℓ : ℕ) : Generator (Fin �
 abbrev univariatePowersGenerator (F : Type) [Field F] (k : ℕ) :
     Generator F (Fin (k + 1)) F :=
   fun x i => x ^ (i : ℕ)
+
+/-- The degree-one powers curve is the affine line generator. -/
+theorem univariatePowersGenerator_one_eq_affineLineGenerator :
+    univariatePowersGenerator F 1 = AffineLineGenerator F := by
+  funext x i
+  fin_cases i <;> simp [univariatePowersGenerator, AffineLineGenerator]
+
+/-- The same-agreement-set interpretation of MCA for a polynomial curve of arbitrary degree.
+This is a statement bridge for [BCHKS25, Theorem 4.6], independent of its exceptional-set bound. -/
+theorem not_isMCA_univariatePowersGenerator_iff [Fintype F]
+    {A : Type} [AddCommMonoid A] [Module F A]
+    (M : ℕ) (MC : ModuleCode ι F A) (z : F) (U : Fin (M + 1) → ι → A) (δ : ℝ) :
+    ¬ IsMCA (univariatePowersGenerator F M) MC z U δ ↔
+      ∀ T : Finset ι, (T.card : ℝ) ≥ Fintype.card ι * (1 - δ) →
+        projectedWord (fun i => ∑ j : Fin (M + 1), z ^ (j : ℕ) • U j i) T ∈
+          projectedCodeSubmod MC T →
+        ∃ p : Fin (M + 1) → MC, ∀ j i, i ∈ T → (p j).val i = U j i :=
+  not_isMCA_iff_forall_exists_codewords (univariatePowersGenerator F M) MC z U δ
 
 end CoreDefinitions
 

--- a/ArkLib/Data/CodingTheory/ProximityGenerator/ExceptionalSet.lean
+++ b/ArkLib/Data/CodingTheory/ProximityGenerator/ExceptionalSet.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.CodingTheory.ProximityGenerator.Basic
+
+/-!
+# Exceptional sets for mutual correlated agreement
+
+Convert a uniform bound on the number of bad challenges into an MCA error bound. The exceptional
+set may depend on the input words, but it must work simultaneously for every agreement set. This
+is the quantifier order needed to consume [BCHKS25, Theorem 4.6]. These bridges do not assert the
+Reed–Solomon exceptional-set bound itself.
+
+## References
+
+* [Ben-Sasson, E., Carmon, D., Haböck, U., Kopparty, S., Saraf, S.,
+    *On Proximity Gaps for Reed--Solomon Codes*][BCHKS25], Theorem 4.6.
+-/
+
+namespace CoreDefinitions
+
+open LinearCode
+open scoped ProbabilityTheory
+
+variable {ι F ℓ S A : Type} [Fintype ι] [Field F] [Fintype ℓ]
+  [Nonempty S] [Fintype S] [AddCommMonoid A] [Module F A]
+
+/-- An exceptional set of at most `B` seeds for each input family bounds the worst-case MCA
+error by `B / |S|`. A single exceptional set must cover all bad agreement sets for that family. -/
+theorem mcaError_le_of_exists_exceptional_set
+    (G : Generator S ℓ F) (MC : ModuleCode ι F A) (δ B : ℝ)
+    (h : ∀ U : ℓ → ι → A, ∃ E : Finset S, (E.card : ℝ) ≤ B ∧
+      ∀ x, x ∉ E → ¬ IsMCA G MC x U δ) :
+    mcaError G MC δ ≤ ENNReal.ofReal (B / Fintype.card S) := by
+  classical
+  refine iSup_le fun U => ?_
+  obtain ⟨E, hE, hgood⟩ := h U
+  rw [Probability.prob_uniform_eq_ofReal]
+  apply ENNReal.ofReal_le_ofReal
+  apply div_le_div_of_nonneg_right _ (Nat.cast_nonneg _)
+  refine le_trans (Nat.cast_le.mpr (Finset.card_le_card ?_)) hE
+  intro x hx
+  by_contra hxE
+  exact hgood x hxE (Finset.mem_filter.mp hx).2
+
+/-- Same-set simultaneous extension outside an exceptional set implies the MCA error bound.
+The codeword extensions are chosen after the agreement set, not uniformly across all sets. -/
+theorem mcaError_le_of_exists_exceptional_set_codewords
+    (G : Generator S ℓ F) (MC : ModuleCode ι F A) (δ B : ℝ)
+    (h : ∀ U : ℓ → ι → A, ∃ E : Finset S, (E.card : ℝ) ≤ B ∧
+      ∀ x, x ∉ E → ∀ T : Finset ι,
+        (T.card : ℝ) ≥ Fintype.card ι * (1 - δ) →
+        projectedWord (fun i => ∑ j, G x j • U j i) T ∈ projectedCodeSubmod MC T →
+        ∃ p : ℓ → MC, ∀ j i, i ∈ T → (p j).val i = U j i) :
+    mcaError G MC δ ≤ ENNReal.ofReal (B / Fintype.card S) := by
+  apply mcaError_le_of_exists_exceptional_set
+  intro U
+  obtain ⟨E, hE, hgood⟩ := h U
+  exact ⟨E, hE, fun x hx =>
+    (not_isMCA_iff_forall_exists_codewords G MC x U δ).mpr (hgood x hx)⟩
+
+end CoreDefinitions

--- a/ArkLibTest/Data/CodingTheory/ProximityGenerator/Basic.lean
+++ b/ArkLibTest/Data/CodingTheory/ProximityGenerator/Basic.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.CodingTheory.ProximityGenerator.Basic
+
+/-!
+# Same-set MCA extension clients
+
+The generic bridge works with a module alphabet over an infinite field. The curve client checks
+the constant-curve endpoint, where the MCA error event must be empty at every real radius.
+-/
+
+open CoreDefinitions LinearCode
+
+-- No finite-field assumption: the seed is finite, while the alphabet is the module `ℚ²`.
+example {ι : Type} [Fintype ι] (MC : ModuleCode ι ℚ (Fin 2 → ℚ))
+    (G : Generator (Fin 1) (Fin 3) ℚ) (U : Fin 3 → ι → Fin 2 → ℚ) (δ : ℝ)
+    (h : ¬ IsMCA G MC 0 U δ) (T : Finset ι)
+    (hT : (T.card : ℝ) ≥ Fintype.card ι * (1 - δ))
+    (hv : projectedWord (fun i => ∑ j, G 0 j • U j i) T ∈ projectedCodeSubmod MC T) :
+    ∃ p : Fin 3 → MC, ∀ j i, i ∈ T → (p j).val i = U j i :=
+  (not_isMCA_iff_forall_exists_codewords G MC 0 U δ).mp h T hT hv
+
+example {ι F : Type} [Fintype ι] [Field F] [Fintype F]
+    (MC : ModuleCode ι F F) (z : F) (U : Fin 1 → ι → F) (δ : ℝ) :
+    ¬ IsMCA (univariatePowersGenerator F 0) MC z U δ := by
+  rintro ⟨T, _, hv, j, hj⟩
+  apply hj
+  have hj0 : j = 0 := by omega
+  simpa [univariatePowersGenerator, Fin.sum_univ_one, hj0] using hv
+
+-- At challenge zero, the generated zero word extends but the second component does not.
+example {F : Type} [Field F] [Fintype F] :
+    IsMCA (univariatePowersGenerator F 1) (⊥ : ModuleCode (Fin 1) F F)
+      0 ![0, 1] 0 := by
+  refine ⟨Finset.univ, by norm_num, ?_, 1, ?_⟩
+  · apply (mem_projectedCodeSubmod_iff _ _ _).mpr
+    refine ⟨0, Submodule.zero_mem _, ?_⟩
+    ext i
+    simp [projectedWord, univariatePowersGenerator, Fin.sum_univ_two]
+  · intro h
+    obtain ⟨p, hp, heq⟩ := (mem_projectedCodeSubmod_iff _ _ _).mp h
+    have hp0 : p = 0 := hp
+    have heq0 := congrFun heq ⟨0, Finset.mem_univ _⟩
+    simp [hp0, projectedWord] at heq0
+
+-- A degree-one curve can be passed directly to an affine-line consumer.
+example {ι F : Type} [Fintype ι] [Field F] [Fintype F]
+    (MC : ModuleCode ι F F) (z : F) (U : Fin 2 → ι → F) (δ : ℝ)
+    (h : ¬ IsMCA (AffineLineGenerator F) MC z U δ) :
+    ¬ IsMCA (univariatePowersGenerator F 1) MC z U δ := by
+  rwa [univariatePowersGenerator_one_eq_affineLineGenerator]

--- a/ArkLibTest/Data/CodingTheory/ProximityGenerator/ExceptionalSet.lean
+++ b/ArkLibTest/Data/CodingTheory/ProximityGenerator/ExceptionalSet.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.CodingTheory.ProximityGenerator.ExceptionalSet
+
+/-!
+# Exceptional-set consumers
+
+An empty exceptional set gives zero error for the full code, including module alphabets and
+arbitrary real radii. Taking every seed as exceptional gives the universal probability bound.
+-/
+
+open CoreDefinitions LinearCode
+
+example {ι F ℓ S A : Type} [Fintype ι] [Field F] [Fintype ℓ]
+    [Nonempty S] [Fintype S] [AddCommMonoid A] [Module F A]
+    (G : Generator S ℓ F) (δ : ℝ) :
+    mcaError G (⊤ : ModuleCode ι F A) δ = 0 := by
+  apply le_antisymm _ bot_le
+  have h := mcaError_le_of_exists_exceptional_set_codewords G
+    (⊤ : ModuleCode ι F A) δ 0 (fun U => ?_)
+  · simpa using h
+  · refine ⟨∅, by simp, fun _ _ _ _ _ => ?_⟩
+    exact ⟨fun j => ⟨U j, Submodule.mem_top⟩, fun _ _ _ => rfl⟩
+
+example {ι F ℓ S A : Type} [Fintype ι] [Field F] [Fintype ℓ]
+    [Nonempty S] [Fintype S] [AddCommMonoid A] [Module F A]
+    (G : Generator S ℓ F) (MC : ModuleCode ι F A) (δ : ℝ) :
+    mcaError G MC δ ≤ 1 := by
+  classical
+  have h := mcaError_le_of_exists_exceptional_set G MC δ (Fintype.card S)
+    (fun _ => ⟨Finset.univ, by simp, fun x hx => False.elim (hx (Finset.mem_univ x))⟩)
+  simpa [Fintype.card_ne_zero] using h


### PR DESCRIPTION
## Summary

Connect the canonical MCA bad event to simultaneous codeword extension on the **same** agreement
set, and convert finite exceptional-set bounds into `mcaError` bounds. This is a statement-level
prerequisite for BCHKS25 Theorem 4.6 and #859; it does not prove the Reed–Solomon exception bound.

The key quantifier order is:

```text
for every input family U,
  choose one exceptional seed set E;
  for every seed outside E and every qualifying agreement set T,
    choose codewords extending every component of U on that same T.
```

The codewords may depend on `T`. The exceptional set may depend on `U`, but not on `T`.

## Motivation and compatibility

`IsMCA` already expresses the bad event, and `mcaError` already takes its worst-case probability.
The new lemmas expose the paper's simultaneous-extension formulation without introducing another
MCA predicate or changing either existing definition. They work for module alphabets and arbitrary
real radii. Only the seed type must be finite and nonempty; the coefficient field need not be finite
unless it is itself the seed type.

For an exceptional-set cardinality bound `B`, the conclusion is
`mcaError G MC δ ≤ ENNReal.ofReal (B / Fintype.card S)`.

The existing powers generator is reused. Its degree-one specialization is proved equal to the
affine-line generator, in the correct `(1,z)` order.

Source: [BCHKS25, Theorem 4.6](https://eprint.iacr.org/2025/2055).

## Reviewer map

| File | Change |
|---|---|
| `ArkLib/Data/CodingTheory/ProximityGenerator/Basic.lean` | Generic same-set equivalence, polynomial-curve specialization, degree-one generator identity. |
| `ArkLib/Data/CodingTheory/ProximityGenerator/ExceptionalSet.lean` | Cardinality-to-error bridge and same-set-codeword consumer. |
| `ArkLibTest/Data/CodingTheory/ProximityGenerator/Basic.lean` | Infinite-field module alphabet, constant curve, positive bad event, and affine rewriting clients. |
| `ArkLibTest/Data/CodingTheory/ProximityGenerator/ExceptionalSet.lean` | Empty and full exceptional-set consumers. |
| `ArkLib.lean` | Generated import for the new production module. |

## Validation and trust

At `272fe77c77fc0ae18506fb245983af8c01b23ef0`, the complete `./scripts/validate.sh --axioms` passes:
library build, acceptance tests, warning budgets, source policy and its fixtures, compiled runtime
checks, generated imports, timing fixtures, documentation checks, and the axiom/sorry regression gate.
Targeted compilation and independent source review also pass. GitHub CI is pending at creation.
All five new public declarations have exactly `propext`, `Classical.choice`, and `Quot.sound` in
their axiom footprints. No new admissions or additional trusted axioms are introduced.

## Scope

Additive API only. No dependency updates, existing proof replacements, or old PR closures.
The numerical exceptional-set bound, interpolation, factorization, and rigidity proofs remain
separate work. #859 stays open.

## Diff metadata

Base: `a527b514e029ecf9da40d66b5531a0707c686edc` (`main`).
Head: `272fe77c77fc0ae18506fb245983af8c01b23ef0` (`quang/bchks-curve-contract`).
One commit; five files; 206 insertions and no deletions.
