### PR TITLE
feat(polynomial): add universal Hensel numerator recurrence

### DIFF
--- a/ArkLib.lean
+++ b/ArkLib.lean
@@ -274,6 +274,7 @@ import ArkLib.Data.Polynomial.RationalFunctions.RationalRootVanishing
 import ArkLib.Data.Polynomial.RationalFunctions.Weight
 import ArkLib.Data.Polynomial.SplitFold
 import ArkLib.Data.Polynomial.Trivariate
+import ArkLib.Data.Polynomial.UniversalHenselNumerator
 import ArkLib.Data.Probability.Combinatorial
 import ArkLib.Data.Probability.Instances
 import ArkLib.Data.Probability.KoalaBear

--- a/ArkLib/Data/Polynomial/UniversalHenselNumerator.lean
+++ b/ArkLib/Data/Polynomial/UniversalHenselNumerator.lean
@@ -22,7 +22,10 @@ increment. The constant coefficient of the prior prefix is deliberately zero.
 
 Adapted from Jieyi Long's universal numerator construction, building on Remco Bloemen's BCHKS
 formalization (Apache-2.0):
-https://github.com/proximity-prize/proximity-prize/blob/19bc7d3e21b2261257e1961acd720b2c395d87e1/ProximityPrize/SubmissionLower/BCHKSUniversalNumerator.lean
+* Repository: https://github.com/proximity-prize/proximity-prize
+* Commit: `19bc7d3e21b2261257e1961acd720b2c395d87e1`
+* File: `ProximityPrize/SubmissionLower/BCHKSUniversalNumerator.lean`
+
 The recurrence is defined directly here, without importing the donor's Hensel engine.
 -/
 

