### PR TITLE
feat(polynomial): factor over fraction fields with explicit content

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -259,6 +259,9 @@ import ArkLib.Data.Polynomial.Bivariate
 import ArkLib.Data.Polynomial.ClassicalWronskian
 import ArkLib.Data.Polynomial.FoldedWronskian
 import ArkLib.Data.Polynomial.FoldingPolynomial
+import ArkLib.Data.Polynomial.FractionFieldExpand
+import ArkLib.Data.Polynomial.FractionFieldFactorization
+import ArkLib.Data.Polynomial.FractionFieldRoots
 import ArkLib.Data.Polynomial.Indicator
 import ArkLib.Data.Polynomial.Interface
 import ArkLib.Data.Polynomial.Prelims

--- a/ArkLib/Data/Polynomial/FractionFieldExpand.lean
+++ b/ArkLib/Data/Polynomial/FractionFieldExpand.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.FractionFieldRoots
+
+/-!
+# Frobenius expansion over a coefficient domain
+
+An irreducible fraction-field polynomial descends to a separable factor by contracting exponents.
+When the starting coefficients lie in a domain, the contracted coefficients still lie there.
+This keeps the polynomial identity and its degree accounting in the original coefficient ring.
+It does not factor content or provide bounds for specialization exceptions.
+
+## References
+
+* [Ben-Sasson, E., Carmon, D., Haböck, U., Kopparty, S., Saraf, S.,
+  *On Proximity Gaps for Reed--Solomon Codes*][BCHKS25], Section 3.2.
+-/
+
+namespace Polynomial
+
+variable {R K : Type*} [CommRing R] [Field K]
+  [Algebra R K] [IsFractionRing R K]
+
+/-- Separating a fraction-field irreducible by Frobenius contraction does not introduce
+denominators into its coefficients. The expansion identity and degree equality hold over `R`.
+The irreducibility premise deliberately applies after mapping, excluding pure content factors. -/
+theorem exists_fractionField_separable_expand (p : ℕ) [CharP K p] (hp : p ≠ 0)
+    {f : R[X]} (hf : Irreducible (f.map (algebraMap R K))) :
+    ∃ (n : ℕ) (g : R[X]), Irreducible (g.map (algebraMap R K)) ∧
+      (g.map (algebraMap R K)).Separable ∧
+      expand R (p ^ n) g = f ∧ g.natDegree * p ^ n = f.natDegree := by
+  obtain ⟨n, g, hg, hgf⟩ := exists_separable_of_irreducible p hf hp
+  have hpow : p ^ n ≠ 0 := pow_ne_zero n hp
+  have hmap : (contract (p ^ n) f).map (algebraMap R K) = g := by
+    rw [map_contract hpow, ← hgf, contract_expand (p ^ n) hpow]
+  have hexpand : expand R (p ^ n) (contract (p ^ n) f) = f := by
+    apply Polynomial.map_injective (algebraMap R K) (IsFractionRing.injective R K)
+    rw [map_expand, hmap, hgf]
+  have hgi : Irreducible g := by
+    let := isLocalHom_expand K (Nat.pos_of_ne_zero hpow)
+    exact Irreducible.of_map (by rwa [hgf])
+  exact ⟨n, contract (p ^ n) f, hmap ▸ hgi, hmap ▸ hg, hexpand,
+    by rw [← natDegree_expand, hexpand]⟩
+
+end Polynomial

