### PR TITLE
feat(Polynomial): bound both bivariate factor degree sums

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -257,6 +257,7 @@ import ArkLib.Data.MvPolynomial.RestrictDegree
 import ArkLib.Data.MvPolynomial.RestrictDegreeVar
 import ArkLib.Data.MvPolynomial.SchwartzZippelCounting
 import ArkLib.Data.Polynomial.Bivariate
+import ArkLib.Data.Polynomial.BivariateFactorDegrees
 import ArkLib.Data.Polynomial.ClassicalWronskian
 import ArkLib.Data.Polynomial.FoldedWronskian
 import ArkLib.Data.Polynomial.FoldingPolynomial

--- a/ArkLib/Data/Polynomial/BivariateFactorDegrees.lean
+++ b/ArkLib/Data/Polynomial/BivariateFactorDegrees.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jieyi Long, Quang Dao
+-/
+
+import CompPoly.ToMathlib.Polynomial.BivariateDegree
+import Mathlib.RingTheory.Polynomial.UniqueFactorization
+
+/-!
+# Degree sums for bivariate factors
+
+The sum of either axis degree over distinct normalized factors of a nonzero polynomial is
+bounded by the corresponding degree of that polynomial. Here `R[X][Y]` has outer variable `Y`:
+`natDegree` measures `Y`, whereas `degreeX` measures the coefficient variable `X`.
+The bounds also hold after selecting any subset of the distinct factors.
+
+The finite-product lemmas work over an integral domain. The normalized-factor bounds additionally
+require normalization and unique factorization for the bivariate polynomial ring.
+
+## Implementation references
+
+Adapted from Jieyi Long (`jieyilong`), `BCHKSUniversalFactorSums.lean`, lines 15–123, and
+`BCHKSFactorPigeon.lean`, lines 277–302, in the Apache-2.0 licensed better-codes development:
+https://github.com/proximity-prize/proximity-prize/blob/19bc7d3e21b2261257e1961acd720b2c395d87e1/ProximityPrize/SubmissionLower/BCHKSUniversalFactorSums.lean
+
+Changes: use the existing CompPoly degree API, generalize finite products to indexed families,
+weaken field assumptions to domain and factorization assumptions, and generalize the
+positive-degree filter to an arbitrary subset. No donor `LocalMathlib` modules are copied.
+-/
+
+open Polynomial
+open scoped Polynomial.Bivariate
+
+namespace Polynomial.Bivariate
+
+noncomputable section
+
+variable {R : Type*} [CommRing R] [IsDomain R]
+
+/-- The coefficient-variable degree is additive on a finite product of nonzero polynomials. -/
+theorem degreeX_prod {ι : Type*} (s : Finset ι) (f : ι → R[X][Y])
+    (hf : ∀ i ∈ s, f i ≠ 0) :
+    degreeX (∏ i ∈ s, f i) = ∑ i ∈ s, degreeX (f i) := by
+  classical
+  induction s using Finset.induction_on with
+  | empty =>
+    simp only [Finset.prod_empty, Finset.sum_empty]
+    apply Nat.eq_zero_of_le_zero
+    unfold degreeX
+    apply Finset.sup_le
+    intro i _hi
+    by_cases h : i = 0 <;> simp [Polynomial.coeff_one, h]
+  | @insert i s hi ih =>
+    rw [Finset.prod_insert hi, Finset.sum_insert hi]
+    rw [degreeX_mul _ _ (hf i (Finset.mem_insert_self _ _))
+      (Finset.prod_ne_zero_iff.mpr (fun j hj ↦ hf j (Finset.mem_insert_of_mem hj)))]
+    rw [ih (fun j hj ↦ hf j (Finset.mem_insert_of_mem hj))]
+
+/-- Divisibility into a nonzero polynomial bounds the coefficient-variable degree. -/
+theorem degreeX_le_of_dvd {p q : R[X][Y]} (h : p ∣ q) (hq : q ≠ 0) :
+    degreeX p ≤ degreeX q := by
+  obtain ⟨r, rfl⟩ := h
+  rw [degreeX_mul _ _ (left_ne_zero_of_mul hq) (right_ne_zero_of_mul hq)]
+  exact Nat.le_add_right _ _
+
+/-- A nonzero polynomial bounds both axis-degree sums of any indexed family whose product
+divides it. The product premise accounts for repeated factors and their multiplicities. -/
+theorem sum_natDegree_degreeX_le_of_prod_dvd {ι : Type*} (s : Finset ι)
+    (f : ι → R[X][Y]) {p : R[X][Y]} (hp : p ≠ 0) (h : (∏ i ∈ s, f i) ∣ p) :
+    (∑ i ∈ s, (f i).natDegree) ≤ p.natDegree ∧
+      (∑ i ∈ s, degreeX (f i)) ≤ degreeX p := by
+  have hf : ∀ i ∈ s, f i ≠ 0 := Finset.prod_ne_zero_iff.mp (ne_zero_of_dvd_ne_zero hp h)
+  constructor
+  · rw [← Polynomial.natDegree_prod s f hf]
+    exact Polynomial.natDegree_le_of_dvd h hp
+  · rw [← degreeX_prod s f hf]
+    exact degreeX_le_of_dvd h hp
+
+variable [DecidableEq R] [NormalizationMonoid R[X][Y]] [UniqueFactorizationMonoid R[X][Y]]
+
+omit [IsDomain R] in
+/-- The product of the distinct normalized factors divides the original nonzero polynomial. -/
+theorem normalizedFactors_toFinset_prod_dvd (p : R[X][Y]) (hp : p ≠ 0) :
+    (UniqueFactorizationMonoid.normalizedFactors p).toFinset.prod id ∣ p := by
+  classical
+  exact (Multiset.toFinset_prod_dvd_prod _).trans
+    (UniqueFactorizationMonoid.prod_normalizedFactors hp).dvd
+
+/-- The distinct normalized factors separately satisfy both axis-degree budgets. -/
+theorem normalizedFactors_toFinset_sum_natDegree_degreeX_le (p : R[X][Y]) (hp : p ≠ 0) :
+    (∑ q ∈ (UniqueFactorizationMonoid.normalizedFactors p).toFinset, q.natDegree) ≤
+        p.natDegree ∧
+      (∑ q ∈ (UniqueFactorizationMonoid.normalizedFactors p).toFinset, degreeX q) ≤
+        degreeX p := by
+  classical
+  exact sum_natDegree_degreeX_le_of_prod_dvd _ id hp
+    (normalizedFactors_toFinset_prod_dvd p hp)
+
+/-- Selecting any subset of the distinct normalized factors preserves both degree budgets.
+In particular, this applies to the subset of factors with positive outer degree. -/
+theorem sum_natDegree_degreeX_le_of_subset_normalizedFactors {p : R[X][Y]} (hp : p ≠ 0)
+    (s : Finset R[X][Y]) (hs : s ⊆ (UniqueFactorizationMonoid.normalizedFactors p).toFinset) :
+    (∑ q ∈ s, q.natDegree) ≤ p.natDegree ∧ (∑ q ∈ s, degreeX q) ≤ degreeX p := by
+  have h := normalizedFactors_toFinset_sum_natDegree_degreeX_le p hp
+  constructor
+  · exact (Finset.sum_le_sum_of_subset_of_nonneg hs (by simp)).trans h.1
+  · exact (Finset.sum_le_sum_of_subset_of_nonneg hs (by simp)).trans h.2
+
+end
+
+end Polynomial.Bivariate