--- a/ArkLib/Data/Polynomial/UniversalHenselNumerator.lean
+++ b/ArkLib/Data/Polynomial/UniversalHenselNumerator.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jieyi Long, Quang Dao
+-/
+
+import Mathlib.Algebra.Polynomial.Eval.Coeff
+import Mathlib.Algebra.Polynomial.Coeff
+
+/-!
+# Universal implicit-function numerators
+
+This ring-valued recurrence constructs branch-independent cleared Taylor numerators from a
+shifted bivariate polynomial and a designated slope. It commutes with every coefficient ring map.
+The definition alone does not assert an implicit-root identity: that requires a compatible
+nonzero slope and a root equation, proved separately by consumers.
+
+The outer variable of `Rshift` is the root increment; the inner variable is the parameter
+increment. The constant coefficient of the prior prefix is deliberately zero.
+
+## References
+
+Adapted from Jieyi Long's universal numerator construction, building on Remco Bloemen's BCHKS
+formalization (Apache-2.0):
+https://github.com/proximity-prize/proximity-prize/blob/19bc7d3e21b2261257e1961acd720b2c395d87e1/ProximityPrize/SubmissionLower/BCHKSUniversalNumerator.lean
+The recurrence is defined directly here, without importing the donor's Hensel engine.
+-/
+
+namespace Polynomial.UniversalHenselNumerator
+
+variable {A B : Type*} [CommRing A] [CommRing B]
+
+/-- Previously constructed positive-index numerators, strictly before index `n`. -/
+noncomputable def positivePrefix (prior : ℕ → A) (n : ℕ) : Polynomial A :=
+  ∑ i ∈ Finset.Ico 1 n, monomial i (prior i)
+
+/-- The prefix has precisely the positive coefficients before the current index. -/
+theorem positivePrefix_coeff (prior : ℕ → A) (n i : ℕ) :
+    (positivePrefix prior n).coeff i = if 0 < i ∧ i < n then prior i else 0 := by
+  classical
+  simp [positivePrefix, coeff_monomial, Nat.succ_le_iff]
+
+@[simp] theorem positivePrefix_zero (prior : ℕ → A) : positivePrefix prior 0 = 0 := by
+  simp [positivePrefix]
+
+@[simp] theorem positivePrefix_coeff_self (prior : ℕ → A) (n : ℕ) :
+    (positivePrefix prior n).coeff n = 0 := by
+  simp [positivePrefix_coeff]
+
+/-- One residual summand; its denominator padding does not depend on a composition of `n-a`. -/
+noncomputable def residualTerm (Rshift : Polynomial (Polynomial A)) (s : A)
+    (n a b : ℕ) (prior : ℕ → A) : A :=
+  ((Rshift.coeff b).coeff a) * s ^ (2 * a + b - 2) *
+    ((positivePrefix prior n) ^ b).coeff (n - a)
+
+/-- Cleared residual step with a declared outer-degree cap `d`; used at positive indices. -/
+noncomputable def numeratorStep (Rshift : Polynomial (Polynomial A)) (s : A)
+    (d n : ℕ) (prior : ℕ → A) : A :=
+  -∑ a ∈ Finset.range (n + 1),
+    ∑ b ∈ Finset.range (d + 1), residualTerm Rshift s n a b prior
+
+/-- Universal cleared numerators. Index zero is unused; each successor sees only its prior. -/
+noncomputable def numerators (Rshift : Polynomial (Polynomial A)) (s : A) (d : ℕ) : ℕ → A
+  | 0 => 0
+  | t + 1 => numeratorStep Rshift s d (t + 1)
+      (fun i ↦ if i ≤ t then numerators Rshift s d i else 0)
+termination_by n => n
+decreasing_by omega
+
+@[simp] theorem numerators_zero (Rshift : Polynomial (Polynomial A)) (s : A) (d : ℕ) :
+    numerators Rshift s d 0 = 0 := by
+  rw [numerators]
+
+theorem numerators_succ (Rshift : Polynomial (Polynomial A)) (s : A) (d t : ℕ) :
+    numerators Rshift s d (t + 1) = numeratorStep Rshift s d (t + 1)
+      (fun i ↦ if i ≤ t then numerators Rshift s d i else 0) := by
+  rw [numerators]
+
+/-- Prefix formation commutes with coefficient specialization. -/
+theorem positivePrefix_map (f : A →+* B) (prior : ℕ → A) (n : ℕ) :
+    (positivePrefix prior n).map f = positivePrefix (fun i ↦ f (prior i)) n := by
+  classical
+  simp [positivePrefix, Polynomial.map_sum]
+
+/-- Residual summands commute with arbitrary coefficient ring maps. -/
+theorem residualTerm_map (f : A →+* B) (Rshift : Polynomial (Polynomial A)) (s : A)
+    (n a b : ℕ) (prior : ℕ → A) :
+    f (residualTerm Rshift s n a b prior) =
+      residualTerm (Rshift.map (mapRingHom f)) (f s) n a b (fun i ↦ f (prior i)) := by
+  have hPcoeff : f (((positivePrefix prior n) ^ b).coeff (n - a)) =
+      ((positivePrefix (fun i ↦ f (prior i)) n) ^ b).coeff (n - a) := by
+    rw [← coeff_map, Polynomial.map_pow, positivePrefix_map]
+  have hRcoeff : f ((Rshift.coeff b).coeff a) =
+      ((Rshift.map (mapRingHom f)).coeff b).coeff a := by simp
+  simp only [residualTerm, map_mul, map_pow, hPcoeff, hRcoeff]
+
+/-- One recurrence step commutes with arbitrary coefficient ring maps. -/
+theorem numeratorStep_map (f : A →+* B) (Rshift : Polynomial (Polynomial A)) (s : A)
+    (d n : ℕ) (prior : ℕ → A) :
+    f (numeratorStep Rshift s d n prior) =
+      numeratorStep (Rshift.map (mapRingHom f)) (f s) d n (fun i ↦ f (prior i)) := by
+  classical
+  simp only [numeratorStep, map_neg, map_sum, residualTerm_map]
+
+/-- The same universal numerator specializes to the recurrence in every coefficient ring. -/
+theorem numerators_map (f : A →+* B) (Rshift : Polynomial (Polynomial A)) (s : A) (d : ℕ)
+    (n : ℕ) :
+    f (numerators Rshift s d n) = numerators (Rshift.map (mapRingHom f)) (f s) d n := by
+  induction n using Nat.strong_induction_on with
+  | h n ih =>
+    cases n with
+    | zero => simp
+    | succ t =>
+      rw [numerators_succ, numerators_succ, numeratorStep_map]
+      congr 2
+      funext i
+      by_cases hi : i ≤ t
+      · simp only [hi, if_true]
+        exact ih i (by omega)
+      · simp [hi]
+
+end Polynomial.UniversalHenselNumerator

