### PR TITLE
feat(polynomial): prove rounded symbolic interpolation surplus

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -273,6 +273,9 @@ import ArkLib.Data.Polynomial.RationalFunctions.Lifts
 import ArkLib.Data.Polynomial.RationalFunctions.RationalRootVanishing
 import ArkLib.Data.Polynomial.RationalFunctions.Weight
 import ArkLib.Data.Polynomial.SplitFold
+import ArkLib.Data.Polynomial.SymbolicInterpolationParameters
+import ArkLib.Data.Polynomial.SymbolicInterpolationSupport
+import ArkLib.Data.Polynomial.SymbolicInterpolationSurplus
 import ArkLib.Data.Polynomial.Trivariate
 import ArkLib.Data.Probability.Combinatorial
 import ArkLib.Data.Probability.Instances

--- a/ArkLib/Data/Polynomial/SymbolicInterpolationParameters.lean
+++ b/ArkLib/Data/Polynomial/SymbolicInterpolationParameters.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Ring
+
+/-!
+# Real budgets for symbolic interpolation
+
+The arithmetic comparison below is the strict surplus criterion from the proof of
+[BCHKS25, Lemma 3.1], with `r = √(k/n)`. It does not assert the ceiling-count lower bound
+or construct an interpolant.
+
+## References
+
+* [Ben-Sasson, E., Carmon, D., Haböck, U., Kopparty, S., Saraf, S.,
+    *On Proximity Gaps for Reed--Solomon Codes*][BCHKS25], Section 3.1.
+-/
+
+namespace Polynomial.SymbolicInterpolation
+
+/-- The real comparison guaranteeing strict surplus, once the variable-count lower bound
+has been established. The coefficient budget `z` may exceed its prescribed minimum. -/
+theorem strict_surplus_of_coefficient_budget (m r z : ℝ) (hm : 1 ≤ m) (hr : 0 < r)
+    (hz : (m + 1 / 2) ^ 2 / (3 * r ^ 2) ≤ z) :
+    (r ^ 2 * ((m + 1 / 2) / r) * ((m + 1 / 2) / r + 1) - m * (m + 1)) * z >
+      (r ^ 2 * (((m + 1 / 2) / r) ^ 3 - (m + 1 / 2) / r) - (m ^ 3 - m)) / 3 := by
+  have hr0 : r ≠ 0 := ne_of_gt hr
+  have ht : 0 < m + 1 / 2 := by linarith
+  have hc : 0 < 1 / 4 + (m + 1 / 2) * r := by positivity
+  have hcoef : r ^ 2 * ((m + 1 / 2) / r) * ((m + 1 / 2) / r + 1) -
+      m * (m + 1) = 1 / 4 + (m + 1 / 2) * r := by field_simp; ring
+  have hcube : 0 ≤ m ^ 3 - m := by nlinarith [sq_nonneg (m - 1)]
+  have hres : 0 < (m + 1 / 2) ^ 2 / (12 * r ^ 2) +
+      ((m + 1 / 2) * r + m ^ 3 - m) / 3 := by
+    have hp : 0 < (m + 1 / 2) * r := mul_pos ht hr
+    have hq : 0 < (m + 1 / 2) ^ 2 / (12 * r ^ 2) := by positivity
+    linarith
+  have hid : (1 / 4 + (m + 1 / 2) * r) * ((m + 1 / 2) ^ 2 / (3 * r ^ 2)) -
+      (r ^ 2 * (((m + 1 / 2) / r) ^ 3 - (m + 1 / 2) / r) - (m ^ 3 - m)) / 3 =
+      (m + 1 / 2) ^ 2 / (12 * r ^ 2) +
+        ((m + 1 / 2) * r + m ^ 3 - m) / 3 := by field_simp; ring
+  rw [hcoef]
+  have hmono := mul_le_mul_of_nonneg_left hz hc.le
+  linarith
+
+/-- The prescribed coefficient budget dominates the Y-degree budget in the paper's regime. -/
+theorem y_budget_le_coefficient_budget (m r : ℝ) (hm : 3 ≤ m)
+    (hr : 0 < r) (hr1 : r ≤ 1) :
+    (m + 1 / 2) / r ≤ (m + 1 / 2) ^ 2 / (3 * r ^ 2) := by
+  apply (div_le_div_iff₀ hr (by positivity : 0 < 3 * r ^ 2)).mpr
+  have ht : 0 ≤ m + 1 / 2 := by linarith
+  have htr : 3 * r ≤ m + 1 / 2 := by linarith
+  nlinarith [mul_nonneg hr.le (mul_nonneg ht (sub_nonneg.mpr htr))]
+
+/-- The multiplicity threshold makes the X-degree budget small enough for the root argument.
+Here `eta = 1 - r - gamma`; multiplying this inequality by the block length gives the
+paper's `D_X ≤ (1 - gamma) * m * n`. -/
+theorem x_budget_le_multiplicity_budget (m r eta : ℝ) (heta : 0 < eta)
+    (hm : r / (2 * eta) ≤ m) :
+    (m + 1 / 2) * r ≤ (r + eta) * m := by
+  have h := (div_le_iff₀ (by positivity : 0 < 2 * eta)).mp hm
+  nlinarith
+
+end Polynomial.SymbolicInterpolation

