### PR TITLE
feat(Polynomial): generalize resultant degree bounds and reuse native proof

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -272,6 +272,7 @@ import ArkLib.Data.Polynomial.RationalFunctions.HenselNumerators.Weight
 import ArkLib.Data.Polynomial.RationalFunctions.Lifts
 import ArkLib.Data.Polynomial.RationalFunctions.RationalRootVanishing
 import ArkLib.Data.Polynomial.RationalFunctions.Weight
+import ArkLib.Data.Polynomial.ResultantDegree
 import ArkLib.Data.Polynomial.SplitFold
 import ArkLib.Data.Polynomial.Trivariate
 import ArkLib.Data.Probability.Combinatorial

--- a/ArkLib/Data/CodingTheory/PolishchukSpielman/Resultant.lean
+++ b/ArkLib/Data/CodingTheory/PolishchukSpielman/Resultant.lean
@@ -5,6 +5,7 @@ Authors: Alexander Hicks, Aleph
 -/
 
 import ArkLib.Data.CodingTheory.PolishchukSpielman.Degrees
+import ArkLib.Data.Polynomial.ResultantDegree
 import Mathlib.Algebra.Polynomial.OfFn
 
 /-!
@@ -43,51 +44,8 @@ lemma ps_nat_degree_mul_x_pow_le {F : Type} [Semiring F] [Nontrivial F]
 lemma ps_nat_degree_resultant_le {F : Type} [Field F]
     (A B : F[X][Y]) (m n : ℕ) :
     (resultant B A n m).natDegree ≤
-      m * (degreeX B) + n * (degreeX A) := by
-  classical
-  let M : Matrix (Fin (n + m)) (Fin (n + m)) F[X] := sylvester B A n m
-  have h_coeff (P : F[X][Y]) (k : ℕ) : (P.coeff k).natDegree ≤ degreeX P := by
-    unfold degreeX
-    by_cases hk : k ∈ P.support
-    · simp [Finset.le_sup (f := fun t ↦ (P.coeff t).natDegree) hk]
-    · simp [notMem_support_iff.mp hk]
-  let cb : Fin (n + m) → ℕ :=
-    Fin.addCases (fun _ : Fin n ↦ degreeX A) (fun _ : Fin m ↦ degreeX B)
-  have h_entry (σ : Equiv.Perm (Fin (n + m))) (i : Fin (n + m)) :
-      (M (σ i) i).natDegree ≤ cb i := by
-    cases i using Fin.addCases with
-    | left i0 =>
-      simp only [cb, Fin.addCases_left]
-      have hM : M (σ (.castAdd m i0)) (.castAdd m i0) =
-          if ((σ (.castAdd m i0) : ℕ) ∈ Set.Icc (i0 : ℕ) ((i0 : ℕ) + m))
-          then A.coeff ((σ (.castAdd m i0) : ℕ) - i0) else 0 := by
-        simp [M, sylvester, of_apply, Fin.addCases_left]
-      by_cases h : (σ (.castAdd m i0) : ℕ) ∈ Set.Icc (i0 : ℕ) ((i0 : ℕ) + m)
-      · simp only [hM, h, ↓reduceIte, ge_iff_le]; exact h_coeff A _
-      · simp [hM, h]
-    | right i0 =>
-      simp only [cb, Fin.addCases_right]
-      have hM : M (σ (.natAdd n i0)) (.natAdd n i0) =
-          if ((σ (.natAdd n i0) : ℕ) ∈ Set.Icc (i0 : ℕ) ((i0 : ℕ) + n))
-          then B.coeff ((σ (.natAdd n i0) : ℕ) - i0) else 0 := by
-        simp [M, sylvester, of_apply, Fin.addCases_right]
-      by_cases h : (σ (.natAdd n i0) : ℕ) ∈ Set.Icc (i0 : ℕ) ((i0 : ℕ) + n)
-      · simp only [hM, h, ↓reduceIte, ge_iff_le]; exact h_coeff B _
-      · simp [hM, h]
-  have h_term (σ : Equiv.Perm (Fin (n + m))) :
-      (Equiv.Perm.sign σ • ∏ i : Fin (n + m), M (σ i) i).natDegree ≤
-        m * degreeX B + n * degreeX A := by
-    refine le_trans (natDegree_smul_le _ _) ?_
-    have hprod : (∏ i : Fin (n + m), M (σ i) i).natDegree ≤
-        ∑ i : Fin (n + m), (M (σ i) i).natDegree := by
-      simpa using natDegree_prod_le _ (fun i ↦ M (σ i) i)
-    refine le_trans (le_trans hprod (Finset.sum_le_sum fun i _ ↦ h_entry σ i)) ?_
-    simp [cb, Fin.sum_univ_add, Nat.add_comm]
-  have hdet : M.det.natDegree ≤ m * degreeX B + n * degreeX A := by
-    rw [det_apply]
-    exact natDegree_sum_le_of_forall_le _ _ (fun σ _ ↦ h_term σ)
-  simpa [resultant, M, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc, Nat.mul_comm,
-    Nat.mul_left_comm, Nat.mul_assoc] using hdet
+      m * (degreeX B) + n * (degreeX A) :=
+  natDegree_resultant_le_degreeX B A n m
 
 /-- The resultant commutes with ring homomorphisms. -/
 lemma ps_resultant_map {R S : Type} [CommRing R] [CommRing S]