--- a/ArkLibTest/Data/Polynomial/UniversalHenselNumerator.lean
+++ b/ArkLibTest/Data/Polynomial/UniversalHenselNumerator.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ArkLib.Data.Polynomial.UniversalHenselNumerator
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic.NormNum
+
+/-!
+# Universal numerator recurrence acceptance clients
+
+The nonlinear equation `V² + 2V - U = 0` distinguishes the first two numerators and tests
+both omission of the current coefficient and the zero constant prefix. Reduction modulo two
+checks that naturality requires no injectivity and remains a ring identity at a zero slope.
+-/
+
+open Polynomial Polynomial.UniversalHenselNumerator
+
+private noncomputable def shifted : Polynomial (Polynomial ℤ) :=
+  X ^ 2 + C 2 * X - C X
+
+example : numerators shifted 2 2 1 = 1 := by
+  norm_num [numerators_succ, numeratorStep, residualTerm, positivePrefix,
+    shifted, Finset.sum_range_succ]
+
+private theorem second_numerator : numerators shifted 2 2 2 = -1 := by
+  norm_num [numerators_succ, numeratorStep, residualTerm, positivePrefix,
+    shifted, Finset.sum_range_succ, coeff_X, coeff_one, coeff_monomial]
+
+example : numerators (shifted.map (mapRingHom (Int.castRingHom (ZMod 2)))) 0 2 2 = 1 := by
+  have h := numerators_map (Int.castRingHom (ZMod 2)) shifted 2 2 2
+  norm_num [second_numerator] at h
+  exact h.symm
+
+example : (positivePrefix (fun i ↦ (i + 7 : ℤ)) 3).coeff 0 = 0 := by
+  simp [positivePrefix_coeff]


### PR DESCRIPTION
## Summary

Add a branch-independent polynomial recurrence for cleared implicit-function numerators and prove
that it commutes with arbitrary coefficient ring maps. This is one small algebraic slice of #859.

The positive prefix excludes both index zero and the current coefficient. A successor step sums
the shifted equation's residual terms with the denominator padding `2*a+b-2`. The recurrence is
defined over any commutative ring: neither a nonzero slope nor an injective specialization is
required for the ring-map identity.

## Scope and provenance

Adapted from Jieyi Long's universal numerator construction, building on Remco Bloemen's BCHKS
formalization, under Apache-2.0. Exact source:
[BCHKSUniversalNumerator.lean at 19bc7d3](https://github.com/proximity-prize/proximity-prize/blob/19bc7d3e21b2261257e1961acd720b2c395d87e1/ProximityPrize/SubmissionLower/BCHKSUniversalNumerator.lean).

This port uses a direct well-founded recurrence and a positive interval prefix; it does not
import or duplicate the donor's Hensel lifting engine. The module records authorship and the exact
source commit. Capacity development is outside this PR.

## Diff metadata

- Base: `66f3d089a41704597f54d641b78254d2a8f361f8` (`main`).
- Head: `8f589831261a5ca84231f3034c92995c8447e545`.
- Two commits; three files; 164 additions, no deletions.
- Production: 125 lines; acceptance tests: 38 lines; generated umbrella: one import.

## Reviewer map

1. `ArkLib/Data/Polynomial/UniversalHenselNumerator.lean`: prefix, residual term, recurrence,
   then the prefix/step/full-sequence ring-map laws.
2. `ArkLibTest/Data/Polynomial/UniversalHenselNumerator.lean`: nonlinear equation
   `V²+2V-U`, first two distinct numerators, and reduction modulo two at zero slope.
3. `ArkLib.lean`: generated registration of the production module.

## Validation and trust

The exact head's source tree passed
`LAKE_ARTIFACT_CACHE=false LAKE_NO_CACHE=true ./scripts/validate.sh --axioms`, including the full
production/test build, zero-warning gates, source policy, runtime checks, imports/docs/KB checks,
axiom-checker fixtures, and the library-wide regression sweep. Independent review and ordinary-import
axiom checks passed; new declarations use only `propext`, `Classical.choice`, and `Quot.sound`.
No admission, trust-baseline change, or dependency update is included. Hosted CI will run after
publication; it is not being reported as complete here.

## Deliberate boundary

This PR proves the recurrence and its naturality, not identification with an implicit root,
weighted-degree bounds, effective primitive specialization, or the BCHKS exceptional-set theorem.
The clearing identity and exact-polynomial-root specialization are separate dependent slices.
All existing APIs are unchanged. This PR does not close #859 and should remain unmerged pending
maintainer review.