--- a/ArkLib/Data/Polynomial/FractionFieldFactorization.lean
+++ b/ArkLib/Data/Polynomial/FractionFieldFactorization.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.FractionFieldExpand
+import Mathlib.RingTheory.Polynomial.UniqueFactorization
+
+/-!
+# Content-aware fraction-field factorization
+
+Nonconstant factors are represented by a single list of polynomial/exponent pairs. Repeated
+entries retain factor multiplicities, and all degree-zero factors are accumulated into content.
+Separability is asserted over the fraction field, not as a Bezout identity over the coefficient
+ring. This algebraic factorization does not bound specialization exceptions.
+
+## References
+
+* [Ben-Sasson, E., Carmon, D., Haböck, U., Kopparty, S., Saraf, S.,
+  *On Proximity Gaps for Reed--Solomon Codes*][BCHKS25], Section 3.2.
+-/
+
+namespace Polynomial
+
+variable {R K : Type*} [CommRing R] [IsDomain R] [UniqueFactorizationMonoid R]
+  [Field K] [Algebra R K] [IsFractionRing R K]
+
+/-- Every nonzero polynomial is nonzero content times a list of Frobenius expansions of
+positive-degree factors that are irreducible and separable over the fraction field.
+Repeated list entries encode multiplicity independently of their Frobenius exponents. -/
+theorem exists_content_mul_fractionField_separable_factors (p : ℕ) [CharP K p]
+    (hp : p ≠ 0) (f : R[X]) (hf : f ≠ 0) :
+    ∃ (c : R) (s : List (R[X] × ℕ)), c ≠ 0 ∧
+      (∀ t ∈ s, 0 < t.1.natDegree ∧ Irreducible t.1 ∧
+        Irreducible (t.1.map (algebraMap R K)) ∧
+        (t.1.map (algebraMap R K)).Separable) ∧
+      f = C c * (s.map (fun t ↦ expand R (p ^ t.2) t.1)).prod ∧
+      f.natDegree = (s.map (fun t ↦ t.1.natDegree * p ^ t.2)).sum := by
+  classical
+  induction f using WfDvdMonoid.induction_on_irreducible with
+  | zero => exact (hf rfl).elim
+  | unit u hu =>
+    obtain ⟨c, hc, rfl⟩ := Polynomial.isUnit_iff.mp hu
+    exact ⟨c, [], hc.ne_zero, by simp, by simp⟩
+  | mul a i ha hi ih =>
+    obtain ⟨c, s, hc, hs, hprod, hsum⟩ := ih ha
+    by_cases hdeg : i.natDegree = 0
+    · have hiC : i = C (i.coeff 0) := eq_C_of_natDegree_eq_zero hdeg
+      have hi0 : i.coeff 0 ≠ 0 := by
+        intro h
+        exact hi.ne_zero (by simpa [h] using hiC)
+      refine ⟨i.coeff 0 * c, s, mul_ne_zero hi0 hc, hs, ?_, ?_⟩
+      · rw [hiC, hprod, C_mul, mul_assoc]
+        simp
+      · rw [natDegree_mul hi.ne_zero ha, hdeg, zero_add, hsum]
+    · have hprim := hi.isPrimitive hdeg
+      have hmap := (hprim.irreducible_iff_irreducible_map_fraction_map (K := K)).mp hi
+      obtain ⟨n, g, hgi, hgs, hgi_eq, hdegree⟩ :=
+        exists_fractionField_separable_expand p hp hmap
+      have hgiR : Irreducible g := by
+        let := isLocalHom_expand R (Nat.pos_of_ne_zero (pow_ne_zero n hp))
+        exact Irreducible.of_map (by rwa [hgi_eq])
+      have hgpos : 0 < g.natDegree := by
+        by_contra h
+        have hz : g.natDegree = 0 := Nat.eq_zero_of_not_pos h
+        exact hdeg (by simpa [hz] using hdegree.symm)
+      refine ⟨c, (g, n) :: s, hc, ?_, ?_, ?_⟩
+      · intro t ht
+        rcases List.mem_cons.mp ht with rfl | ht
+        · exact ⟨hgpos, hgiR, hgi, hgs⟩
+        · exact hs t ht
+      · simp only [List.map_cons, List.prod_cons]
+        rw [hgi_eq, hprod]
+        ring
+      · simp only [List.map_cons, List.sum_cons]
+        rw [natDegree_mul hi.ne_zero ha, hdegree, hsum]
+
+end Polynomial

