### PR TITLE
feat(Polynomial): lift Hensel roots from fraction-field separability

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -265,6 +265,7 @@ import ArkLib.Data.Polynomial.Interface
 import ArkLib.Data.Polynomial.Prelims
 import ArkLib.Data.Polynomial.RationalFunctions
 import ArkLib.Data.Polynomial.RationalFunctions.FunctionField
+import ArkLib.Data.Polynomial.RationalFunctions.HenselNumerators.FractionField
 import ArkLib.Data.Polynomial.RationalFunctions.HenselNumerators.Hensel
 import ArkLib.Data.Polynomial.RationalFunctions.HenselNumerators.Sequence
 import ArkLib.Data.Polynomial.RationalFunctions.HenselNumerators.Setup

--- a/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/FractionField.lean
+++ b/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/FractionField.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2024-2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Katerina Hristova, František Silváši, Julian Sutherland, Ilia Vlasov, Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.RationalFunctions.HenselNumerators.Hensel
+
+/-!
+# Fraction-field-separable Hensel lifts
+
+This backward-compatible adapter reuses the native Hensel engine and the initial-root proof
+from `Hensel.lean`. It replaces coefficient-ring separability only at the lift-existence
+boundary, using an explicit embedding of any coefficient fraction field into the function field.
+Existing `Hypotheses` and numerator/weight interfaces remain unchanged.
+-/
+
+open Polynomial Polynomial.Bivariate
+namespace RationalFunctions.HenselNumerators
+variable {F : Type} [Field F]
+
+/-- The initial root identity needs only divisibility, not coefficient-ring separability. -/
+theorem initial_root_at_x0_of_dvd (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
+    [Fact (Irreducible H)] [Fact (0 < H.natDegree)]
+    (hdvd : H ∣ Bivariate.evalX (Polynomial.C x₀) R) :
+    Polynomial.eval₂ (liftToFunctionField (H := H))
+      (functionFieldT (H := H) / liftToFunctionField (H := H) H.leadingCoeff)
+      (Bivariate.evalX (Polynomial.C x₀) R) = 0 := by
+  classical
+  rcases hdvd with ⟨Q, hQ⟩
+  rw [hQ, Polynomial.eval₂_mul, H_eval2_T_div_W_eq_zero H, zero_mul]
+
+set_option maxHeartbeats 800000 in
+-- Reducing the explicit fraction-field lift composite needs extra elaboration heartbeats.
+/-- Separability over any fraction field of the coefficient ring makes the initial root simple.
+The fraction-field embedding is constructed explicitly from the native coefficient embedding. -/
+theorem zeta_ne_zero_of_fractionField_separable
+    (K : Type*) [Field K] [Algebra F[X] K] [IsFractionRing F[X] K]
+    (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
+    [Fact (Irreducible H)] [Fact (0 < H.natDegree)]
+    (hdvd : H ∣ Bivariate.evalX (Polynomial.C x₀) R)
+    (hsep : ((Bivariate.evalX (Polynomial.C x₀) R).map
+      (algebraMap F[X] K)).Separable) :
+    zeta R x₀ H ≠ 0 := by
+  let P : F[X][Y] := Bivariate.evalX (Polynomial.C x₀) R
+  let t : 𝕃 H := functionFieldT (H := H) / liftToFunctionField (H := H) H.leadingCoeff
+  have hinj : Function.Injective (liftToFunctionField (H := H)) := by
+    intro a b hab
+    apply sub_eq_zero.mp
+    by_contra h
+    exact liftToFunctionField_ne_zero (H := H) h (by simp [map_sub, hab])
+  let φ : K →+* 𝕃 H := IsFractionRing.lift hinj
+  have hcomp : φ.comp (algebraMap F[X] K) = liftToFunctionField (H := H) := by
+    apply RingHom.ext
+    intro p
+    exact IsFractionRing.lift_algebraMap (K := K) hinj p
+  have hroot : Polynomial.eval₂ (liftToFunctionField (H := H)) t P = 0 :=
+    initial_root_at_x0_of_dvd x₀ R H hdvd
+  have hroot' : Polynomial.eval₂ φ t (P.map (algebraMap F[X] K)) = 0 := by
+    simpa only [Polynomial.eval₂_map, hcomp] using hroot
+  have hne := hsep.eval₂_derivative_ne_zero φ hroot'
+  have hne' : Polynomial.eval₂ (liftToFunctionField (H := H)) t P.derivative ≠ 0 := by
+    simpa only [Polynomial.derivative_map, Polynomial.eval₂_map, hcomp] using hne
+  have hderiv_evalX : Bivariate.evalX (Polynomial.C x₀) R.derivative = P.derivative := by
+    ext i
+    simp [P, derivative_evalX_coeff, Polynomial.coeff_derivative, Nat.cast_add, Nat.cast_one]
+  simpa [zeta, P, t, hderiv_evalX] using hne'
+
+/-- The existing formal Hensel engine applies under fraction-field separability.
+This is a lift-existence endpoint only; it does not extend the numerator/weight interfaces. -/
+theorem exists_hensel_alpha_sequence_of_fractionField_separable
+    (K : Type*) [Field K] [Algebra F[X] K] [IsFractionRing F[X] K]
+    (x₀ : F) (R : F[X][X][Y]) (H : F[X][Y])
+    [Fact (Irreducible H)] [Fact (0 < H.natDegree)]
+    (hdvd : H ∣ Bivariate.evalX (Polynomial.C x₀) R)
+    (hsep : ((Bivariate.evalX (Polynomial.C x₀) R).map
+      (algebraMap F[X] K)).Separable) :
+    ∃ αseq : ℕ → 𝕃 H,
+      αseq 0 = functionFieldT (H := H) / liftToFunctionField (H := H) H.leadingCoeff ∧
+      evalRAtPowerSeries x₀ H R (gammaFromAlpha H αseq) = 0 := by
+  exact formalHenselAlphaSequence x₀ R H (initial_root_at_x0_of_dvd x₀ R H hdvd)
+    (zeta_ne_zero_of_fractionField_separable K x₀ R H hdvd hsep)
+
+end RationalFunctions.HenselNumerators

--- a/ArkLibTest/Data/Polynomial/RationalFunctions/HenselNumerators/FractionField.lean
+++ b/ArkLibTest/Data/Polynomial/RationalFunctions/HenselNumerators/FractionField.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.RationalFunctions.HenselNumerators.FractionField
+
+/-! Ordinary-import clients for fraction-field-separable lifts and their separability boundary. -/
+
+open Polynomial Polynomial.Bivariate
+
+namespace AdapterTest
+noncomputable section
+open RationalFunctions RationalFunctions.HenselNumerators
+local notation "K" => FractionRing ℚ[X]
+private def R : ℚ[X][X][Y] := Polynomial.C (Polynomial.C Polynomial.X) * Polynomial.X
+private def H : ℚ[X][Y] := Polynomial.X
+private instance : Fact (Irreducible H) := ⟨by exact Polynomial.irreducible_X⟩
+private instance : Fact (0 < H.natDegree) := ⟨by simp [H]⟩
+
+example : ∃ αseq : ℕ → 𝕃 H,
+    αseq 0 = functionFieldT (H := H) / liftToFunctionField (H := H) H.leadingCoeff ∧
+    evalRAtPowerSeries 0 H R (gammaFromAlpha H αseq) = 0 := by
+  apply exists_hensel_alpha_sequence_of_fractionField_separable K 0 R H
+  · refine ⟨Polynomial.C Polynomial.X, ?_⟩
+    simp [R, H, Bivariate.evalX, Polynomial.C_mul_X_eq_monomial]
+  · have hx : algebraMap ℚ[X] K Polynomial.X ≠ 0 := by
+      intro h
+      apply Polynomial.X_ne_zero (R := ℚ)
+      apply IsFractionRing.injective ℚ[X] K
+      exact h.trans (map_zero _).symm
+    rw [Polynomial.separable_def]
+    refine ⟨0, Polynomial.C ((algebraMap ℚ[X] K Polynomial.X)⁻¹), ?_⟩
+    simp [R, Bivariate.evalX, ← Polynomial.C_mul, hx]
+
+example : ¬ (Polynomial.C Polynomial.X * Polynomial.X : ℚ[X][Y]).Separable := by
+  intro h
+  have hm := h.map (f := Polynomial.evalRingHom (0 : ℚ))
+  exact Polynomial.not_separable_zero (by simpa using hm)
+
+example : ¬ (Polynomial.X ^ 2 : K[X]).Separable := by
+  intro h
+  have := (h.of_pow Polynomial.not_isUnit_X (by decide : (2 : ℕ) ≠ 0)).2
+  norm_num at this
+end
+end AdapterTest
+
+#print axioms RationalFunctions.HenselNumerators.initial_root_at_x0_of_dvd
+#print axioms RationalFunctions.HenselNumerators.zeta_ne_zero_of_fractionField_separable
+#print axioms
+  RationalFunctions.HenselNumerators.exists_hensel_alpha_sequence_of_fractionField_separable


### PR DESCRIPTION
## Summary

Adds a backward-compatible Hensel lift interface that requires separability over a fraction field of the coefficient ring, not separability over the coefficient ring itself. It reuses ArkLib's existing formal Hensel engine unchanged.

This supplies a narrow adapter needed by the characteristic-free BCHKS route in [#859](https://github.com/Verified-zkEVM/ArkLib/issues/859#issuecomment-5576998222). It deliberately does **not** generalize the numerator/weight interfaces, which retain separate primitive/cofactor obligations.

## Audited surface

- Base: `66f3d089a41704597f54d641b78254d2a8f361f8` (`main`).
- Head: `22da7b6d07bc59853d2999544a6b60a1df6d900d`.
- One commit; three files; 137 additions, no deletions (84 production lines, 52 tests, one generated import).
- `ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/FractionField.lean`: three public adapters—initial root from divisibility, nonzero derivative from fraction-field separability, and lift-sequence existence.
- `ArkLibTest/Data/Polynomial/RationalFunctions/HenselNumerators/FractionField.lean`: an actual lift under the weaker assumptions, a counterexample to coefficient-ring separability, and a repeated-root rejection test.
- `ArkLib.lean`: generated import only.

## Mathematical boundary

The initial-root proof uses only divisibility by the selected positive-degree irreducible factor. The derivative proof explicitly constructs the fraction-field embedding using `IsFractionRing.lift`, so it works with any compatible fraction field rather than silently identifying `RatFunc F` and `FractionRing (Polynomial F)`. The existing engine then consumes the initial root and nonzero derivative.

The concrete client uses `P=Z*Y`, `H=Y` over the rationals: the polynomial is separable over the coefficient fraction field but not over `Q[Z]`. The new interface constructs a lift nonetheless. A separate `Y²` test rejects fraction-field separability for a repeated root.

Existing `Hypotheses`, existing theorem signatures, and numerator/weight APIs are unchanged. Fraction-field separability alone does not imply a unit constant cofactor, nor does this PR claim primitive specialization or the final BCHKS theorem. No new dependency or trust mechanism is introduced.

## Attribution

The adapter reuses the native engine and initial-root argument of **Katerina Hristova, František Silváši, Julian Sutherland and Ilia Vlasov**, [Hensel.lean at the pinned main revision](https://github.com/Verified-zkEVM/ArkLib/blob/66f3d089a41704597f54d641b78254d2a8f361f8/ArkLib/Data/Polynomial/RationalFunctions/HenselNumerators/Hensel.lean). Their notices and author credits are retained; Quang Dao is credited for this weaker-assumption adapter. The public Remco/Jieyi BCHKS comparison motivated the interface audit, but no donor Hensel engine is copied and no capacity material is used.

## Validation at the stated head

- Standalone `LAKE_ARTIFACT_CACHE=false LAKE_NO_CACHE=true ./scripts/validate.sh --axioms`: PASS, including build, tests, zero-warning budgets, source policy, generated imports, runtime fixtures and exhaustive axiom regression. The report covers 11,304 declarations across 438 modules, with 312 inherited sorry-tainted declarations, zero nonstandard-axiom taint and no new trust debt.
- The same source/test blobs passed full validation in the integrated BCHKS branch before standalone extraction.
- All three public theorem cones independently replayed with only `propext`, `Classical.choice`, `Quot.sound`.
- Independent Astra medium review: PASS on statements, explicit fraction-field embedding, native-engine reuse, concrete/negative clients, attribution and unchanged old API.
- Hosted CI is pending when opened. Agent review does not replace outside approval; auto-merge is left disabled for inspection.

Suggested reading order: the derivative-nonvanishing adapter, its two thin consumers, then the `Z*Y` and repeated-root tests.