--- a/ArkLibTest/Data/Polynomial/BivariateFactorDegrees.lean
+++ b/ArkLibTest/Data/Polynomial/BivariateFactorDegrees.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.BivariateFactorDegrees
+
+/-!
+# Bivariate factor-degree acceptance tests
+
+Check the normalized-factor interface over a coefficient ring that is not a field, the donor's
+positive-outer-degree selection, indexed products with repeated factors, and unequal axis degrees.
+-/
+
+open Polynomial Polynomial.Bivariate
+
+example (p : ℤ[X][Y]) (hp : p ≠ 0) :
+    let s := (UniqueFactorizationMonoid.normalizedFactors p).toFinset.filter
+      (fun q ↦ 0 < q.natDegree)
+    (∑ q ∈ s, q.natDegree) ≤ p.natDegree ∧ (∑ q ∈ s, degreeX q) ≤ degreeX p := by
+  exact sum_natDegree_degreeX_le_of_subset_normalizedFactors hp _ (Finset.filter_subset _ _)
+
+example (p q : ℚ[X][Y]) (hq : q ≠ 0) (h : p ^ 2 ∣ q) :
+    2 * p.natDegree ≤ q.natDegree ∧ 2 * degreeX p ≤ degreeX q := by
+  have hprod : (∏ _i ∈ (Finset.univ : Finset (Fin 2)), p) ∣ q := by
+    simpa using h
+  simpa using sum_natDegree_degreeX_le_of_prod_dvd Finset.univ (fun _i : Fin 2 ↦ p) hq hprod
+
+example : (Polynomial.monomial 3 ((X : ℚ[X]) ^ 5)).natDegree = 3 ∧
+    degreeX (Polynomial.monomial 3 ((X : ℚ[X]) ^ 5)) = 5 := by
+  simp [degreeX]