--- a/ArkLib/Data/Polynomial/FractionFieldRoots.lean
+++ b/ArkLib/Data/Polynomial/FractionFieldRoots.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import Mathlib.FieldTheory.Separable
+import Mathlib.RingTheory.Polynomial.GaussLemma
+
+/-!
+# Polynomial roots over a fraction field
+
+Separability for a polynomial over a domain is stronger than separability after passage to its
+fraction field. The latter is the relevant condition for function-field factorization in BCHKS25.
+These lemmas keep that passage explicit. They also isolate the rational root of a linear factor;
+they do not assert that this rational root is a polynomial or bound its degrees.
+
+## References
+
+* [Ben-Sasson, E., Carmon, D., Haböck, U., Kopparty, S., Saraf, S.,
+  *On Proximity Gaps for Reed--Solomon Codes*][BCHKS25], Section 3.2.
+-/
+
+namespace Polynomial
+
+variable {R K : Type*} [CommRing R] [IsDomain R] [Field K]
+  [Algebra R K] [IsFractionRing R K]
+
+omit [IsDomain R] in
+/-- For a factor irreducible over the fraction field, separability is exactly nonvanishing of
+the original derivative. No perfectness or characteristic restriction is needed. -/
+theorem separable_map_fractionField_iff {p : R[X]}
+    (hp : Irreducible (p.map (algebraMap R K))) :
+    (p.map (algebraMap R K)).Separable ↔ p.derivative ≠ 0 := by
+  rw [separable_iff_derivative_ne_zero hp, derivative_map]
+  exact not_congr (Polynomial.map_eq_zero_iff (IsFractionRing.injective R K))
+
+/-- A primitive irreducible factor is separable over the fraction field precisely when its
+derivative is nonzero. Primitivity explicitly excludes nonunit constant content factors. -/
+theorem IsPrimitive.separable_map_fractionField_iff [IsGCDMonoid R] {p : R[X]}
+    (hprim : p.IsPrimitive) (hp : Irreducible p) :
+    (p.map (algebraMap R K)).Separable ↔ p.derivative ≠ 0 := by
+  exact Polynomial.separable_map_fractionField_iff
+    ((hprim.irreducible_iff_irreducible_map_fraction_map (K := K)).mp hp)
+
+omit [IsDomain R] in
+/-- A linear factor has a unique fraction-field root when its leading coefficient is nonzero.
+The denominator is retained: polynomiality requires an additional divisibility argument. -/
+theorem eval₂_linear_eq_zero_iff (a b : R) (ha : a ≠ 0) (y : K) :
+    (C a * X + C b).eval₂ (algebraMap R K) y = 0 ↔
+      y = -algebraMap R K b / algebraMap R K a := by
+  have ha' : algebraMap R K a ≠ 0 :=
+    (map_ne_zero_iff _ (IsFractionRing.injective R K)).mpr ha
+  simp only [eval₂_add, eval₂_mul, eval₂_C, eval₂_X]
+  rw [eq_div_iff ha']
+  constructor <;> intro h <;> linear_combination h
+
+omit [IsDomain R] in
+/-- A rational root coming from the coefficient domain is characterized by a denominator-cleared
+equation in that domain. This is the algebraic obligation for extracting a polynomial family. -/
+theorem eval₂_linear_algebraMap_eq_zero_iff (a b c : R) :
+    (C a * X + C b).eval₂ (algebraMap R K) (algebraMap R K c) = 0 ↔
+      a * c + b = 0 := by
+  simpa only [eval₂_add, eval₂_mul, eval₂_C, eval₂_X, ← map_mul, ← map_add] using
+    (map_eq_zero_iff (algebraMap R K) (IsFractionRing.injective R K)
+      (x := a * c + b))
+
+omit [IsDomain R] in
+/-- A linear factor has a root in the coefficient domain exactly when its leading coefficient
+divides its constant coefficient. This includes the degenerate zero-leading-coefficient case. -/
+theorem exists_eval₂_linear_algebraMap_eq_zero_iff (a b : R) :
+    (∃ c : R, (C a * X + C b).eval₂ (algebraMap R K) (algebraMap R K c) = 0) ↔
+      a ∣ b := by
+  simp only [eval₂_linear_algebraMap_eq_zero_iff]
+  constructor
+  · rintro ⟨c, hc⟩
+    refine ⟨-c, ?_⟩
+    rw [mul_neg]
+    exact eq_neg_of_add_eq_zero_left (by simpa [add_comm] using hc)
+  · rintro ⟨c, rfl⟩
+    exact ⟨-c, by simp⟩
+
+end Polynomial

--- a/ArkLibTest/Data/Polynomial/FractionFieldExpand.lean
+++ b/ArkLibTest/Data/Polynomial/FractionFieldExpand.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.FractionFieldExpand
+import Mathlib.Algebra.Field.ZMod
+
+/-! Characteristic-two acceptance for Frobenius descent over two polynomial coefficient axes. -/
+
+open Polynomial
+
+example {f : Polynomial (Polynomial (Polynomial (ZMod 2)))}
+    (hf : Irreducible (f.map
+      (algebraMap _ (FractionRing (Polynomial (Polynomial (ZMod 2))))))) :
+    ∃ (n : ℕ) (g : Polynomial (Polynomial (Polynomial (ZMod 2)))),
+      Irreducible (g.map (algebraMap _ (FractionRing (Polynomial (Polynomial (ZMod 2)))))) ∧
+      (g.map (algebraMap _ (FractionRing (Polynomial (Polynomial (ZMod 2)))))).Separable ∧
+      expand _ (2 ^ n) g = f ∧ g.natDegree * 2 ^ n = f.natDegree := by
+  exact exists_fractionField_separable_expand
+    (K := FractionRing (Polynomial (Polynomial (ZMod 2)))) 2 (by decide) hf
+
+#print axioms Polynomial.exists_fractionField_separable_expand

--- a/ArkLibTest/Data/Polynomial/FractionFieldFactorization.lean
+++ b/ArkLibTest/Data/Polynomial/FractionFieldFactorization.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.FractionFieldFactorization
+import Mathlib.Algebra.Field.ZMod
+
+/-! The content-aware decomposition applies over `F₂[Z][X]` in arbitrary outer degree. -/
+
+open Polynomial
+
+example (f : Polynomial (Polynomial (Polynomial (ZMod 2)))) (hf : f ≠ 0) :
+    ∃ (c : Polynomial (Polynomial (ZMod 2)))
+      (s : List (Polynomial (Polynomial (Polynomial (ZMod 2))) × ℕ)), c ≠ 0 ∧
+      (∀ t ∈ s, 0 < t.1.natDegree ∧ Irreducible t.1 ∧
+        Irreducible (t.1.map
+          (algebraMap _ (FractionRing (Polynomial (Polynomial (ZMod 2)))))) ∧
+        (t.1.map (algebraMap _ (FractionRing (Polynomial (Polynomial (ZMod 2)))))).Separable) ∧
+      f = C c * (s.map (fun t ↦ expand _ (2 ^ t.2) t.1)).prod ∧
+      f.natDegree = (s.map (fun t ↦ t.1.natDegree * 2 ^ t.2)).sum := by
+  exact exists_content_mul_fractionField_separable_factors
+    (K := FractionRing (Polynomial (Polynomial (ZMod 2)))) 2 (by decide) f hf
+
+#print axioms Polynomial.exists_content_mul_fractionField_separable_factors

--- a/ArkLibTest/Data/Polynomial/FractionFieldRoots.lean
+++ b/ArkLibTest/Data/Polynomial/FractionFieldRoots.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.FractionFieldRoots
+import Mathlib.Algebra.Field.ZMod
+
+/-! Acceptance checks for rational linear roots, including characteristic two and two coefficient
+axes as used by the function-field argument. -/
+
+open Polynomial
+
+-- A nonconstant denominator need not give a polynomial root: `X * Y + 1` over `ℚ[X]`.
+example : ¬ ∃ c : Polynomial ℚ,
+    (C (X : Polynomial ℚ) * X + C 1).eval₂
+      (algebraMap (Polynomial ℚ) (FractionRing (Polynomial ℚ)))
+      (algebraMap (Polynomial ℚ) (FractionRing (Polynomial ℚ)) c) = 0 := by
+  rw [exists_eval₂_linear_algebraMap_eq_zero_iff]
+  rw [X_dvd_iff]
+  simp
+
+-- The same domain-root criterion works over `F₂[Z][X]`, with no characteristic bound.
+example (a b : Polynomial (Polynomial (ZMod 2))) :
+    (∃ c : Polynomial (Polynomial (ZMod 2)),
+      (C a * X + C b).eval₂
+        (algebraMap _ (FractionRing (Polynomial (Polynomial (ZMod 2)))))
+        (algebraMap _ (FractionRing (Polynomial (Polynomial (ZMod 2)))) c) = 0) ↔
+      a ∣ b :=
+  exists_eval₂_linear_algebraMap_eq_zero_iff
+    (K := FractionRing (Polynomial (Polynomial (ZMod 2)))) a b
+
+#print axioms Polynomial.separable_map_fractionField_iff
+#print axioms Polynomial.IsPrimitive.separable_map_fractionField_iff
+#print axioms Polynomial.eval₂_linear_eq_zero_iff
+#print axioms Polynomial.eval₂_linear_algebraMap_eq_zero_iff
+#print axioms Polynomial.exists_eval₂_linear_algebraMap_eq_zero_iff


### PR DESCRIPTION
## Summary

Adds content-aware polynomial factorization over a fraction field for the BCHKS25 development in #859. This is an independent algebraic prerequisite, based on `main`; it does not depend on #865.

For a nonzero polynomial over a UFD in positive characteristic, the new theorem gives nonzero coefficient-ring content and a list of positive-degree irreducible, fraction-field-separable factors with Frobenius exponents. The product identity and exact degree sum hold in the original coefficient ring. Repeated factors remain repeated list entries.

## Audited surface

- Fork/merge base: `a527b514e029ecf9da40d66b5531a0707c686edc`.
- Target `main` at publication: `e029c9f5d4e06e30f3a44079146ecbe58d413e0c` (the unrelated Hachi #847 landed while this slice was being validated).
- Head: `4e413e3ad9f5373a1223ca4dbdd08d60471d5e4c`.
- One commit; seven files; 302 insertions, no deletions.
- Mathematical reference: [BCHKS25, Section 3.2](https://eprint.iacr.org/2025/2055).

## Motivation and mathematical boundaries

Function-field factorization must distinguish separability over the fraction field from the stronger coefficient-ring separability condition. It must also retain constant content, repeated factors, and inseparable Frobenius powers. These distinctions matter when later counting specialization exceptions.

The linear-root helpers deliberately retain the denominator: a fraction-field root is not automatically a polynomial root. A separate theorem characterizes a coefficient-ring root by divisibility of the constant coefficient by the leading coefficient, including a zero leading coefficient.

No existing definitions or proofs change. In particular, this PR does not weaken the existing Hensel hypotheses, prove specialization bounds, extract polynomial families, or establish the BCHKS proximity-gap theorem. It contains no capacity-development extraction.

## Reviewer map

1. `ArkLib/Data/Polynomial/FractionFieldRoots.lean` (83 lines): fraction-field separability criteria and rational versus coefficient-ring linear roots.
2. `ArkLib/Data/Polynomial/FractionFieldExpand.lean` (49 lines): Frobenius contraction preserves original-ring coefficients, with exact expansion identity and degree accounting.
3. `ArkLib/Data/Polynomial/FractionFieldFactorization.lean` (79 lines): UFD induction collects constant content and retains all positive-degree factors and multiplicities.
4. The three mirrored `ArkLibTest/Data/Polynomial/` files (88 lines total): characteristic-two applicability over two polynomial coefficient axes; a non-polynomial rational-root example; explicit axiom checks for all seven public results.
5. `ArkLib.lean`: three generated imports.

## Validation at `4e413e3ad`

The complete `./scripts/validate.sh --axioms` passed on the exact committed tree, including the library build, warning-free test target, lint/style fixtures, runtime tests, import and documentation checks, and axiom-regression checks. An independent reviewer also checked the three production modules and tests.

The seven public results use only `propext`, `Classical.choice`, and `Quot.sound`; no admissions or nonstandard axioms were added. The repository-wide sweep found 312 existing sorry-tainted declarations and zero nonstandard-axiom-tainted declarations, with no regression. Two unrelated stale baseline entries were left untouched.

GitHub CI is separate from this local validation and will run after publication, testing integration with the current target. The local full-suite claim above is for the stated head, not the newer target's merge tree.

## Follow-up

Specialization/resultant bounds and the BCHKS interpolation and rigidity arguments remain separate work. This PR is a small algebraic prerequisite, not a claim that #859 is resolved.