--- a/ArkLib/Data/Polynomial/ResultantDegree.lean
+++ b/ArkLib/Data/Polynomial/ResultantDegree.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2024-2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alexander Hicks, Aleph, Quang Dao
+-/
+
+import CompPoly.ToMathlib.Polynomial.BivariateDegree
+import Mathlib.Algebra.Polynomial.BigOperators
+import Mathlib.RingTheory.Polynomial.Resultant.Basic
+
+/-!
+# Coefficient-variable degree bounds for resultants
+
+The Sylvester matrix has one column budget per shifted input polynomial. Summing those budgets
+bounds the degree of every determinant term. Adapted from Alexander Hicks and Aleph's
+field-only result in ArkLib (Apache-2.0), generalizing the
+`ps_nat_degree_resultant_le` argument to commutative coefficient rings and explicit coefficient
+budgets, including padded resultants. For `R = F[Z]`, the resulting bound is in the middle `X`
+axis of `F[Z][X][Y]`.
+
+Source and adaptation: the native ArkLib theorem is at
+https://github.com/Verified-zkEVM/ArkLib/blob/66f3d089a41704597f54d641b78254d2a8f361f8/ArkLib/Data/CodingTheory/PolishchukSpielman/Resultant.lean#L43-L98
+The explicit coefficient budgets and derivative corollaries below extend that argument.
+No donor compatibility modules are imported.
+
+## References
+
+* [Ben-Sasson, E., Carmon, D., Haböck, U., Kopparty, S., Saraf, S.,
+  *On Proximity Gaps for Reed--Solomon Codes*][BCHKS25], Section 3.2.
+-/
+
+namespace Polynomial
+
+variable {R : Type*} [CommRing R]
+
+/-- A padded resultant's coefficient-variable degree is bounded by the Sylvester column count
+times each input's coefficient-degree budget. No degree or nonzero assumptions are necessary. -/
+theorem natDegree_resultant_le_of_coeff_natDegree_le
+    (P Q : Polynomial (Polynomial R)) (m n A B : ℕ)
+    (hP : ∀ j, (P.coeff j).natDegree ≤ A) (hQ : ∀ j, (Q.coeff j).natDegree ≤ B) :
+    (resultant P Q m n).natDegree ≤ n * A + m * B := by
+  classical
+  let M := sylvester P Q m n
+  let cb : Fin (m + n) → ℕ :=
+    Fin.addCases (fun _ : Fin m ↦ B) (fun _ : Fin n ↦ A)
+  have hentry (σ : Equiv.Perm (Fin (m + n))) (i : Fin (m + n)) :
+      (M (σ i) i).natDegree ≤ cb i := by
+    cases i using Fin.addCases with
+    | left j =>
+      simp only [cb, Fin.addCases_left]
+      have hM : M (σ (.castAdd n j)) (.castAdd n j) =
+          if (σ (.castAdd n j) : ℕ) ∈ Set.Icc (j : ℕ) ((j : ℕ) + n) then
+            Q.coeff ((σ (.castAdd n j) : ℕ) - j) else 0 := by
+        simp [M, sylvester]
+      rw [hM]
+      split_ifs
+      · exact hQ _
+      · simp
+    | right j =>
+      simp only [cb, Fin.addCases_right]
+      have hM : M (σ (.natAdd m j)) (.natAdd m j) =
+          if (σ (.natAdd m j) : ℕ) ∈ Set.Icc (j : ℕ) ((j : ℕ) + m) then
+            P.coeff ((σ (.natAdd m j) : ℕ) - j) else 0 := by
+        simp [M, sylvester]
+      rw [hM]
+      split_ifs
+      · exact hP _
+      · simp
+  change M.det.natDegree ≤ _
+  rw [Matrix.det_apply]
+  apply natDegree_sum_le_of_forall_le
+  intro σ _
+  refine (natDegree_smul_le _ _).trans ?_
+  refine (natDegree_prod_le Finset.univ (fun i ↦ M (σ i) i)).trans ?_
+  refine (Finset.sum_le_sum (fun i _ ↦ hentry σ i)).trans ?_
+  simp [cb, Fin.sum_univ_add, Nat.add_comm]
+
+/-- The resultant degree bound in terms of each input's inner-variable degree. -/
+theorem natDegree_resultant_le_degreeX (P Q : Polynomial (Polynomial R)) (m n : ℕ) :
+    (resultant P Q m n).natDegree ≤ n * Bivariate.degreeX P + m * Bivariate.degreeX Q :=
+  natDegree_resultant_le_of_coeff_natDegree_le P Q m n _ _
+    (Bivariate.coeff_natDegree_le_degreeX P) (Bivariate.coeff_natDegree_le_degreeX Q)
+
+/-- Differentiating in the outer variable does not increase any coefficient-variable degree. -/
+theorem coeff_derivative_natDegree_le (P : Polynomial (Polynomial R)) (j : ℕ) :
+    (P.derivative.coeff j).natDegree ≤ (P.coeff (j + 1)).natDegree := by
+  rw [coeff_derivative]
+  rw [show (j : Polynomial R) + 1 = C ((j : R) + 1) by simp]
+  exact natDegree_mul_C_le _ _
+
+/-- The actual-degree derivative resultant obeys the usual `(2d-1)D` coefficient-variable
+bound, also in small characteristic where the derivative degree may drop. -/
+theorem natDegree_resultant_derivative_le (P : Polynomial (Polynomial R)) :
+    (resultant P P.derivative).natDegree ≤ (2 * P.natDegree - 1) * Bivariate.degreeX P := by
+  have h := natDegree_resultant_le_of_coeff_natDegree_le P P.derivative
+    P.natDegree P.derivative.natDegree (Bivariate.degreeX P) (Bivariate.degreeX P)
+    (Bivariate.coeff_natDegree_le_degreeX P)
+    (fun j ↦ (coeff_derivative_natDegree_le P j).trans
+      (Bivariate.coeff_natDegree_le_degreeX P (j + 1)))
+  calc
+    _ ≤ (P.derivative.natDegree + P.natDegree) * Bivariate.degreeX P := by
+      simpa only [add_mul] using h
+    _ ≤ (2 * P.natDegree - 1) * Bivariate.degreeX P := by
+      apply Nat.mul_le_mul_right
+      have hd := natDegree_derivative_le P
+      omega
+
+/-- Padding the derivative to degree `d - 1` obeys the same coefficient-variable bound.
+The derivative may have smaller actual degree, including in positive characteristic. -/
+theorem natDegree_resultant_derivative_padded_le (P : Polynomial (Polynomial R)) :
+    (resultant P P.derivative P.natDegree (P.natDegree - 1)).natDegree ≤
+      (2 * P.natDegree - 1) * Bivariate.degreeX P := by
+  have h := natDegree_resultant_le_of_coeff_natDegree_le P P.derivative
+    P.natDegree (P.natDegree - 1) (Bivariate.degreeX P) (Bivariate.degreeX P)
+    (Bivariate.coeff_natDegree_le_degreeX P)
+    (fun j ↦ (coeff_derivative_natDegree_le P j).trans
+      (Bivariate.coeff_natDegree_le_degreeX P (j + 1)))
+  have hn : P.natDegree - 1 + P.natDegree = 2 * P.natDegree - 1 := by omega
+  simpa only [← add_mul, hn] using h
+
+end Polynomial