### PR DESCRIPTION
## Summary

Adds reusable bounds on the sums of both coordinate degrees of bivariate factors. This is P03 of the BCHKS25 port plan in [#859](https://github.com/Verified-zkEVM/ArkLib/issues/859#issuecomment-5576998222), independent of the other open foundations.

The generic theorem handles an indexed family whose **product divides** a nonzero polynomial, so repeated factors are charged with multiplicity. Corollaries handle distinct normalized factors and arbitrary subsets of them. The finite-product API works over domains, not only fields.

## Audited surface

- Base: `66f3d089a41704597f54d641b78254d2a8f361f8` (`main`).
- Head: `0ef306fc6a430e679acfde79b304eeec0b1e4946`.
- One commit; three files; 145 additions, no deletions: 112 production lines, 32 tests, one generated umbrella import.
- `ArkLib/Data/Polynomial/BivariateFactorDegrees.lean`: six product/divisibility/factor-sum lemmas using the native CompPoly and Mathlib APIs.
- `ArkLibTest/Data/Polynomial/BivariateFactorDegrees.lean`: domain-not-field, repeated indexed factors, unequal coordinate degrees and subset-filter clients.
- `ArkLib.lean`: generated import only.

## Motivation and mathematical boundary

Subsequent BCHKS resultant and obstruction accounting needs to retain **both** total factor-degree budgets. Bounding each factor separately would lose the aggregate estimate. Here the outer polynomial variable is Y (`natDegree`), and the coefficient variable is X (`degreeX`). Normalized-factor results explicitly require normalization and unique factorization of the bivariate ring.

This PR does not construct resultants, specialization points, exceptional sets, or prove the final BCHKS theorem. It adds no new axioms, placeholders, trust mechanisms, dependencies or breaking changes.

## Attribution

Adapted from **Jieyi Long** (`jieyilong`), [BCHKSUniversalFactorSums.lean, lines 15–123](https://github.com/proximity-prize/proximity-prize/blob/19bc7d3e21b2261257e1961acd720b2c395d87e1/ProximityPrize/SubmissionLower/BCHKSUniversalFactorSums.lean#L15-L123), and the paired-degree argument in [BCHKSFactorPigeon.lean, lines 277–302](https://github.com/proximity-prize/proximity-prize/blob/19bc7d3e21b2261257e1961acd720b2c395d87e1/ProximityPrize/SubmissionLower/BCHKSFactorPigeon.lean#L277-L302), from the Apache-2.0 Better Codes development. That development extends Remco Bloemen's earlier BCHKS formalization; this slice ports the later factor-sum results, not Remco's whole development.

The source header preserves authorship and immutable provenance. Adaptations use existing CompPoly/Mathlib lemmas, generalize finite sets to indexed products, weaken field assumptions, and replace the positive-degree filter with an arbitrary subset. No donor LocalMathlib modules or capacity material are copied.

## Validation at the stated head

- `LAKE_ARTIFACT_CACHE=false LAKE_NO_CACHE=true ./scripts/validate.sh --axioms`: PASS, including production build, tests, zero-warning budgets, source policy, generated imports, runtime fixtures and exhaustive axiom regression checks.
- Six new exported theorem cones: only `propext`, `Classical.choice`, `Quot.sound`.
- Whole-project report: 11,307 declarations across 438 modules; 312 inherited sorry-tainted declarations, zero nonstandard-axiom-tainted declarations, no new trust debt.
- Independent Astra medium review of statements, proof/API boundaries, pinned source correspondence, tests and final validation evidence: PASS, no blocking findings. This is agent review, not a qualifying outside GitHub approval.
- Hosted CI is pending when opened; local validation is not represented as hosted CI success.

Suggested reading order: paired product-divisibility theorem, normalized-factor/subset corollaries, then regression tests. This PR can land independently of #865–867.
