### PR TITLE
feat(mvpoly): add exact weighted product bounds

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -256,6 +256,7 @@ import ArkLib.Data.MvPolynomial.NestedEvaluationTree
 import ArkLib.Data.MvPolynomial.RestrictDegree
 import ArkLib.Data.MvPolynomial.RestrictDegreeVar
 import ArkLib.Data.MvPolynomial.SchwartzZippelCounting
+import ArkLib.Data.MvPolynomial.WeightedDegree
 import ArkLib.Data.Polynomial.Bivariate
 import ArkLib.Data.Polynomial.ClassicalWronskian
 import ArkLib.Data.Polynomial.FoldedWronskian

--- a/ArkLib/Data/MvPolynomial/WeightedDegree.lean
+++ b/ArkLib/Data/MvPolynomial/WeightedDegree.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: nasqret, Jieyi Long, Quang Dao
+-/
+
+import Mathlib.Algebra.MvPolynomial.NoZeroDivisors
+import Mathlib.Data.Finsupp.Option
+import Mathlib.RingTheory.MvPolynomial.WeightedHomogeneous
+
+/-!
+# Weighted degrees of products and divisors
+
+For multivariate polynomials over a semiring without zero divisors, natural weighted total degree
+is additive on nonzero products. No weight is required to be positive. Consequently, a finite
+family whose product divides a nonzero polynomial satisfies an additive weighted-degree budget.
+
+The proof appends a new variable with exponent equal to the weighted degree of each monomial,
+while preserving all original exponents. This injective substitution prevents cancellation even
+when some weights are zero. Ordinary variable-degree additivity then gives weighted additivity.
+The variable type is arbitrary; in particular the results apply uniformly to every `Fin n`.
+
+## Implementation references
+
+Adapted from `nasqret`, `ContactFactorCaps.lean`, lines 28–122, in the Apache-2.0 licensed
+proximity-prize development:
+https://github.com/proximity-prize/proximity-prize/blob/b3fac81ad2b1ee609672b04bd3c3ee1ca5c06884/ProximityPrize/SubmissionLower/ContactFactorCaps.lean
+
+Finite-product and divisibility accounting is adapted from Jieyi Long (`jieyilong`),
+`ContactCumulativeWeightedDegreeResearch.lean`, lines 16–50:
+https://github.com/proximity-prize/proximity-prize/blob/695ff8319bdf7d0666149d8db84daaa30f8b88eb/ProximityPrize/SubmissionLower/ContactCumulativeWeightedDegreeResearch.lean
+
+Changes: replace separate `Fin 3` and `Fin 4` constructions by an `Option`-variable embedding;
+weaken field assumptions to a commutative semiring without zero divisors; use native Mathlib
+weighted-degree and variable-degree APIs without copying the donor's `LocalMathlib` hierarchy.
+-/
+
+namespace MvPolynomial
+
+noncomputable section
+
+variable {σ R : Type*}
+
+private def weightedDegreeEmbedding (w : σ → ℕ) : (σ →₀ ℕ) →+ (Option σ →₀ ℕ) where
+  toFun d := d.optionElim (Finsupp.weight w d)
+  map_zero' := by ext i; cases i <;> simp
+  map_add' d e := by ext i; cases i <;> simp
+
+private theorem weightedDegreeEmbedding_injective (w : σ → ℕ) :
+    Function.Injective (weightedDegreeEmbedding w) := by
+  intro d e h
+  have := congrArg Finsupp.some h
+  simpa [weightedDegreeEmbedding] using this
+
+variable [CommSemiring R]
+
+private def weightedDegreeLift (w : σ → ℕ) :
+    MvPolynomial σ R →+* MvPolynomial (Option σ) R :=
+  AddMonoidAlgebra.mapDomainRingHom R (weightedDegreeEmbedding w)
+
+private theorem weightedDegreeLift_injective (w : σ → ℕ) :
+    Function.Injective (weightedDegreeLift (R := R) w) :=
+  AddMonoidAlgebra.mapDomain_injective (weightedDegreeEmbedding_injective w)
+
+private theorem degreeOf_weightedDegreeLift (w : σ → ℕ) (p : MvPolynomial σ R) :
+    (weightedDegreeLift w p).degreeOf none = weightedTotalDegree w p := by
+  classical
+  have hs : (weightedDegreeLift w p).support = p.support.image (weightedDegreeEmbedding w) :=
+    Finsupp.mapDomain_support_of_injective (weightedDegreeEmbedding_injective w) _
+  rw [degreeOf_eq_sup, hs, Finset.sup_image]
+  simp [Function.comp_def, weightedDegreeEmbedding, weightedTotalDegree]
+
+variable [NoZeroDivisors R]
+
+/-- Natural weighted degree is additive on nonzero products, including for zero weights. -/
+theorem weightedTotalDegree_mul (w : σ → ℕ) (p q : MvPolynomial σ R)
+    (hp : p ≠ 0) (hq : q ≠ 0) :
+    weightedTotalDegree w (p * q) = weightedTotalDegree w p + weightedTotalDegree w q := by
+  have hp' : weightedDegreeLift w p ≠ 0 :=
+    fun h ↦ hp (weightedDegreeLift_injective w (h.trans (map_zero _).symm))
+  have hq' : weightedDegreeLift w q ≠ 0 :=
+    fun h ↦ hq (weightedDegreeLift_injective w (h.trans (map_zero _).symm))
+  rw [← degreeOf_weightedDegreeLift w (p * q), map_mul, degreeOf_mul_eq hp' hq',
+    degreeOf_weightedDegreeLift, degreeOf_weightedDegreeLift]
+
+/-- Natural weighted degree is additive on any finite indexed product of nonzero polynomials. -/
+theorem weightedTotalDegree_prod {ι : Type*} (w : σ → ℕ) (s : Finset ι)
+    (f : ι → MvPolynomial σ R) (hf : ∀ i ∈ s, f i ≠ 0) :
+    weightedTotalDegree w (∏ i ∈ s, f i) = ∑ i ∈ s, weightedTotalDegree w (f i) := by
+  have hf' : ∀ i ∈ s, weightedDegreeLift w (f i) ≠ 0 := by
+    intro i hi h
+    exact hf i hi (weightedDegreeLift_injective w (h.trans (map_zero _).symm))
+  rw [← degreeOf_weightedDegreeLift w (∏ i ∈ s, f i), map_prod, degreeOf_prod_eq s _ hf']
+  simp only [degreeOf_weightedDegreeLift]
+
+/-- Divisibility into a nonzero polynomial bounds natural weighted degree. -/
+theorem weightedTotalDegree_le_of_dvd (w : σ → ℕ) {p q : MvPolynomial σ R}
+    (h : p ∣ q) (hq : q ≠ 0) : weightedTotalDegree w p ≤ weightedTotalDegree w q := by
+  obtain ⟨r, rfl⟩ := h
+  rw [weightedTotalDegree_mul _ _ _ (left_ne_zero_of_mul hq) (right_ne_zero_of_mul hq)]
+  exact Nat.le_add_right _ _
+
+/-- A product-divisibility certificate bounds the sum of actual weighted factor degrees.
+Repeated indices are counted with multiplicity; the weight function may vanish anywhere. -/
+theorem sum_weightedTotalDegree_le_of_prod_dvd {ι : Type*} (w : σ → ℕ) (s : Finset ι)
+    (f : ι → MvPolynomial σ R) {p : MvPolynomial σ R} (hp : p ≠ 0)
+    (h : (∏ i ∈ s, f i) ∣ p) :
+    (∑ i ∈ s, weightedTotalDegree w (f i)) ≤ weightedTotalDegree w p := by
+  let := nontrivial_of_ne p 0 hp
+  have hf : ∀ i ∈ s, f i ≠ 0 := Finset.prod_ne_zero_iff.mp (ne_zero_of_dvd_ne_zero hp h)
+  rw [← weightedTotalDegree_prod w s f hf]
+  exact weightedTotalDegree_le_of_dvd w h hp
+
+end
+
+end MvPolynomial

--- a/ArkLibTest/Data/MvPolynomial/WeightedDegree.lean
+++ b/ArkLibTest/Data/MvPolynomial/WeightedDegree.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.MvPolynomial.WeightedDegree
+
+/-!
+# Weighted-degree acceptance tests
+
+Check mixed zero and positive weights with unequal exponents, repeated indexed factors, an
+infinite variable type, and the empty product without assuming the coefficient ring nontrivial.
+-/
+
+open MvPolynomial
+
+example : weightedTotalDegree (![0, 2] : Fin 2 → ℕ)
+    ((X 0 : MvPolynomial (Fin 2) ℤ) ^ 5 * X 1 ^ 3) = 6 := by
+  rw [weightedTotalDegree_mul _ _ _ (pow_ne_zero _ (X_ne_zero 0)) (pow_ne_zero _ (X_ne_zero 1))]
+  simp [weightedTotalDegree, support_X_pow, Finsupp.weight_single]
+
+example (w : ℕ → ℕ) (p q : MvPolynomial ℕ ℤ) (hq : q ≠ 0) (h : p ^ 2 ∣ q) :
+    2 * weightedTotalDegree w p ≤ weightedTotalDegree w q := by
+  have hprod : (∏ _i ∈ (Finset.univ : Finset (Fin 2)), p) ∣ q := by
+    simpa using h
+  simpa using sum_weightedTotalDegree_le_of_prod_dvd w Finset.univ
+    (fun _i : Fin 2 ↦ p) hq hprod
+
+example {σ R : Type*} [CommSemiring R] [NoZeroDivisors R] (w : σ → ℕ) :
+    weightedTotalDegree w (1 : MvPolynomial σ R) = 0 := by
+  simpa using weightedTotalDegree_prod w (∅ : Finset Unit) (fun _ ↦ (1 : MvPolynomial σ R))
+    (by simp)


### PR DESCRIPTION
Refs #907. This refreshes the exact weighted product and divisor results as an independent main-based module. It complements #857 without sharing its `WeightedDegree.lean` owner, so the two ports can be reviewed and landed separately.

## What changed

`ArkLib.Data.MvPolynomial.WeightedDegree.Products` adds four public theorems:

- `weightedTotalDegree_mul` gives equality for a product of nonzero multivariate polynomials over a domain;
- `weightedTotalDegree_prod` extends the equality to a finite product of nonzero factors;
- `weightedTotalDegree_le_of_dvd` makes weighted degree monotone under divisibility by a nonzero dividend;
- `sum_weightedTotalDegree_le_of_prod_dvd` bounds the sum of factor degrees when their finite product divides a nonzero polynomial. Repeated factor values are counted with multiplicity through distinct finite indices.

The module imports the pinned Mathlib primitives directly and does not depend on #857. The acceptance client directly invokes multiplication, finite products, and the product-divisor sum bound; that last proof covers divisibility monotonicity transitively.

The overarching paper-port snapshot is pinned at `a5aa2677fee4e3a79d6bb05136631cce4a08587d`. This theorem family is sourced from the immutable previous-PR donor head `0ffecb528a8a63eb9522b68d7061e0b671339a47`; it is not present in `a5aa2677`.

## Validation

Head `f328a01ad9ab8ed0b2513bd765f534f5472f1613` is based on the merged Lean 4.34 `main` commit `fa14552d40e793f2ea26e65c440306aae0c08a26`:

- `LAKE_ARTIFACT_CACHE=false LAKE_NO_CACHE=true ./scripts/validate.sh --axioms` passed, including the production module, acceptance client, runtime checks, generated imports, documentation integrity, and the repository-wide axiom regression sweep;
- the sweep checked 12,637 declarations across 505 modules, with 291 baseline `sorry`-tainted declarations and no non-standard-axiom-tainted declarations;
- the exact dependency pins are Mathlib `5ed2965256430c3649e86755f9576b54eca72435` and CompPoly `7e3683ba72f61c1f3c2deda85953ce26392f0771`;
- `git diff --check` and the added-line trust scan passed.

The port delta is patch-identical to the independently reviewed pre-migration head. No new admission, axiom, unsafe declaration, native trust, or suppression is introduced.

## Reviewer map

1. The private additive embedding and lifted weights.
2. Exact multiplication and finite-product equalities.
3. Divisibility monotonicity.
4. The product-divisor sum bound and repeated-factor semantics.