--- a/ArkLibTest/Data/Polynomial/ResultantDegree.lean
+++ b/ArkLibTest/Data/Polynomial/ResultantDegree.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.ResultantDegree
+import Mathlib.Algebra.Field.ZMod
+
+/-! Padded resultants over a ring with zero divisors, and the middle-axis derivative bound. -/
+
+open Polynomial
+
+-- Unequal budgets expose accidental reversal of the Sylvester column counts:
+-- Res_Y(Y - X^5, Y^3) = X^15, saturating 3 * 5 + 1 * 0.
+example :
+    (resultant (X - C ((X : Polynomial ℤ) ^ 5)) (X ^ 3) 1 3).natDegree = 15 := by
+  rw [resultant_X_sub_C_left _ _ _ (by simp)]
+  simp [← pow_mul]
+
+-- The determinant bound needs only a commutative ring, even for arbitrary padded dimensions.
+example (P Q : Polynomial (Polynomial (ZMod 4))) (m n A B : ℕ)
+    (hP : ∀ j, (P.coeff j).natDegree ≤ A) (hQ : ∀ j, (Q.coeff j).natDegree ≤ B) :
+    (resultant P Q m n).natDegree ≤ n * A + m * B :=
+  natDegree_resultant_le_of_coeff_natDegree_le P Q m n A B hP hQ
+
+-- With base ring F₂[Z], the resultant lies in F₂[Z][X] and the bound measures its X-degree.
+example (P : Polynomial (Polynomial (Polynomial (ZMod 2)))) :
+    (resultant P P.derivative).natDegree ≤ (2 * P.natDegree - 1) * Bivariate.degreeX P :=
+  natDegree_resultant_derivative_le P
+
+-- Natural subtraction also covers the zero-degree boundary without a spurious positive budget.
+example (a : Polynomial (ZMod 2)) :
+    (resultant (C a) (C a).derivative).natDegree ≤ 0 := by
+  simp
+
+-- Padded derivative resultants retain the same budget when characteristic forces a degree drop.
+example (P : Polynomial (Polynomial (ZMod 3))) :
+    (resultant P P.derivative P.natDegree (P.natDegree - 1)).natDegree ≤
+      (2 * P.natDegree - 1) * Bivariate.degreeX P :=
+  natDegree_resultant_derivative_padded_le P