--- a/ArkLib/Data/Polynomial/SymbolicInterpolationSupport.lean
+++ b/ArkLib/Data/Polynomial/SymbolicInterpolationSupport.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import Mathlib.Data.Finset.Sigma
+import Mathlib.Data.Finset.Prod
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.BigOperators.Group.Finset.Sigma
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Ring
+
+/-!
+# Support counts for symbolic interpolation
+
+The integer budgets below give the non-Cartesian support used in BCHKS25, Lemma 3.1.
+For the paper's real strict degree bounds, the budgets are their natural ceilings.
+Indices are ordered as `⟨j, (i, h)⟩`: outer Y, middle X, inner Z in `F[Z][X][Y]`.
+This module counts unknowns and scalar equations only; it does not assert the numerical
+surplus or construct an interpolating polynomial.
+
+## References
+
+- [BCHKS25] Eli Ben-Sasson, Dan Carmon, Ulrich Haböck, Swastik Kopparty, and Shubhangi Saraf.
+  On Proximity Gaps for Reed--Solomon Codes. Cryptology ePrint Archive, Paper 2025/2055,
+  Lemma 3.1. https://eprint.iacr.org/2025/2055
+-/
+
+namespace Polynomial.SymbolicInterpolation
+
+open Finset
+
+/-- Monomials with `i + k*j < dx`, `j < dy`, and `j + h < dz`. -/
+def monomialSupport (k dx dy dz : ℕ) : Finset (Σ _ : ℕ, ℕ × ℕ) :=
+  (range dy).sigma fun j => (range (dx - k * j)) ×ˢ (range (dz - j))
+
+/-- The support inequalities expose the semantic X, Y, and Z axes. -/
+@[simp] theorem mem_monomialSupport (k dx dy dz i j h : ℕ) :
+    ⟨j, (i, h)⟩ ∈ monomialSupport k dx dy dz ↔
+      j < dy ∧ i + k * j < dx ∧ j + h < dz := by
+  simp only [monomialSupport, mem_sigma, mem_range, mem_product]
+  omega
+
+/-- Exact unknown count, including truncated rows when a budget is small. -/
+theorem card_monomialSupport (k dx dy dz : ℕ) :
+    (monomialSupport k dx dy dz).card =
+      ∑ j ∈ range dy, (dx - k * j) * (dz - j) := by
+  simp [monomialSupport, card_sigma]
+
+/-- Scalar constraint indices at one interpolation point: Y-Hasse order `s`, X-Hasse
+order `r`, and Z-coefficient `d`. The degree budget drops by `s`. -/
+def constraintSupport (m dz : ℕ) : Finset (Σ _ : ℕ, ℕ × ℕ) :=
+  (range m).sigma fun s => (range (m - s)) ×ˢ (range (dz - s))
+
+/-- The Hasse order is strictly below the requested multiplicity. -/
+@[simp] theorem mem_constraintSupport (m dz r s d : ℕ) :
+    ⟨s, (r, d)⟩ ∈ constraintSupport m dz ↔ r + s < m ∧ d + s < dz := by
+  simp only [constraintSupport, mem_sigma, mem_range, mem_product]
+  omega
+
+/-- Exact per-point scalar equation count. -/
+theorem card_constraintSupport (m dz : ℕ) :
+    (constraintSupport m dz).card = ∑ s ∈ range m, (dz - s) * (m - s) := by
+  simp [constraintSupport, card_sigma, Nat.mul_comm]
+
+/-- Multiplying by the number of points gives the full scalar equation count. -/
+theorem card_pointConstraints (n m dz : ℕ) :
+    ((range n) ×ˢ constraintSupport m dz).card =
+      n * ∑ s ∈ range m, (dz - s) * (m - s) := by
+  simp [card_constraintSupport]
+
+private theorem six_mul_sum (a b : ℤ) (m : ℕ) :
+    6 * (∑ s ∈ range m, (a - s) * (b - s)) =
+      6 * a * b * m - 3 * (a + b) * m * (m - 1) + m * (m - 1) * (2 * m - 1) := by
+  induction m with
+  | zero => simp
+  | succ m ih =>
+    rw [sum_range_succ, mul_add, ih]
+    push_cast
+    ring
+
+/-- The paper's exact equation count without division or truncated subtraction:
+`6 E + m³ = 3 dz m (m+1) + m`. The hypothesis ensures every Hasse row has
+the untruncated coefficient budget used by the closed formula. -/
+theorem six_mul_card_constraintSupport (m dz : ℕ) (hm : m ≤ dz) :
+    6 * (constraintSupport m dz).card + m ^ 3 = 3 * dz * m * (m + 1) + m := by
+  have hsum := six_mul_sum (dz : ℤ) (m : ℤ) m
+  have hcast : ((constraintSupport m dz).card : ℤ) =
+      ∑ s ∈ range m, ((dz : ℤ) - s) * ((m : ℤ) - s) := by
+    rw [card_constraintSupport, Nat.cast_sum]
+    apply sum_congr rfl
+    intro s hs
+    have hsm : s ≤ m := Nat.le_of_lt (mem_range.mp hs)
+    rw [Nat.cast_mul, Nat.cast_sub (hsm.trans hm), Nat.cast_sub hsm]
+  have h : (6 : ℤ) * (constraintSupport m dz).card + (m : ℤ) ^ 3 =
+      3 * dz * m * (m + 1) + m := by
+    rw [hcast]
+    nlinarith [hsum]
+  exact_mod_cast h
+
+end Polynomial.SymbolicInterpolation