### PR DESCRIPTION
## Summary

Moves the existing Sylvester-matrix degree argument into a reusable polynomial-layer API, generalizes it to arbitrary commutative coefficient rings and explicit coefficient budgets, and derives both ordinary and padded derivative-resultant bounds. The existing Polishchuk–Spielman theorem keeps its signature and becomes a wrapper.

This is P05 of the [BCHKS25 execution plan](https://github.com/Verified-zkEVM/ArkLib/issues/859#issuecomment-5576998222). It is independently main-based; it does not require the other new BCHKS PRs.

## Audited surface

- Base: `66f3d089a41704597f54d641b78254d2a8f361f8` (`main`).
- Head: `cb7f88959ff9fa8246976c7892807dca8f1d94f1`.
- One commit; four files; 166 additions and 45 deletions.
- `ArkLib/Data/Polynomial/ResultantDegree.lean`: 121 lines, five general coefficient/resultant degree lemmas.
- `ArkLib/Data/CodingTheory/PolishchukSpielman/Resultant.lean`: adds the lower-layer import and replaces the original determinant proof with a call to the generic theorem; existing API preserved.
- `ArkLibTest/Data/Polynomial/ResultantDegree.lean`: 41 lines of regression clients.
- `ArkLib.lean`: generated import only.

## Mathematical boundary

For dimensions `m,n` and coefficient-degree budgets `A,B`, every determinant term is charged by the Sylvester columns, giving `natDegree(resultant P Q m n) ≤ n*A + m*B`. This needs neither nonzero inputs nor field/domain assumptions and permits padding.

For a polynomial of outer degree `d`, both its actual-degree and its `(d,d-1)` padded derivative resultant have coefficient-variable degree at most `(2*d-1)*degreeX P`. Natural subtraction covers degree zero, and derivative degree may drop in small characteristic. These are degree estimates only: resultant nonzeroness and specialization certificates are separate interfaces (see #877).

The legacy `ps_nat_degree_resultant_le A B m n` retains its argument order and conclusion. Its wrapper passes `B A n m` to the new theorem, avoiding a second maintained determinant proof. The new lower-level file does not import coding theory, so the dependency direction stays acyclic.

## Attribution

This generalizes **Alexander Hicks and Aleph's existing ArkLib proof**, not a missing external donor lemma: [the original theorem at the pinned main revision](https://github.com/Verified-zkEVM/ArkLib/blob/66f3d089a41704597f54d641b78254d2a8f361f8/ArkLib/Data/CodingTheory/PolishchukSpielman/Resultant.lean#L43-L98). The original 2024–2026 copyright and contributor names are retained; Quang Dao is credited for the explicit coefficient-budget, coefficient-ring and derivative extensions. No donor compatibility module or capacity code is copied.

## Validation at the stated head

- Standalone `LAKE_ARTIFACT_CACHE=false LAKE_NO_CACHE=true ./scripts/validate.sh --axioms`: PASS, including build, tests, warning budgets, source policy, generated imports, runtime fixtures and exhaustive axiom regression. The report covers 11,306 declarations across 438 modules, with 312 inherited sorry-tainted declarations, zero nonstandard-axiom-tainted declarations and no new trust debt.
- The same source/test blobs also passed full validation in the integrated BCHKS branch at `bfaf440712fb7c42284aacca4c7bad5752ea78f6`.
- Five new theorem cones and the newly compiled legacy wrapper independently replayed: only `propext`, `Classical.choice`, `Quot.sound`.
- Tests cover coefficient rings with zero divisors (`ZMod 4`), constant/zero-degree boundaries, the middle coordinate of a trivariate polynomial, and padded derivative bounds in small characteristic. The asymmetric concrete identity `Res_Y(Y-X^5,Y^3)=X^15` catches reversed column budgets.
- Independent Astra medium source/math/API/provenance review: PASS, no blockers. No new admissions, nonstandard axioms, dependencies or breaking APIs.
- Hosted CI is pending when opened; agent review does not replace required outside approval.

Suggested review order: the column-budget theorem, derivative corollaries, unchanged legacy signature/wrapper, and the asymmetric regression test.