--- a/ArkLib/Data/Polynomial/SymbolicInterpolationSurplus.lean
+++ b/ArkLib/Data/Polynomial/SymbolicInterpolationSurplus.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.SymbolicInterpolationParameters
+import ArkLib.Data.Polynomial.SymbolicInterpolationSupport
+import Mathlib.Algebra.Order.Floor.Ring
+import Mathlib.Algebra.Order.Archimedean.Real.Basic
+
+/-!
+# Rounded support counts for symbolic interpolation
+
+The exact support cardinality is a polynomial when all rows have nonnegative budgets.
+Its lower bound below isolates the rounding step in [BCHKS25, Lemma 3.1].
+
+## References
+
+* [Ben-Sasson, E., Carmon, D., Haböck, U., Kopparty, S., Saraf, S.,
+    *On Proximity Gaps for Reed--Solomon Codes*][BCHKS25], Section 3.1.
+-/
+
+namespace Polynomial.SymbolicInterpolation
+
+open Finset
+
+/-- Polynomial expression for the number of monomials in untruncated rows. -/
+noncomputable def variableCountPolynomial (k x y z : ℝ) : ℝ :=
+  x * y * z - (x + k * z) * y * (y - 1) / 2 +
+    k * y * (y - 1) * (2 * y - 1) / 6
+
+/-- Summing real row budgets gives the variable-count polynomial, independently of rounding. -/
+theorem sum_untruncated_monomial_rows (k x z : ℝ) (d : ℕ) :
+    (∑ j ∈ range d, (x - k * j) * (z - j)) = variableCountPolynomial k x d z := by
+  induction d with
+  | zero => simp [variableCountPolynomial]
+  | succ d ih =>
+    rw [sum_range_succ, ih]
+    simp only [variableCountPolynomial, Nat.cast_add, Nat.cast_one]
+    ring
+
+/-- Exact cardinality as a real polynomial, under explicit nontruncation assumptions. -/
+theorem card_monomialSupport_eq_polynomial (k dx d dz : ℕ)
+    (hx : ∀ j < d, k * j ≤ dx) (hz : d ≤ dz) :
+    ((monomialSupport k dx d dz).card : ℝ) = variableCountPolynomial k dx d dz := by
+  rw [card_monomialSupport, Nat.cast_sum]
+  calc
+    (∑ j ∈ range d, (((dx - k * j) * (dz - j) : ℕ) : ℝ)) =
+        ∑ j ∈ range d, ((dx : ℝ) - k * j) * ((dz : ℝ) - j) := by
+      apply sum_congr rfl
+      intro j hj
+      rw [Nat.cast_mul, Nat.cast_sub (hx j (mem_range.mp hj)),
+        Nat.cast_sub ((Nat.le_of_lt (mem_range.mp hj)).trans hz), Nat.cast_mul]
+    _ = _ := sum_untruncated_monomial_rows k dx dz d
+
+/-- Rounding X upward and Y upward by at most one does not decrease the paper's lower bound.
+The Z budget covers the rounded Y budget, so every added row remains nonnegative. -/
+theorem variableCountPolynomial_lower_bound (k x y d z : ℝ)
+    (hk : 0 ≤ k) (hy : 0 ≤ y) (hyd : y ≤ d) (hdy : d ≤ y + 1)
+    (hdz : d ≤ z) (hx : k * y ≤ x) :
+    k * (y * (y + 1) * z / 2 - (y ^ 3 - y) / 6) ≤
+      variableCountPolynomial k x d z := by
+  have hd : 0 ≤ d := hy.trans hyd
+  have hz : 0 ≤ z := hd.trans hdz
+  have hxpart : 0 ≤ (x - k * y) * d * (2 * z - d + 1) := by
+    apply mul_nonneg (mul_nonneg (sub_nonneg.mpr hx) hd)
+    linarith
+  have ht : 0 ≤ d - y := sub_nonneg.mpr hyd
+  have ht1 : 0 ≤ 1 - (d - y) := by linarith
+  have hround : 0 ≤ k * (d - y) * (1 - (d - y)) *
+      (3 * (z - y) + 1 - 2 * (d - y)) := by
+    apply mul_nonneg (mul_nonneg (mul_nonneg hk ht) ht1)
+    linarith
+  have hid : 6 * (variableCountPolynomial k x d z -
+      k * (y * (y + 1) * z / 2 - (y ^ 3 - y) / 6)) =
+      3 * ((x - k * y) * d * (2 * z - d + 1)) +
+        k * (d - y) * (1 - (d - y)) * (3 * (z - y) + 1 - 2 * (d - y)) := by
+    unfold variableCountPolynomial
+    ring
+  linarith
+
+/-- The actual rounded monomial support dominates the real count used in the surplus criterion. -/
+theorem card_monomialSupport_ceil_lower_bound (k : ℕ) (y z : ℝ)
+    (hy : 0 ≤ y) (hyz : y ≤ z) :
+    k * (y * (y + 1) * (⌈z⌉₊ : ℝ) / 2 - (y ^ 3 - y) / 6) ≤
+      ((monomialSupport k ⌈(k : ℝ) * y⌉₊ ⌈y⌉₊ ⌈z⌉₊).card : ℝ) := by
+  have hx : ∀ j < ⌈y⌉₊, k * j ≤ ⌈(k : ℝ) * y⌉₊ := by
+    intro j hj
+    have hjy : (j : ℝ) < y := Nat.lt_ceil.mp hj
+    have h := (mul_le_mul_of_nonneg_left hjy.le (Nat.cast_nonneg k)).trans
+      (Nat.le_ceil ((k : ℝ) * y))
+    exact_mod_cast h
+  rw [card_monomialSupport_eq_polynomial k _ _ _ hx (Nat.ceil_mono hyz)]
+  exact variableCountPolynomial_lower_bound k _ y _ _ (Nat.cast_nonneg k) hy
+    (Nat.le_ceil y) (Nat.ceil_lt_add_one hy).le
+    (by exact_mod_cast Nat.ceil_mono hyz) (Nat.le_ceil _)
+
+/-- The rounded supports have strictly more unknowns than point constraints at the prescribed
+budgets. The identity `k = n*r²` exposes the rate without choosing a square-root representation. -/
+theorem card_constraints_lt_monomials (n k m : ℕ) (r : ℝ)
+    (hn : 0 < n) (hm : 3 ≤ m) (hr : 0 < r) (hr1 : r ≤ 1)
+    (hkr : (k : ℝ) = n * r ^ 2) :
+    n * (constraintSupport m ⌈((m : ℝ) + 1 / 2) ^ 2 / (3 * r ^ 2)⌉₊).card <
+      (monomialSupport k ⌈(k : ℝ) * (((m : ℝ) + 1 / 2) / r)⌉₊
+        ⌈((m : ℝ) + 1 / 2) / r⌉₊
+        ⌈((m : ℝ) + 1 / 2) ^ 2 / (3 * r ^ 2)⌉₊).card := by
+  let y : ℝ := ((m : ℝ) + 1 / 2) / r
+  let z : ℝ := ((m : ℝ) + 1 / 2) ^ 2 / (3 * r ^ 2)
+  have hmR : (3 : ℝ) ≤ m := by exact_mod_cast hm
+  have hy : 0 ≤ y := by dsimp [y]; positivity
+  have hyz : y ≤ z := y_budget_le_coefficient_budget m r hmR hr hr1
+  have hmy : (m : ℝ) ≤ y := by
+    apply (le_div_iff₀ hr).mpr
+    have := mul_le_mul_of_nonneg_left hr1 (Nat.cast_nonneg m : (0 : ℝ) ≤ m)
+    linarith
+  have hmz : m ≤ ⌈z⌉₊ := by
+    exact_mod_cast hmy.trans (hyz.trans (Nat.le_ceil z))
+  have heq := six_mul_card_constraintSupport m ⌈z⌉₊ hmz
+  have heqR : (6 : ℝ) * (constraintSupport m ⌈z⌉₊).card + (m : ℝ) ^ 3 =
+      3 * (⌈z⌉₊ : ℝ) * m * (m + 1) + m := by exact_mod_cast heq
+  have hlow := card_monomialSupport_ceil_lower_bound k y z hy hyz
+  have hstrict := strict_surplus_of_coefficient_budget m r (⌈z⌉₊ : ℝ)
+    (by linarith) hr (Nat.le_ceil z)
+  change (r ^ 2 * y * (y + 1) - (m : ℝ) * (m + 1)) * (⌈z⌉₊ : ℝ) >
+    (r ^ 2 * (y ^ 3 - y) - ((m : ℝ) ^ 3 - m)) / 3 at hstrict
+  have hnR : (0 : ℝ) < n := by exact_mod_cast hn
+  have hscaled := mul_lt_mul_of_pos_left hstrict hnR
+  have heqscaled := congrArg (fun a : ℝ => (n : ℝ) * a) heqR
+  have hlow' : (n : ℝ) * r ^ 2 * (y * (y + 1) * (⌈z⌉₊ : ℝ) / 2 -
+      (y ^ 3 - y) / 6) ≤ (monomialSupport k ⌈(k : ℝ) * y⌉₊ ⌈y⌉₊ ⌈z⌉₊).card := by
+    rw [← hkr]
+    exact hlow
+  have hout : (n : ℝ) * (constraintSupport m ⌈z⌉₊).card <
+      (monomialSupport k ⌈(k : ℝ) * y⌉₊ ⌈y⌉₊ ⌈z⌉₊).card := by
+    nlinarith [hlow', hscaled, heqscaled]
+  exact_mod_cast hout
+
+end Polynomial.SymbolicInterpolation

--- a/ArkLibTest/Data/Polynomial/SymbolicInterpolationParameters.lean
+++ b/ArkLibTest/Data/Polynomial/SymbolicInterpolationParameters.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.SymbolicInterpolationParameters
+
+/-! Boundary checks for the real interpolation budgets. -/
+
+open Polynomial.SymbolicInterpolation
+
+-- The surplus criterion also applies at the smaller multiplicity endpoint `m = 1`.
+example (z : ℝ) (hz : 3 ≤ z) : z > 2 := by
+  have h := strict_surplus_of_coefficient_budget 1 (1 / 2) z (by norm_num)
+    (by norm_num) (by norm_num at hz ⊢; exact hz)
+  norm_num at h
+  linarith
+
+-- At full rate and the paper's smallest multiplicity, the Z budget still dominates Y.
+example : (7 / 2 : ℝ) ≤ 49 / 12 := by
+  have h := y_budget_le_coefficient_budget 3 1 (by norm_num) (by norm_num) (by norm_num)
+  norm_num at h ⊢
+
+-- Equality in the multiplicity threshold is allowed.
+example : (3 + 1 / 2 : ℝ) * (1 / 2) ≤ (1 / 2 + 1 / 12) * 3 := by
+  apply x_budget_le_multiplicity_budget
+  · norm_num
+  · norm_num

--- a/ArkLibTest/Data/Polynomial/SymbolicInterpolationSupport.lean
+++ b/ArkLibTest/Data/Polynomial/SymbolicInterpolationSupport.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.SymbolicInterpolationSupport
+
+/-! Acceptance checks for the BCHKS25 integer interpolation support. -/
+
+open Polynomial.SymbolicInterpolation
+
+-- Unequal X and Z budgets detect exchanging the nested polynomial axes.
+example : ⟨0, (7, 1)⟩ ∈ monomialSupport 2 9 4 6 := by decide
+
+example : ⟨0, (1, 7)⟩ ∉ monomialSupport 2 9 4 6 := by decide
+
+-- A high Y exponent reduces both the X and Z budgets.
+example : ⟨3, (2, 2)⟩ ∈ monomialSupport 2 9 4 6 := by decide
+
+example : ⟨3, (3, 2)⟩ ∉ monomialSupport 2 9 4 6 := by decide
+
+example : (monomialSupport 2 9 4 6).card = 118 := by decide
+
+example : (constraintSupport 3 6).card = 32 := by decide
+
+-- Small and zero budgets remain well-defined even outside the closed-form regime.
+example : (constraintSupport 3 1).card = 3 := by decide
+
+example : (monomialSupport 2 0 4 6).card = 0 := by decide

--- a/ArkLibTest/Data/Polynomial/SymbolicInterpolationSurplus.lean
+++ b/ArkLibTest/Data/Polynomial/SymbolicInterpolationSurplus.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.SymbolicInterpolationSurplus
+
+/-! Rounded support clients, with nonintegral budgets and unequal axes. -/
+
+open Polynomial.SymbolicInterpolation
+
+-- The Y budget is 7/2 and the Z budget 49/12: both require upward rounding.
+example : (constraintSupport 3 5).card < (monomialSupport 1 4 4 5).card := by
+  have h := card_constraints_lt_monomials 1 1 3 1 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+  have hy : ⌈(7 / 2 : ℝ)⌉₊ = 4 := (Nat.ceil_eq_iff (by decide)).mpr (by norm_num)
+  have hz : ⌈(49 / 12 : ℝ)⌉₊ = 5 := (Nat.ceil_eq_iff (by decide)).mpr (by norm_num)
+  norm_num at h
+  rw [hy, hz] at h
+  exact h
+
+-- A genuinely fractional Y row still has the lower bound with an independent real Z budget.
+example : (2 : ℝ) * ((7 / 2) * (7 / 2 + 1) * 6 / 2 - ((7 / 2) ^ 3 - 7 / 2) / 6) ≤
+    (monomialSupport 2 7 4 6).card := by
+  have h := card_monomialSupport_ceil_lower_bound 2 (7 / 2) 6 (by norm_num) (by norm_num)
+  have hy : ⌈(7 / 2 : ℝ)⌉₊ = 4 := (Nat.ceil_eq_iff (by decide)).mpr (by norm_num)
+  norm_num at h ⊢
+  rwa [hy] at h


### PR DESCRIPTION
## Summary

Proves the exact support counts and rounded numerical surplus used by BCHKS25 symbolic interpolation. This is an independent prerequisite for #859, based on `main`, with no dependency on #865 or #866.

For `m ≥ 3`, `0 < r ≤ 1`, `n > 0`, and `k = n*r²`, the final theorem proves that the prescribed integer monomial support has strictly more unknowns than scalar interpolation constraints. The caller does not need to assume the dimension surplus.

## Audited surface

- Base: `e029c9f5d4e06e30f3a44079146ecbe58d413e0c` (`main`).
- Head: `d2fe9538beb54b414b2da3b0fd4f717b3b353136`.
- One commit; seven files; 404 insertions, no deletions.
- Reference: [BCHKS25, Lemma 3.1 and Section 3.1](https://eprint.iacr.org/2025/2055).

## Motivation and mathematical contract

The symbolic interpolation support is not a rectangular degree box. In the nesting `F[Z][X][Y]`, scalar indices are Y, X, Z, and the monomials satisfy

```text
j < dy,   i + k*j < dx,   j + h < dz.
```

Its exact size is `Σ j<dy, (dx-k*j)*(dz-j)`, with natural subtraction retaining truncated rows. The Hasse constraint count is `Σ s<m, (dz-s)*(m-s)` per point. The closed equation-count formula explicitly assumes `m ≤ dz`.

The real-budget and rounding proofs establish the surplus at natural ceilings of

```text
dy = (m+1/2)/r,
dx = k*dy,
dz = (m+1/2)²/(3*r²).
```

The rounding lower bound exposes its nonnegative remainder instead of assuming a monotonicity assertion across fractional rows. A separate threshold inequality connects the X budget to the multiplicity budget needed by the later root-count argument.

This PR proves counts and arithmetic only. It does not construct the polynomial, prove its symbolic multiplicities, or establish BCHKS correlated agreement. Those consumers have been prototyped locally, but are not part of this diff. No capacity-development extraction or existing API modification is included.

## Reviewer map

1. `ArkLib/Data/Polynomial/SymbolicInterpolationSupport.lean` (103 lines): supports, semantic-axis membership, exact counts, and untruncated closed equation count.
2. `ArkLib/Data/Polynomial/SymbolicInterpolationParameters.lean` (71 lines): real surplus criterion and budget comparisons.
3. `ArkLib/Data/Polynomial/SymbolicInterpolationSurplus.lean` (139 lines): exact polynomial count, rounding lower bound, and actual strict surplus.
4. The three mirrored test files (88 lines): unequal X/Z budgets, high-Y restrictions, truncated and zero budgets, fractional ceilings, smallest multiplicity/full-rate boundary, and equality at the multiplicity threshold.
5. `ArkLib.lean`: three generated imports.

## Validation at `d2fe9538b`

The complete `./scripts/validate.sh --axioms` passed on the exact committed tree: library build, warning-free tests, source-policy/style gates and fixtures, runtime tests, import/documentation checks, and axiom-regression checks. Independent reviews covered the support and numerical arguments.

No admissions, nonstandard axioms, or source-policy suppressions were added. The sweep reports 11,284 declarations across 439 modules, 312 existing sorry-tainted declarations, and zero nonstandard-axiom-tainted declarations, with no new taint. Two unrelated stale baseline entries remain unchanged.

GitHub CI will run separately after publication. Polynomial construction, arbitrary-curve rounding, specialization, and rigidity remain separate review units; this PR does not resolve #859 by itself.
